### PR TITLE
fix(scope): treat delivery ancestry as delivery evidence (#3380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **scope:complete: ancestry on deliveryBranch is delivery; PR base is provenance (#3380).** A merge commit that is an ancestor of refreshed `origin/<deliveryBranch>` completes as delivered even when `prBase` is develop. Ancestry miss stays `merged_to_integration`. Remediations name `--merge-commit` and typed `deliveryBranch`. Documents squash-sync ancestry break. Closes #3380.
+
 - **Failing verify:ac walks emit a walk-level verification fingerprint (#3397).** A fail then a later pass with a different command set on the same check id flags; an honest same-command product fix does not. Shrinking command-set delta is included on the flag. The #3322 detector stays. Closes #3397. Refs #3322, #3396.
 - **engine:_ts-build: trailing no-op for go-task <3.52 (#3381).** Older go-task treats an untaken last if/fi as exit 1, so consumer deposits fail every non-runtime `task deft:*`. A colon after the outer fi keeps the skip-build path exit 0. Closes #3381.
 - **One SoT for advisory doctor fails; dirty copy no longer says address findings (#3379).** `deriveExitCode` and `cmdDoctor` share `DOCTOR_ADVISORY_FAIL_CHECKS`. A fail is a warning when `data.advisory` is true or the name is in that set. Dirty status / throttle hint names `--full` as re-probe only and says hard errors block writes, advisory warnings do not. Closes #3379. Refs #3372.

--- a/content/docs/directive-lifecycle.md
+++ b/content/docs/directive-lifecycle.md
@@ -65,14 +65,22 @@ framework:
 | **Ship** | PR merge and release — `task pr:*` and [`deft-directive-release`](../skills/deft-directive-release/SKILL.md). |
 | **Issues / Features** | GitHub issues and feature requests mirrored into `.deft-cache/` and surfaced as triage candidates. |
 
-## Delivery integrity vs deploy / UAT (#3041)
+## Delivery integrity vs deploy / UAT (#3041 / #3380)
 
 `scope:complete` and swarm cohort completion mark **lifecycle bookkeeping**, not environment
 green. For **code-bearing** scopes, delivered completion requires durable proof that the
 implementation reached the configured **delivery branch** (`plan.policy.deliveryBranch`,
-defaulting to the repo default branch) — typically: PR `base.ref` equals that branch, and the
-merge commit is an ancestor of the refreshed remote delivery ref. A merge into an intermediate
-feature/integration branch is **not** delivery.
+defaulting to the repo default branch). Ancestry on the refreshed remote delivery ref
+(`origin/<deliveryBranch>`) is delivery. PR `base.ref` / `prBase` is provenance only: a
+develop-targeted scope PR can still complete as delivered when its merge commit is already
+an ancestor of `origin/<deliveryBranch>`. `merged_to_integration` applies only when that
+ancestry fails.
+
+Squash-sync from develop to main can rewrite commits so a develop merge SHA is no longer
+an ancestor of `origin/main`. Wait until the work is reachable on the delivery ref, or
+type `plan.policy.deliveryBranch` to the branch you actually ship from
+(`task policy:show --field=deliveryBranch`). This document does not prescribe a squash-sync
+repair.
 
 Handoff states that Git can assert are distinct: `implemented` → `pr_open` →
 `merged_to_integration` → `delivered`. **Deployed** and **UAT verified** are separate evidence

--- a/packages/core/src/scope/delivery-evidence.test.ts
+++ b/packages/core/src/scope/delivery-evidence.test.ts
@@ -130,6 +130,9 @@ describe("delivery evidence (#3041)", () => {
     const result = runTransition("complete", file, new Date(), { runGit: gitOk() });
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/Delivery evidence required|#3041/);
+    expect(result.message).toMatch(/--merge-commit/);
+    expect(result.message).toMatch(/policy:show --field=deliveryBranch/);
+    expect(result.message).toMatch(/Do not use --non-delivery for work that shipped/);
     expect(readFileSync(file, "utf8")).toContain("running");
   });
 
@@ -190,10 +193,10 @@ describe("delivery evidence (#3041)", () => {
     expect(data.plan.metadata.completionProvenance.uatVerified).toBeNull();
   });
 
-  it("rejects intermediate-branch PR base as delivery evidence", () => {
+  it("treats intermediate-branch PR base as delivered when ancestry passes (#3380)", () => {
     root = makeRepo();
     const file = writeCodeBearing(root);
-    const result = runTransition("complete", file, new Date(), {
+    const result = runTransition("complete", file, new Date("2026-08-02T12:00:00Z"), {
       runGit: gitOk(),
       deliveryEvidence: {
         prNumber: 7,
@@ -203,8 +206,48 @@ describe("delivery evidence (#3041)", () => {
         deliveryBranch: "master",
       },
     });
-    expect(result.ok).toBe(false);
-    expect(result.message).toMatch(/not the configured delivery branch|intermediate/i);
+    expect(result.ok).toBe(true);
+    const dest = join(root, "xbrief", "completed", "story.xbrief.json");
+    const data = JSON.parse(readFileSync(dest, "utf8")) as {
+      plan: {
+        metadata: {
+          completionProvenance: {
+            disposition: string;
+            handoffState: string;
+            prBase: string;
+          };
+        };
+      };
+    };
+    expect(data.plan.metadata.completionProvenance.disposition).toBe("delivered");
+    expect(data.plan.metadata.completionProvenance.handoffState).toBe("delivered");
+    expect(data.plan.metadata.completionProvenance.prBase).toBe("feature/integration");
+  });
+
+  it("records merged_to_integration when intermediate PR base fails ancestry (#3380)", () => {
+    root = makeRepo();
+    const gate = evaluateDeliveryGate({
+      projectRoot: root,
+      plan: {
+        references: [{ type: "x-xbrief/github-issue", uri: "https://github.com/o/r/issues/1" }],
+      },
+      nowIso: "2026-08-02T12:00:00Z",
+      evidence: {
+        prNumber: 7,
+        prBase: "develop",
+        mergeCommit: "abc",
+        mergedAt: "2026-08-02T11:00:00Z",
+        deliveryBranch: "master",
+      },
+      runGit: gitOk({ notAncestor: true }),
+    });
+    expect(gate.ok).toBe(false);
+    expect(gate.provenance?.disposition).toBe("merged_to_integration");
+    expect(gate.provenance?.handoffState).toBe("merged_to_integration");
+    expect(gate.provenance?.prBase).toBe("develop");
+    expect(gate.message).toMatch(/--merge-commit/);
+    expect(gate.message).toMatch(/policy:show --field=deliveryBranch/);
+    expect(gate.message).not.toMatch(/never shipped|did not ship|work never/i);
   });
 
   it("rejects when remote refresh fails", () => {
@@ -245,6 +288,8 @@ describe("delivery evidence (#3041)", () => {
     });
     expect(gate.ok).toBe(false);
     expect(gate.message).toMatch(/not an ancestor|delivery/i);
+    expect(gate.message).toMatch(/--merge-commit/);
+    expect(gate.provenance?.disposition).toBe("not_delivered");
   });
 
   it("resolveCompletionSessionId prefers DEFT_SESSION_ID then ritual-state (#3357)", () => {

--- a/packages/core/src/scope/delivery-evidence.ts
+++ b/packages/core/src/scope/delivery-evidence.ts
@@ -280,7 +280,7 @@ export function verifyDeliveryAncestry(
       ok: false,
       error:
         `merge commit ${mergeCommit} is not an ancestor of refreshed remote delivery ref ` +
-        `${refresh.remoteRef} (${remoteTip}). Intermediate/integration-only merges are not delivery evidence (#3041).`,
+        `${refresh.remoteRef} (${remoteTip}).`,
       remoteTip,
     };
   }
@@ -314,14 +314,24 @@ function buildProvenance(input: {
   };
 }
 
+function deliveryEvidenceRemediation(deliveryBranch: string): string {
+  return (
+    `Pass scope:complete -- --merge-commit <sha> (and --pr <n> if you have one). ` +
+    `When develop is the real delivery target, type plan.policy.deliveryBranch ` +
+    `(task policy:show --field=deliveryBranch). ` +
+    `When ${deliveryBranch} is delivery, wait until the merge commit is an ancestor of ` +
+    `origin/${deliveryBranch}, then complete. Do not use --non-delivery for work that shipped.`
+  );
+}
+
 /**
- * Gate delivered completion for a code-bearing scope (#3041).
+ * Gate delivered completion for a code-bearing scope (#3041 / #3380).
  *
  * Returns ok=true with provenance when:
  * - scope is not code-bearing (provenance may be null or non-code note), OR
  * - explicit non-delivery disposition is provided, OR
- * - durable delivery evidence validates (PR base == deliveryBranch, merge commit
- *   ancestor of refreshed remote delivery ref).
+ * - merge commit is an ancestor of the refreshed remote delivery ref (prBase is
+ *   provenance only; it need not equal deliveryBranch).
  */
 export function evaluateDeliveryGate(options: DeliveryGateOptions): DeliveryGateResult {
   const runGit = options.runGit ?? defaultGitRunner;
@@ -391,10 +401,8 @@ export function evaluateDeliveryGate(options: DeliveryGateOptions): DeliveryGate
       ok: false,
       message:
         `Delivery evidence required for code-bearing scope completion (#3041). ` +
-        `Provide merge/PR delivery proof (merge commit ancestor of remote ` +
-        `'${deliveryBranch}') or an explicit --non-delivery disposition ` +
-        `(${NON_DELIVERY_DISPOSITIONS.join("|")}). ` +
-        `Merged-to-integration alone is not delivery.`,
+        `A merge commit that is an ancestor of refreshed origin/${deliveryBranch} is delivery; ` +
+        `PR base is provenance only. ${deliveryEvidenceRemediation(deliveryBranch)}`,
       provenance: null,
       codeBearing: true,
     };
@@ -424,30 +432,12 @@ export function evaluateDeliveryGate(options: DeliveryGateOptions): DeliveryGate
     }
   }
 
-  if (prBase !== null && prBase !== deliveryBranch) {
-    const provenance = buildProvenance({
-      evidence,
-      deliveryBranch,
-      disposition: "merged_to_integration",
-      handoffState: "merged_to_integration",
-      nowIso: options.nowIso,
-      verifier,
-    });
-    return {
-      ok: false,
-      message:
-        `PR base '${prBase}' is not the configured delivery branch '${deliveryBranch}'. ` +
-        `A merge into an intermediate/feature/integration branch is not delivery evidence (#3041).`,
-      provenance,
-      codeBearing: true,
-    };
-  }
-
   if (mergeCommit === null) {
     return {
       ok: false,
       message:
-        "Delivery evidence missing merge_commit_sha; cannot prove ancestry on delivery branch (#3041).",
+        "Delivery evidence missing merge_commit_sha; cannot prove ancestry on delivery branch (#3041). " +
+        deliveryEvidenceRemediation(deliveryBranch),
       provenance: null,
       codeBearing: true,
     };
@@ -474,9 +464,15 @@ export function evaluateDeliveryGate(options: DeliveryGateOptions): DeliveryGate
   const ancestry = verifyDeliveryAncestry(options.projectRoot, mergeCommit, deliveryBranch, runGit);
   if (!ancestry.ok) {
     const integrationOnly = prBase !== null && prBase !== deliveryBranch;
+    const ancestryMsg = ancestry.error ?? "delivery ancestry check failed";
+    const rem = deliveryEvidenceRemediation(deliveryBranch);
+    const message = integrationOnly
+      ? `${ancestryMsg} PR base '${prBase}' is provenance only; ` +
+        `the merge is not yet on origin/${deliveryBranch}. ${rem}`
+      : `${ancestryMsg} ${rem}`;
     return {
       ok: false,
-      message: ancestry.error ?? "delivery ancestry check failed",
+      message,
       provenance: buildProvenance({
         evidence,
         deliveryBranch,


### PR DESCRIPTION
## Summary

`scope:complete` treated `prBase === deliveryBranch` as a hard gate and failed two-hop `feature → develop → main` work even when the merge commit was already on the delivery ref.

Ancestry on refreshed `origin/<deliveryBranch>` is now delivery. `prBase` is stamped as provenance (develop is fine). `merged_to_integration` is used only when ancestry fails, and remediations name `--merge-commit` plus typed `plan.policy.deliveryBranch`. Squash-sync ancestry break is documented, not solved.

## Related Issues

Closes #3380

## Checklist

- [x] `/deft:change <name>` — N/A: four files, one delivery-gate story, swarm-cohort allocation already approved
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (not a tracked roadmap item)
- [x] Tests pass locally — `pnpm exec vitest run packages/core/src/scope/delivery-evidence.test.ts` (16 passed); `task check` (13487 passed, 141 skipped)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed.
