### PR TITLE
fix(security): gate scope:record-approved-scope on shared #3110 mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`scope:record-approved-scope` uses the #3110 human-presence mint gate (#3384).** Shared TTY / controlling-terminal / `--confirm` / typed `mint` / agent-CI refuse; `--actor` is display-only. New records omit `xbriefBodyDigest`. Wave 1 records have no `intentDigest` and are legacy under #3385. Closes #3384. Refs #3376, #3110.
 - **scope:complete: ancestry on deliveryBranch is delivery; PR base is provenance (#3380).** A merge commit that is an ancestor of refreshed `origin/<deliveryBranch>` completes as delivered even when `prBase` is develop. Ancestry miss stays `merged_to_integration`. Remediations name `--merge-commit` and typed `deliveryBranch`. Documents squash-sync ancestry break. Closes #3380.
 
 - **Failing verify:ac walks emit a walk-level verification fingerprint (#3397).** A fail then a later pass with a different command set on the same check id flags; an honest same-command product fix does not. Shrinking command-set delta is included on the flag. The #3322 detector stays. Closes #3397. Refs #3322, #3396.

--- a/content/docs/scope-provenance.md
+++ b/content/docs/scope-provenance.md
@@ -58,32 +58,49 @@ Authority comes from the approval record in the **merge base**, not from whether
 
 ## Operator command: `scope:record-approved-scope`
 
-Deposit a human-origin digest (first adoption or renewal):
+Deposit a human-origin digest (first adoption or renewal). Mint on a real TTY, then commit the approval artifacts to the merge base (or a prior PR) before implement.
 
 ```bash
-task scope:record-approved-scope -- xbrief/pending/story.xbrief.json --actor scott
+task scope:record-approved-scope -- xbrief/pending/story.xbrief.json --actor scott --confirm
 # or after expansion review:
-task scope:record-approved-scope -- xbrief/active/story.xbrief.json --actor scott --kind renewed-approval
+task scope:record-approved-scope -- xbrief/active/story.xbrief.json --actor scott --kind renewed-approval --confirm
 ```
+
+`--actor` is **display only**. It never authorizes mint. `--actor Flynn` from an agent or CI shell cannot mint.
+
+Mint uses the shared #3110 human-presence gate (same module as `authz`):
+
+- Interactive TTY (stdin + stdout) and a controlling terminal (`/dev/tty` or `CONIN$`)
+- Explicit `--confirm`
+- Typed phrase `mint` on the controlling TTY
+- Agent/CI env markers (`AUTHZ_AGENT_SHELL_ENV_MARKERS`) refuse fail-closed
+- An active UAT lease refuses mint with no TTY / `--confirm` / phrase escape
+
+No authz grant is written. `verify:scope-provenance` does not read `.deft/authz/grants`.
 
 Flags:
 
 | Flag | Required | Notes |
 | --- | --- | --- |
 | `<xbrief-path>` | yes | pending or active xBRIEF JSON |
-| `--actor` | yes | human operator identity (agent actors refused) |
+| `--actor` | yes | display-only human identity (never authorization) |
+| `--confirm` | yes | required; flag alone never authorizes mint |
 | `--kind` | no | default `operator`; also `human`, `renewed-approval`, … |
 | `--project-root` | no | defaults via Taskfile to consumer CWD |
 | `--xbrief-rel-path` | no | override path binding; default maps `pending/` → `active/` |
 
 Commit the written `.deft/approved-scope/<plan-id>.json` on the **merge base** (or a prior PR) before the implementation PR activates or expands the scoped xBRIEF.
 
+### Wave 1 records are legacy under Wave 2 (#3384 / #3385)
+
+Wave 1 mints write the current approved-scope record shape with a human-looking stamp. They do **not** write `xbriefBodyDigest` and they carry **no** `intentDigest`. Under Wave 2 (#3385) those records are **legacy**: later intent edits will warn, then fail; gated remint is the remediation. That is intended, not a bug.
+
 ## First-adoption flow (single consumer upgrade)
 
 When the first non-empty `file_scope` story and the 0.97+/0.98 gate land together:
 
 1. Author the pending xBRIEF with the intended `file_scope`
-2. Run `task scope:record-approved-scope -- <pending-xbrief> --actor <you>`
+2. Run `task scope:record-approved-scope -- <pending-xbrief> --actor <you> --confirm`
 3. **Commit and merge** the approval record (and preferably the pending xBRIEF) first — multi-PR bootstrap
 4. In a follow-up PR, activate (`pending/` → `active/`) without rewriting the approval
 5. `task verify:scope-provenance -- --base-ref origin/master --enforce` exits 0
@@ -105,7 +122,7 @@ Emptying `file_scope` to soft-warn past the gate is **not** the supported migrat
 ## Remediation
 
 ```bash
-task scope:record-approved-scope -- <xbrief-path> --actor <you>
+task scope:record-approved-scope -- <xbrief-path> --actor <you> --confirm
 git add .deft/approved-scope/<plan-id>.json
 # merge that commit before (or without) co-changing the active xBRIEF expansion
 ```

--- a/packages/cli/src/authz.ts
+++ b/packages/cli/src/authz.ts
@@ -22,7 +22,7 @@
  * TTY + controlling terminal + `--confirm` + typed phrase `mint`; agent/CI env
  * markers refuse fail-closed. Argv `--confirm` alone is never enough.
  */
-import { closeSync, existsSync, openSync, readSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 import {
   AFK_TEMPLATE_NAMES,
@@ -34,7 +34,6 @@ import {
   isAfkTemplateName,
   isClosedVerbTemplateName,
   isFinishLoopTemplateName,
-  loadAuthzState,
   mintAfkTemplateGrant,
   mintDecomposeStructuralApplyGrant,
   mintHumanOriginGrant,
@@ -44,6 +43,18 @@ import {
   suspendUatLease,
   toProjectRelativePosix,
 } from "@deftai/directive-core/authz";
+import {
+  type HumanPresenceMintSeams,
+  refuseMintWhileUatActive,
+  refuseNonInteractiveMint,
+  resolveHumanPresenceMintSeams,
+} from "./human-presence-mint.js";
+
+export type { HumanPresenceMintSeams as AuthzMainSeams } from "./human-presence-mint.js";
+export {
+  AUTHZ_AGENT_SHELL_ENV_MARKERS,
+  AUTHZ_INTERACTIVE_CONFIRM_PHRASE,
+} from "./human-presence-mint.js";
 
 interface Parsed {
   cmd: "show" | "uat-start" | "uat-suspend" | "grant" | "revoke";
@@ -72,77 +83,6 @@ interface Parsed {
   /** Explicit operator confirm for non-TTY / agent shells (#3110). */
   confirm: boolean;
   error?: string;
-}
-
-/**
- * Env markers that indicate an agent/host/CI shell even when stdin reports a TTY
- * (pseudo-terminal residual; #3110 Greptile). Presence refuses mutating authz.
- * Expanded for dogfood conf 5/5 — markers are fail-closed (any non-empty value).
- */
-export const AUTHZ_AGENT_SHELL_ENV_MARKERS = [
-  // Coding agents / IDEs
-  "CLAUDECODE",
-  "CLAUDE_CODE",
-  "CLAUDE_CODE_ENTRYPOINT",
-  "CURSOR_AGENT",
-  "CURSOR_TRACE_ID",
-  "CURSOR_SESSION_ID",
-  "AIDER",
-  "CONTINUE_CLI",
-  "CODEX_SANDBOX",
-  "CODEX_CI",
-  "OPENAI_CODEX",
-  "OPENCLAW",
-  "OPENCLAW_STATE_DIR",
-  "DEFT_PROBE_OPENCLAW",
-  "DEFT_HOOK_HOST",
-  "DEFT_AGENT_SHELL",
-  "DEFT_AGENT_RUNTIME",
-  "WARP_SESSION_ID",
-  "WARP_HARNESS",
-  "WARP_RUN_ID",
-  "GEMINI_CLI",
-  "AMP_CLI",
-  "SWARM_AGENT",
-  "AI_AGENT",
-  // CI / automation (never a human interactive operator mint)
-  "CI",
-  "CONTINUOUS_INTEGRATION",
-  "GITHUB_ACTIONS",
-  "GITLAB_CI",
-  "CIRCLECI",
-  "BUILDKITE",
-  "TRAVIS",
-  "JENKINS_URL",
-  "TEAMCITY_VERSION",
-  "TF_BUILD",
-  "APPVEYOR",
-  "BITBUCKET_BUILD_NUMBER",
-  "CODEBUILD_BUILD_ID",
-] as const;
-
-/** Phrase an operator must type on the controlling TTY after --confirm (#3110). */
-export const AUTHZ_INTERACTIVE_CONFIRM_PHRASE = "mint";
-
-/** Testable seams for TTY / agent-shell detection (#3110). */
-export interface AuthzMainSeams {
-  /**
-   * When true, interactive human TTY is present.
-   * Default: both stdin and stdout report isTTY (pseudo-TTY residual; #3110).
-   */
-  readonly isTty?: () => boolean;
-  /** Environ for agent-shell marker detection (default: process.env). */
-  readonly environ?: NodeJS.ProcessEnv;
-  /**
-   * True when a controlling terminal device is available (`/dev/tty` or `CONIN$`).
-   * Default: open/close the platform controlling terminal (fail-closed on error).
-   */
-  readonly hasControllingTerminal?: () => boolean;
-  /**
-   * Read one interactive confirmation line from the operator (trimmed).
-   * Default: one line from stdin. Tests inject a fixed phrase.
-   */
-  readonly readInteractiveConfirm?: () => string | null;
 }
 
 function parseOps(raw: string): AuthzOperation[] {
@@ -369,150 +309,10 @@ function helpText(): string {
   ].join("\n");
 }
 
-function looksLikeAgentShell(environ: NodeJS.ProcessEnv): boolean {
-  for (const key of AUTHZ_AGENT_SHELL_ENV_MARKERS) {
-    const v = environ[key];
-    if (v !== undefined && String(v).trim().length > 0) return true;
-  }
-  return false;
-}
-
-function defaultHasControllingTerminal(): boolean {
-  try {
-    const path = process.platform === "win32" ? "CONIN$" : "/dev/tty";
-    const fd = openSync(path, "r");
-    closeSync(fd);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function defaultReadInteractiveConfirm(): string | null {
-  // Read from the controlling terminal device — not redirected/piped stdin —
-  // so agent-controlled stdin alone cannot supply the confirm phrase (#3110).
-  let fd: number | null = null;
-  try {
-    const path = process.platform === "win32" ? "CONIN$" : "/dev/tty";
-    fd = openSync(path, "r");
-    const buf = Buffer.alloc(256);
-    const n = readSync(fd, buf, 0, buf.length, null);
-    if (n <= 0) return null;
-    return buf.subarray(0, n).toString("utf8").trim();
-  } catch {
-    return null;
-  } finally {
-    if (fd !== null) {
-      try {
-        closeSync(fd);
-      } catch {
-        /* ignore */
-      }
-    }
-  }
-}
-
-/**
- * While any UAT lease is active, refuse ALL mutating authz CLI verbs (#3110).
- *
- * No multi-factor escape: TTY, `--confirm`, and typed phrase never authorize.
- * Self-approval under UAT is impossible by construction — agents with a PTY
- * cannot mint/suspend/revoke operator-cli authority during an active lease.
- * Operators mint fix-cohort grants *before* `uat-start`.
- *
- * Returns exit code when blocked, or null when the command may continue.
- */
-function refuseMutatingAuthzWhileUatActive(projectRoot: string, cmd: Parsed["cmd"]): number | null {
-  if (cmd === "show") return null;
-  const state = loadAuthzState(projectRoot);
-  if (state.uat === null || !state.uat.active) return null;
-  process.stderr.write(
-    `authz:${cmd}: refusing mutating authz while UAT lease is ACTIVE ` +
-      `(campaign=${state.uat.campaignId}). Under active UAT, grant / uat-start / ` +
-      "uat-suspend / revoke are hard-refused — no TTY, --confirm, or phrase path " +
-      "authorizes self-approval (#3110). Mint grants before uat-start; clear the " +
-      "lease out-of-band (edit .deft/authz/state.json as a human outside agent hooks) " +
-      "to end UAT.\n",
-  );
-  return 2;
-}
-
-/**
- * Refuse non-interactive / agent-shell operator-cli stamps outside UAT (#3110).
- *
- * Multi-factor human-presence gate (applies only when UAT lease is inactive):
- * 1. No known agent/CI env markers
- * 2. Interactive TTY (stdin + stdout isTTY)
- * 3. Controlling terminal device present (`/dev/tty` / `CONIN$`)
- * 4. Explicit argv `--confirm` (flag alone never enough)
- * 5. Interactive typed phrase `mint` (argv --confirm alone never enough even on PTY)
- *
- * Fail-closed: if a real human interactive path cannot be proven, refuse mint.
- * Returns an exit code when blocked, or null when the mutation may proceed.
- */
-function refuseNonInteractiveMint(
-  cmd: Parsed["cmd"],
-  isTty: () => boolean,
-  environ: NodeJS.ProcessEnv,
-  confirm: boolean,
-  hasControllingTerminal: () => boolean,
-  readInteractiveConfirm: () => string | null,
-): number | null {
-  if (cmd === "show") return null;
-  if (looksLikeAgentShell(environ)) {
-    process.stderr.write(
-      `authz:${cmd}: refusing operator-cli stamp from an agent/host/CI shell ` +
-        `(detected agent or CI env marker). Mutating authz requires a human interactive ` +
-        "TTY without agent-shell markers, plus --confirm and typed phrase (#3110).\n",
-    );
-    return 2;
-  }
-  const tty = isTty();
-  if (!tty && !confirm) {
-    process.stderr.write(
-      `authz:${cmd}: refusing non-interactive operator-cli stamp. ` +
-        "Mutating authz verbs require interactive TTY, --confirm, and typed phrase " +
-        `'${AUTHZ_INTERACTIVE_CONFIRM_PHRASE}' (#3110).\n`,
-    );
-    return 2;
-  }
-  if (!tty) {
-    process.stderr.write(
-      `authz:${cmd}: refusing non-TTY operator-cli stamp. ` +
-        "--confirm alone never authorizes mint — interactive TTY is required (#3110).\n",
-    );
-    return 2;
-  }
-  if (!confirm) {
-    process.stderr.write(
-      `authz:${cmd}: refusing operator-cli stamp without --confirm. ` +
-        "Interactive TTY alone never authorizes mint — pass --confirm explicitly (#3110).\n",
-    );
-    return 2;
-  }
-  if (!hasControllingTerminal()) {
-    process.stderr.write(
-      `authz:${cmd}: refusing operator-cli stamp without a controlling terminal. ` +
-        "Open a real interactive console (not a headless/agent pipe) to mint (#3110).\n",
-    );
-    return 2;
-  }
-  process.stderr.write(
-    `authz:${cmd}: type '${AUTHZ_INTERACTIVE_CONFIRM_PHRASE}' and press Enter to confirm operator mint: `,
-  );
-  const line = readInteractiveConfirm();
-  const phrase = (line ?? "").trim().toLowerCase();
-  if (phrase !== AUTHZ_INTERACTIVE_CONFIRM_PHRASE) {
-    process.stderr.write(
-      `\nauthz:${cmd}: interactive confirm phrase mismatch (got ${JSON.stringify(line ?? "")}). ` +
-        `Type exactly '${AUTHZ_INTERACTIVE_CONFIRM_PHRASE}' on the controlling TTY (#3110).\n`,
-    );
-    return 2;
-  }
-  return null;
-}
-
-export function main(argv: string[] = process.argv.slice(2), seams: AuthzMainSeams = {}): number {
+export function main(
+  argv: string[] = process.argv.slice(2),
+  seams: HumanPresenceMintSeams = {},
+): number {
   const args = parseArgv(argv);
   if (args.error === "help") {
     process.stdout.write(`${helpText()}\n`);
@@ -524,12 +324,7 @@ export function main(argv: string[] = process.argv.slice(2), seams: AuthzMainSea
     return 2;
   }
 
-  // Both stdin and stdout TTY — agent-allocated single-side PTY is not enough.
-  const isTty =
-    seams.isTty ?? (() => process.stdin.isTTY === true && process.stdout.isTTY === true);
-  const environ = seams.environ ?? process.env;
-  const hasControllingTerminal = seams.hasControllingTerminal ?? defaultHasControllingTerminal;
-  const readInteractiveConfirm = seams.readInteractiveConfirm ?? defaultReadInteractiveConfirm;
+  const resolved = resolveHumanPresenceMintSeams(seams);
   /**
    * Mutating-verb gate stack (#3110):
    * 1. Active UAT → hard refuse (no multi-factor escape; self-approval impossible)
@@ -537,16 +332,17 @@ export function main(argv: string[] = process.argv.slice(2), seams: AuthzMainSea
    * Required-arg validation runs before this so missing --campaign / --ops still report clearly.
    */
   const gateConfirm = (): number | null => {
-    const uatBlocked = refuseMutatingAuthzWhileUatActive(args.projectRoot, args.cmd);
+    if (args.cmd === "show") return null;
+    const uatBlocked = refuseMintWhileUatActive(`authz:${args.cmd}`, args.projectRoot);
     if (uatBlocked !== null) return uatBlocked;
-    return refuseNonInteractiveMint(
-      args.cmd,
-      isTty,
-      environ,
-      args.confirm,
-      hasControllingTerminal,
-      readInteractiveConfirm,
-    );
+    return refuseNonInteractiveMint({
+      verb: `authz:${args.cmd}`,
+      confirm: args.confirm,
+      isTty: resolved.isTty,
+      environ: resolved.environ,
+      hasControllingTerminal: resolved.hasControllingTerminal,
+      readInteractiveConfirm: resolved.readInteractiveConfirm,
+    });
   };
 
   try {

--- a/packages/cli/src/human-presence-mint.test.ts
+++ b/packages/cli/src/human-presence-mint.test.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startUatLease } from "@deftai/directive-core/authz";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AUTHZ_AGENT_SHELL_ENV_MARKERS as fromAuthz } from "./authz.js";
+import {
+  AUTHZ_AGENT_SHELL_ENV_MARKERS,
+  AUTHZ_INTERACTIVE_CONFIRM_PHRASE,
+  looksLikeAgentShell,
+  refuseMintWhileUatActive,
+  refuseNonInteractiveMint,
+  resolveHumanPresenceMintSeams,
+} from "./human-presence-mint.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function operatorSeams() {
+  return {
+    isTty: () => true,
+    environ: {},
+    hasControllingTerminal: () => true,
+    readInteractiveConfirm: () => AUTHZ_INTERACTIVE_CONFIRM_PHRASE,
+  };
+}
+
+describe("shared #3110 human-presence mint (#3384)", () => {
+  it("re-exports the same marker list from authz (no copy-paste)", () => {
+    expect(fromAuthz).toBe(AUTHZ_AGENT_SHELL_ENV_MARKERS);
+    expect(AUTHZ_INTERACTIVE_CONFIRM_PHRASE).toBe("mint");
+    expect(AUTHZ_AGENT_SHELL_ENV_MARKERS).toContain("CI");
+    expect(AUTHZ_AGENT_SHELL_ENV_MARKERS).toContain("CLAUDECODE");
+    expect(AUTHZ_AGENT_SHELL_ENV_MARKERS).toContain("GITHUB_ACTIONS");
+    expect(AUTHZ_AGENT_SHELL_ENV_MARKERS).toContain("CURSOR_AGENT");
+  });
+
+  it("detects agent and CI markers; empty or whitespace values do not", () => {
+    expect(looksLikeAgentShell({})).toBe(false);
+    expect(looksLikeAgentShell({ CI: "" })).toBe(false);
+    expect(looksLikeAgentShell({ CI: "   " })).toBe(false);
+    expect(looksLikeAgentShell({ CI: "true" })).toBe(true);
+    expect(looksLikeAgentShell({ CLAUDECODE: "1" })).toBe(true);
+    expect(looksLikeAgentShell({ CURSOR_AGENT: "1" })).toBe(true);
+    expect(looksLikeAgentShell({ GITHUB_ACTIONS: "true" })).toBe(true);
+  });
+
+  it("refuse matrix: markers, non-TTY, missing confirm, wrong phrase, no controlling tty", () => {
+    const err: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((c) => {
+      err.push(String(c));
+      return true;
+    });
+    const base = operatorSeams();
+    expect(
+      refuseNonInteractiveMint({
+        verb: "scope:record-approved-scope",
+        confirm: true,
+        ...base,
+        environ: { CI: "true" },
+      }),
+    ).toBe(2);
+    expect(
+      refuseNonInteractiveMint({
+        verb: "scope:record-approved-scope",
+        confirm: true,
+        ...base,
+        isTty: () => false,
+      }),
+    ).toBe(2);
+    expect(
+      refuseNonInteractiveMint({
+        verb: "scope:record-approved-scope",
+        confirm: false,
+        ...base,
+      }),
+    ).toBe(2);
+    expect(
+      refuseNonInteractiveMint({
+        verb: "scope:record-approved-scope",
+        confirm: true,
+        ...base,
+        hasControllingTerminal: () => false,
+      }),
+    ).toBe(2);
+    expect(
+      refuseNonInteractiveMint({
+        verb: "scope:record-approved-scope",
+        confirm: true,
+        ...base,
+        readInteractiveConfirm: () => "yes",
+      }),
+    ).toBe(2);
+    expect(err.join("")).toMatch(/agent|CI|TTY|--confirm|controlling terminal|phrase|mint/i);
+  });
+
+  it("allows mint when all multi-factor seams pass", () => {
+    expect(
+      refuseNonInteractiveMint({
+        verb: "scope:record-approved-scope",
+        confirm: true,
+        ...operatorSeams(),
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses mint while UAT is active with no TTY/confirm/phrase escape", () => {
+    const root = mkdtempSync(join(tmpdir(), "hpm-uat-"));
+    roots.push(root);
+    mkdirSync(join(root, ".deft"), { recursive: true });
+    startUatLease({ projectRoot: root, campaignId: "uat-3384", actor: "op" });
+    const err: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((c) => {
+      err.push(String(c));
+      return true;
+    });
+    expect(refuseMintWhileUatActive("scope:record-approved-scope", root)).toBe(2);
+    expect(err.join("")).toMatch(/UAT lease is ACTIVE/i);
+    const empty = mkdtempSync(join(tmpdir(), "hpm-nouat-"));
+    roots.push(empty);
+    expect(refuseMintWhileUatActive("scope:record-approved-scope", empty)).toBeNull();
+  });
+
+  it("resolveHumanPresenceMintSeams fills defaults", () => {
+    const resolved = resolveHumanPresenceMintSeams();
+    expect(typeof resolved.isTty).toBe("function");
+    expect(typeof resolved.hasControllingTerminal).toBe("function");
+    expect(typeof resolved.readInteractiveConfirm).toBe("function");
+    expect(resolved.environ).toBe(process.env);
+  });
+});

--- a/packages/cli/src/human-presence-mint.ts
+++ b/packages/cli/src/human-presence-mint.ts
@@ -1,0 +1,239 @@
+/**
+ * Shared #3110 human-presence mint gate (#3384).
+ *
+ * Used by `authz` mutating verbs and `scope:record-approved-scope`. Multi-factor
+ * human presence: interactive TTY + controlling terminal + `--confirm` + typed
+ * phrase `mint`. Agent/CI env markers refuse fail-closed. `--actor` is never
+ * an input here — display only at the caller.
+ */
+import { closeSync, openSync, readSync } from "node:fs";
+import { loadAuthzState } from "@deftai/directive-core/authz";
+
+/**
+ * Env markers that indicate an agent/host/CI shell even when stdin reports a TTY
+ * (pseudo-terminal residual; #3110 Greptile). Presence refuses mint.
+ * Expanded for dogfood conf 5/5 — markers are fail-closed (any non-empty value).
+ */
+export const AUTHZ_AGENT_SHELL_ENV_MARKERS = [
+  // Coding agents / IDEs
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CURSOR_AGENT",
+  "CURSOR_TRACE_ID",
+  "CURSOR_SESSION_ID",
+  "AIDER",
+  "CONTINUE_CLI",
+  "CODEX_SANDBOX",
+  "CODEX_CI",
+  "OPENAI_CODEX",
+  "OPENCLAW",
+  "OPENCLAW_STATE_DIR",
+  "DEFT_PROBE_OPENCLAW",
+  "DEFT_HOOK_HOST",
+  "DEFT_AGENT_SHELL",
+  "DEFT_AGENT_RUNTIME",
+  "WARP_SESSION_ID",
+  "WARP_HARNESS",
+  "WARP_RUN_ID",
+  "GEMINI_CLI",
+  "AMP_CLI",
+  "SWARM_AGENT",
+  "AI_AGENT",
+  // CI / automation (never a human interactive operator mint)
+  "CI",
+  "CONTINUOUS_INTEGRATION",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "CIRCLECI",
+  "BUILDKITE",
+  "TRAVIS",
+  "JENKINS_URL",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "CODEBUILD_BUILD_ID",
+] as const;
+
+/** Phrase an operator must type on the controlling TTY after --confirm (#3110). */
+export const AUTHZ_INTERACTIVE_CONFIRM_PHRASE = "mint";
+
+/** Testable seams for TTY / agent-shell detection (#3110 / #3384). */
+export interface HumanPresenceMintSeams {
+  /**
+   * When true, interactive human TTY is present.
+   * Default: both stdin and stdout report isTTY (pseudo-TTY residual; #3110).
+   */
+  readonly isTty?: () => boolean;
+  /** Environ for agent-shell marker detection (default: process.env). */
+  readonly environ?: NodeJS.ProcessEnv;
+  /**
+   * True when a controlling terminal device is available (`/dev/tty` or `CONIN$`).
+   * Default: open/close the platform controlling terminal (fail-closed on error).
+   */
+  readonly hasControllingTerminal?: () => boolean;
+  /**
+   * Read one interactive confirmation line from the operator (trimmed).
+   * Default: one line from the controlling terminal. Tests inject a fixed phrase.
+   */
+  readonly readInteractiveConfirm?: () => string | null;
+}
+
+export function looksLikeAgentShell(environ: NodeJS.ProcessEnv): boolean {
+  for (const key of AUTHZ_AGENT_SHELL_ENV_MARKERS) {
+    const v = environ[key];
+    if (v !== undefined && String(v).trim().length > 0) return true;
+  }
+  return false;
+}
+
+function defaultIsTty(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+function defaultHasControllingTerminal(): boolean {
+  try {
+    const path = process.platform === "win32" ? "CONIN$" : "/dev/tty";
+    const fd = openSync(path, "r");
+    closeSync(fd);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultReadInteractiveConfirm(): string | null {
+  // Read from the controlling terminal device — not redirected/piped stdin —
+  // so agent-controlled stdin alone cannot supply the confirm phrase (#3110).
+  let fd: number | null = null;
+  try {
+    const path = process.platform === "win32" ? "CONIN$" : "/dev/tty";
+    fd = openSync(path, "r");
+    const buf = Buffer.alloc(256);
+    const n = readSync(fd, buf, 0, buf.length, null);
+    if (n <= 0) return null;
+    return buf.subarray(0, n).toString("utf8").trim();
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+export function resolveHumanPresenceMintSeams(
+  seams: HumanPresenceMintSeams = {},
+): Required<HumanPresenceMintSeams> {
+  return {
+    isTty: seams.isTty ?? defaultIsTty,
+    environ: seams.environ ?? process.env,
+    hasControllingTerminal: seams.hasControllingTerminal ?? defaultHasControllingTerminal,
+    readInteractiveConfirm: seams.readInteractiveConfirm ?? defaultReadInteractiveConfirm,
+  };
+}
+
+/** Active UAT campaign id, or null when no lease is active. */
+export function activeUatCampaignId(projectRoot: string): string | null {
+  const state = loadAuthzState(projectRoot);
+  if (state.uat === null || !state.uat.active) return null;
+  return state.uat.campaignId;
+}
+
+/**
+ * While any UAT lease is active, refuse mint (#3110 / #3384).
+ *
+ * No multi-factor escape: TTY, `--confirm`, and typed phrase never authorize.
+ * Returns an exit code when blocked, or null when mint may continue.
+ */
+export function refuseMintWhileUatActive(verb: string, projectRoot: string): number | null {
+  const campaignId = activeUatCampaignId(projectRoot);
+  if (campaignId === null) return null;
+  process.stderr.write(
+    `${verb}: refusing mint while UAT lease is ACTIVE (campaign=${campaignId}). ` +
+      "Under active UAT, mint is hard-refused — no TTY, --confirm, or phrase path " +
+      "authorizes remint (#3110 / #3384). Mint before uat-start; clear the lease " +
+      "out-of-band to end UAT.\n",
+  );
+  return 2;
+}
+
+/**
+ * Refuse non-interactive / agent-shell mint outside UAT (#3110 / #3384).
+ *
+ * Multi-factor human-presence gate (applies only when UAT lease is inactive):
+ * 1. No known agent/CI env markers
+ * 2. Interactive TTY (stdin + stdout isTTY)
+ * 3. Controlling terminal device present (`/dev/tty` / `CONIN$`)
+ * 4. Explicit argv `--confirm` (flag alone never enough)
+ * 5. Interactive typed phrase `mint` (argv --confirm alone never enough even on PTY)
+ *
+ * Fail-closed: if a real human interactive path cannot be proven, refuse mint.
+ * Returns an exit code when blocked, or null when the mutation may proceed.
+ */
+export function refuseNonInteractiveMint(input: {
+  readonly verb: string;
+  readonly confirm: boolean;
+  readonly isTty: () => boolean;
+  readonly environ: NodeJS.ProcessEnv;
+  readonly hasControllingTerminal: () => boolean;
+  readonly readInteractiveConfirm: () => string | null;
+}): number | null {
+  const { verb, confirm } = input;
+  if (looksLikeAgentShell(input.environ)) {
+    process.stderr.write(
+      `${verb}: refusing operator-cli stamp from an agent/host/CI shell ` +
+        `(detected agent or CI env marker). Mint requires a human interactive ` +
+        "TTY without agent-shell markers, plus --confirm and typed phrase (#3110).\n",
+    );
+    return 2;
+  }
+  const tty = input.isTty();
+  if (!tty && !confirm) {
+    process.stderr.write(
+      `${verb}: refusing non-interactive operator-cli stamp. ` +
+        "Mint requires interactive TTY, --confirm, and typed phrase " +
+        `'${AUTHZ_INTERACTIVE_CONFIRM_PHRASE}' (#3110).\n`,
+    );
+    return 2;
+  }
+  if (!tty) {
+    process.stderr.write(
+      `${verb}: refusing non-TTY operator-cli stamp. ` +
+        "--confirm alone never authorizes mint — interactive TTY is required (#3110).\n",
+    );
+    return 2;
+  }
+  if (!confirm) {
+    process.stderr.write(
+      `${verb}: refusing operator-cli stamp without --confirm. ` +
+        "Interactive TTY alone never authorizes mint — pass --confirm explicitly (#3110).\n",
+    );
+    return 2;
+  }
+  if (!input.hasControllingTerminal()) {
+    process.stderr.write(
+      `${verb}: refusing operator-cli stamp without a controlling terminal. ` +
+        "Open a real interactive console (not a headless/agent pipe) to mint (#3110).\n",
+    );
+    return 2;
+  }
+  process.stderr.write(
+    `${verb}: type '${AUTHZ_INTERACTIVE_CONFIRM_PHRASE}' and press Enter to confirm operator mint: `,
+  );
+  const line = input.readInteractiveConfirm();
+  const phrase = (line ?? "").trim().toLowerCase();
+  if (phrase !== AUTHZ_INTERACTIVE_CONFIRM_PHRASE) {
+    process.stderr.write(
+      `\n${verb}: interactive confirm phrase mismatch (got ${JSON.stringify(line ?? "")}). ` +
+        `Type exactly '${AUTHZ_INTERACTIVE_CONFIRM_PHRASE}' on the controlling TTY (#3110).\n`,
+    );
+    return 2;
+  }
+  return null;
+}

--- a/packages/cli/src/scope-record-approved-scope.test.ts
+++ b/packages/cli/src/scope-record-approved-scope.test.ts
@@ -1,7 +1,18 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { startUatLease } from "@deftai/directive-core/authz";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AUTHZ_AGENT_SHELL_ENV_MARKERS } from "./human-presence-mint.js";
 import {
   isPathInsideRoot,
   parseArgs,
@@ -9,10 +20,20 @@ import {
   run,
 } from "./scope-record-approved-scope.js";
 
+function operatorSeams() {
+  return {
+    isTty: () => true,
+    environ: {},
+    hasControllingTerminal: () => true,
+    readInteractiveConfirm: () => "mint",
+  };
+}
+
 describe("scope-record-approved-scope CLI (#3205)", () => {
   let root: string | undefined;
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (root !== undefined) {
       rmSync(root, { recursive: true, force: true });
       root = undefined;
@@ -83,33 +104,146 @@ describe("scope-record-approved-scope CLI (#3205)", () => {
     const xb = join(root, "xbrief/pending/story.xbrief.json");
     writeFileSync(xb, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 
-    const code = run([
-      "xbrief/pending/story.xbrief.json",
-      "--project-root",
-      root,
-      "--actor",
-      "scott",
-    ]);
+    const code = run(
+      ["xbrief/pending/story.xbrief.json", "--project-root", root, "--actor", "scott", "--confirm"],
+      operatorSeams(),
+    );
     expect(code).toBe(0);
     const out = join(root, ".deft/approved-scope/story-1.json");
     const rec = JSON.parse(readFileSync(out, "utf8")) as {
       xbriefRelPath: string;
       humanApproval: { actor: string; kind: string };
       fileScope: string[];
+      xbriefBodyDigest?: string;
+      intentDigest?: string;
     };
     expect(rec.xbriefRelPath).toBe("xbrief/active/story.xbrief.json");
     expect(rec.humanApproval.actor).toBe("scott");
     expect(rec.fileScope).toEqual(["src/a.ts"]);
+    expect(rec.xbriefBodyDigest).toBeUndefined();
+    expect(rec.intentDigest).toBeUndefined();
+    expect(existsSync(join(root, ".deft/authz/grants"))).toBe(false);
 
-    const agentCode = run([
+    const agentCode = run(
+      [
+        "xbrief/pending/story.xbrief.json",
+        "--project-root",
+        root,
+        "--actor",
+        "agent:worker",
+        "--kind",
+        "agent",
+        "--confirm",
+      ],
+      operatorSeams(),
+    );
+    expect(agentCode).toBe(1);
+  });
+
+  it("shared-gate refuse matrix for scope:record-approved-scope (#3384)", () => {
+    root = mkdtempSync(join(tmpdir(), "scope-record-refuse-"));
+    mkdirSync(join(root, "xbrief", "pending"), { recursive: true });
+    const xb = join(root, "xbrief/pending/story.xbrief.json");
+    writeFileSync(
+      xb,
+      `${JSON.stringify({
+        plan: { id: "story-1", metadata: { swarm: { file_scope: ["src/a.ts"] } } },
+      })}\n`,
+      "utf8",
+    );
+    const argv = [
       "xbrief/pending/story.xbrief.json",
       "--project-root",
       root,
       "--actor",
-      "agent:worker",
-      "--kind",
-      "agent",
-    ]);
-    expect(agentCode).toBe(1);
+      "Flynn",
+      "--confirm",
+    ];
+    const err: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((c) => {
+      err.push(String(c));
+      return true;
+    });
+
+    expect(run(argv, { ...operatorSeams(), environ: { CLAUDECODE: "1" } })).toBe(2);
+    expect(run(argv, { ...operatorSeams(), environ: { CI: "true" } })).toBe(2);
+    expect(run(argv, { ...operatorSeams(), isTty: () => false })).toBe(2);
+    expect(run(argv, { ...operatorSeams(), hasControllingTerminal: () => false })).toBe(2);
+    expect(run(argv, { ...operatorSeams(), readInteractiveConfirm: () => "yes" })).toBe(2);
+    expect(
+      run(
+        ["xbrief/pending/story.xbrief.json", "--project-root", root, "--actor", "Flynn"],
+        operatorSeams(),
+      ),
+    ).toBe(2);
+    expect(err.join("")).toMatch(/agent|CI|TTY|--confirm|controlling terminal|phrase|mint/i);
+    expect(existsSync(join(root, ".deft/approved-scope"))).toBe(false);
+  });
+
+  it("--actor Flynn from an agent/CI shell cannot mint (#3384)", () => {
+    root = mkdtempSync(join(tmpdir(), "scope-record-flynn-"));
+    mkdirSync(join(root, "xbrief", "pending"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief/pending/story.xbrief.json"),
+      `${JSON.stringify({
+        plan: { id: "story-1", metadata: { swarm: { file_scope: ["src/a.ts"] } } },
+      })}\n`,
+      "utf8",
+    );
+    for (const key of ["CLAUDECODE", "CI", "GITHUB_ACTIONS"] as const) {
+      expect(AUTHZ_AGENT_SHELL_ENV_MARKERS).toContain(key);
+      expect(
+        run(
+          [
+            "xbrief/pending/story.xbrief.json",
+            "--project-root",
+            root,
+            "--actor",
+            "Flynn",
+            "--confirm",
+          ],
+          { ...operatorSeams(), environ: { [key]: "1" } },
+        ),
+      ).toBe(2);
+    }
+    expect(existsSync(join(root, ".deft/approved-scope"))).toBe(false);
+  });
+
+  it("active UAT lease refuses mint with no TTY/confirm/phrase escape (#3384)", () => {
+    root = mkdtempSync(join(tmpdir(), "scope-record-uat-"));
+    mkdirSync(join(root, "xbrief", "pending"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief/pending/story.xbrief.json"),
+      `${JSON.stringify({
+        plan: { id: "story-1", metadata: { swarm: { file_scope: ["src/a.ts"] } } },
+      })}\n`,
+      "utf8",
+    );
+    startUatLease({ projectRoot: root, campaignId: "uat-3384", actor: "op" });
+    const err: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((c) => {
+      err.push(String(c));
+      return true;
+    });
+    expect(
+      run(
+        [
+          "xbrief/pending/story.xbrief.json",
+          "--project-root",
+          root,
+          "--actor",
+          "Flynn",
+          "--confirm",
+        ],
+        operatorSeams(),
+      ),
+    ).toBe(2);
+    expect(err.join("")).toMatch(/UAT lease is ACTIVE/i);
+    expect(existsSync(join(root, ".deft/approved-scope"))).toBe(false);
+    // Grant store may exist from UAT lease, but mint must not add a grant file.
+    const grantsDir = join(root, ".deft/authz/grants");
+    if (existsSync(grantsDir)) {
+      expect(readdirSync(grantsDir).filter((n) => n.endsWith(".json"))).toEqual([]);
+    }
   });
 });

--- a/packages/cli/src/scope-record-approved-scope.ts
+++ b/packages/cli/src/scope-record-approved-scope.ts
@@ -11,6 +11,12 @@ import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
 import { basename, join, relative, resolve, sep } from "node:path";
 import { scopeProvenance } from "@deftai/directive-core";
 import { isDirectEntrypoint } from "./entrypoint.js";
+import {
+  type HumanPresenceMintSeams,
+  refuseMintWhileUatActive,
+  refuseNonInteractiveMint,
+  resolveHumanPresenceMintSeams,
+} from "./human-presence-mint.js";
 
 /** True when `candidate` is the same as or a descendant of `root` after realpath. */
 export function isPathInsideRoot(root: string, candidate: string): boolean {
@@ -49,16 +55,18 @@ export interface ParsedArgs {
   /** Optional override for recorded xbriefRelPath (defaults: pending→active map). */
   xbriefRelPath: string;
   quiet: boolean;
+  /** Explicit operator confirm for the #3110 human-presence mint (#3384). */
+  confirm: boolean;
   error?: string;
 }
 
 function usage(): string {
   return (
-    "usage: scope:record-approved-scope -- <xbrief-path> --actor <name> " +
+    "usage: scope:record-approved-scope -- <xbrief-path> --actor <name> --confirm " +
     "[--kind operator] [--project-root <dir>] [--xbrief-rel-path <posix>] [--quiet]\n" +
-    "  Writes .deft/approved-scope/<plan-id>.json with a humanApproval stamp (#3205).\n" +
-    "  Agent-shaped stamps are refused. Path-binds to xbrief/active/ by default when " +
-    "the source is under pending/ or active/."
+    "  Writes .deft/approved-scope/<plan-id>.json with a humanApproval stamp (#3205 / #3384).\n" +
+    "  --actor is display only and never authorizes mint. Mint requires a real TTY, " +
+    "controlling terminal, --confirm, and typed phrase mint (#3110). Agent/CI shells refuse."
   );
 }
 
@@ -117,6 +125,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     kind: "operator",
     xbriefRelPath: "",
     quiet: false,
+    confirm: false,
   };
   const positionals: string[] = [];
   for (let i = 0; i < argv.length; i += 1) {
@@ -126,6 +135,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (arg === "--quiet") {
       parsed.quiet = true;
+    } else if (arg === "--confirm") {
+      parsed.confirm = true;
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -184,7 +195,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   return parsed;
 }
 
-export function run(argv: string[]): number {
+export function run(argv: string[], seams: HumanPresenceMintSeams = {}): number {
   const args = parseArgs(argv);
   if (args.error !== undefined) {
     process.stderr.write(`scope_record_approved_scope: ${args.error}\n`);
@@ -223,6 +234,20 @@ export function run(argv: string[]): number {
     return 2;
   }
 
+  const verb = "scope:record-approved-scope";
+  const uatBlocked = refuseMintWhileUatActive(verb, projectRoot);
+  if (uatBlocked !== null) return uatBlocked;
+  const resolved = resolveHumanPresenceMintSeams(seams);
+  const mintBlocked = refuseNonInteractiveMint({
+    verb,
+    confirm: args.confirm,
+    isTty: resolved.isTty,
+    environ: resolved.environ,
+    hasControllingTerminal: resolved.hasControllingTerminal,
+    readInteractiveConfirm: resolved.readInteractiveConfirm,
+  });
+  if (mintBlocked !== null) return mintBlocked;
+
   const stamp = {
     kind: args.kind.trim(),
     actor: args.actor.trim(),
@@ -254,7 +279,6 @@ export function run(argv: string[]): number {
     xbriefRelPath,
     payload,
     humanApproval: stamp,
-    xbriefRawText: raw,
   });
   const outPath = writeApprovedScopeRecord(projectRoot, record);
   if (!args.quiet) {

--- a/packages/core/src/scope-provenance/digest-branches.test.ts
+++ b/packages/core/src/scope-provenance/digest-branches.test.ts
@@ -9,7 +9,6 @@ import {
   approvedScopeRecordPath,
   buildApprovedScopeRecord,
   computeFileScopeDigest,
-  computeTextDigest,
   extractFileScope,
   extractPlanId,
   isHumanApprovalStamp,
@@ -71,7 +70,7 @@ describe("extractFileScope / extractPlanId branches (#3185)", () => {
 });
 
 describe("buildApprovedScopeRecord / disk IO branches (#3185)", () => {
-  it("falls back plan id from basename and optional body digest", () => {
+  it("falls back plan id from basename and does not write xbriefBodyDigest (#3384 F4)", () => {
     // Use POSIX separators so node:path basename is portable on Linux CI
     // (Windows basename also accepts "\\", but Linux treats them as literal).
     const rec = buildApprovedScopeRecord({
@@ -82,7 +81,7 @@ describe("buildApprovedScopeRecord / disk IO branches (#3185)", () => {
     });
     expect(rec.planId).toBe("story");
     expect(rec.xbriefRelPath).toBe("xbrief/active/story.xbrief.json");
-    expect(rec.xbriefBodyDigest).toBe(computeTextDigest('{"plan":{}}'));
+    expect(rec.xbriefBodyDigest).toBeUndefined();
     expect(rec.fileScopeDigest).toBe(computeFileScopeDigest(["z.ts"]));
   });
 

--- a/packages/core/src/scope-provenance/digest.test.ts
+++ b/packages/core/src/scope-provenance/digest.test.ts
@@ -33,7 +33,19 @@ describe("scope-provenance digest (#3145)", () => {
     expect(rec.fileScopeDigest).toBe(computeFileScopeDigest(["a.ts", "b.ts"]));
     expect(rec.fileScope).toEqual(normalizeFileScope(["a.ts", "b.ts"]));
     expect(isHumanApprovalStamp(rec.humanApproval)).toBe(true);
+    expect(rec.xbriefBodyDigest).toBeUndefined();
     expect(scopeExpansion(rec.fileScope, ["a.ts", "b.ts", "c.ts"])).toEqual(["c.ts"]);
+  });
+
+  it("does not write xbriefBodyDigest when raw text is provided (#3384 F4)", () => {
+    const rec = buildApprovedScopeRecord({
+      xbriefRelPath: "xbrief/active/demo.xbrief.json",
+      payload: { plan: { id: "demo", metadata: { swarm: { file_scope: ["a.ts"] } } } },
+      xbriefRawText: '{"plan":{"id":"demo"}}',
+      humanApproval: { kind: "operator", actor: "scott", mintedAt: "2026-08-06T00:00:00Z" },
+    });
+    expect(rec.xbriefBodyDigest).toBeUndefined();
+    expect("xbriefBodyDigest" in rec).toBe(false);
   });
 
   it("rejects agent stamps", () => {

--- a/packages/core/src/scope-provenance/digest.ts
+++ b/packages/core/src/scope-provenance/digest.ts
@@ -33,7 +33,10 @@ export interface ApprovedScopeRecord {
     readonly mintedAt: string;
     readonly mintedVia?: string;
   };
-  /** Digest of the full xBRIEF canonical JSON body (optional stronger pin). */
+  /**
+   * Legacy optional body digest. Wave 1 (#3384 F4) does not write this on new
+   * records. Do not treat it as authority (Wave 2 #3385 / R6).
+   */
   readonly xbriefBodyDigest?: string;
 }
 
@@ -112,6 +115,10 @@ export function buildApprovedScopeRecord(input: {
   readonly payload: unknown;
   readonly approvedAt?: string;
   readonly humanApproval?: ApprovedScopeRecord["humanApproval"];
+  /**
+   * Ignored. Wave 1 (#3384 F4) no longer writes `xbriefBodyDigest` on new records.
+   * Kept so existing callers do not have to drop the field in the same change.
+   */
   readonly xbriefRawText?: string;
 }): ApprovedScopeRecord {
   const planId = extractPlanId(input.payload) ?? basename(input.xbriefRelPath, ".xbrief.json");
@@ -127,15 +134,7 @@ export function buildApprovedScopeRecord(input: {
     fileScopeDigest,
   };
   if (input.humanApproval !== undefined) {
-    return {
-      ...record,
-      humanApproval: input.humanApproval,
-      xbriefBodyDigest:
-        input.xbriefRawText !== undefined ? computeTextDigest(input.xbriefRawText) : undefined,
-    };
-  }
-  if (input.xbriefRawText !== undefined) {
-    return { ...record, xbriefBodyDigest: computeTextDigest(input.xbriefRawText) };
+    return { ...record, humanApproval: input.humanApproval };
   }
   return record;
 }

--- a/packages/core/src/scope-provenance/evaluate.test.ts
+++ b/packages/core/src/scope-provenance/evaluate.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   buildApprovedScopeRecord,
@@ -295,5 +298,18 @@ describe("evaluateScopeProvenance (#3145)", () => {
       humanApproval: { kind: "operator", actor: "scott", mintedAt: "2026-08-01T00:00:00Z" },
     });
     expect(parseApprovedScopeRecordRaw(forged)).toBeNull();
+  });
+});
+
+describe("verify:scope-provenance does not read grants (#3384)", () => {
+  it("evaluate and digest sources never look up .deft/authz/grants", () => {
+    const dir = dirname(fileURLToPath(import.meta.url));
+    for (const name of ["evaluate.ts", "digest.ts", "index.ts"]) {
+      const src = readFileSync(join(dir, name), "utf8");
+      expect(src).not.toMatch(/authz\/grants/);
+      expect(src).not.toMatch(/loadAuthzState/);
+      expect(src).not.toMatch(/listActiveHumanGrants/);
+      expect(src).not.toMatch(/from ["'][^"']*authz/);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Wave 1 of #3376 (R7 + pass-4 F4/F5): `scope:record-approved-scope` is a real human-origin mint.

- Shared `#3110` gate (`AUTHZ_AGENT_SHELL_ENV_MARKERS`, TTY, controlling terminal, `--confirm`, typed phrase `mint`) lives in `packages/cli/src/human-presence-mint.ts`. `authz` and `scope:record-approved-scope` both call it.
- `--actor` is display only. `--actor Flynn` from an agent/CI shell cannot mint.
- Successful mint writes `.deft/approved-scope/<plan-id>.json` with a human stamp. No authz grant is written. `verify:scope-provenance` does not read grants.
- New records omit `xbriefBodyDigest`. Wave 1 records carry no `intentDigest` and are legacy under Wave 2 (#3385).

## Related Issues

Closes #3384
Refs #3376
Refs #3110

## Checklist

- [x] `/deft:change` — N/A (scoped story under swarm-cohort allocation 3382-through-merge; not a cross-cutting /deft:change)
- [x] `CHANGELOG.md` — `[Unreleased]` entry for #3384
- [x] `ROADMAP.md` — N/A (child story; parent #3376 owns epic tracking)
- [x] Tests pass locally (`task check` exit 0; targeted vitest on mint + scope-provenance)

## Post-Merge

- [ ] Verify #3384 closed after squash merge
