### PR TITLE
fix(init-deposit): allowlist official Cursor adapter paths (#3393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Official Cursor adapter deletes no longer trip mixed-core-and-app (#3393).** A framework-only update that removes the retired hook adapter is installer-managed, not app. Other consumer hooks stay app-owned. Consumers on `pull_request_target` or pinned workflow refs see the old guard for one PR. Closes #3393. Refs #3378.
+
 - **`scope:record-approved-scope` uses the #3110 human-presence mint gate (#3384).** Shared TTY / controlling-terminal / `--confirm` / typed `mint` / agent-CI refuse; `--actor` is display-only. New records omit `xbriefBodyDigest`. Wave 1 records have no `intentDigest` and are legacy under #3385. Closes #3384. Refs #3376, #3110.
 - **scope:complete: ancestry on deliveryBranch is delivery; PR base is provenance (#3380).** A merge commit that is an ancestor of refreshed `origin/<deliveryBranch>` completes as delivered even when `prBase` is develop. Ancestry miss stays `merged_to_integration`. Remediations name `--merge-commit` and typed `deliveryBranch`. Documents squash-sync ancestry break. Closes #3380.
 

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -152,6 +152,13 @@ func installerManagedMatchers() []installerManagedMatcher {
 		{exact: ".gitattributes"},
 		{exact: ".gitignore"},
 		{exact: "greptile.json"},
+		// Official Cursor adapter only (#3393). Exact paths — not a
+		// `.cursor/hooks/` prefix — so consumer-authored hooks stay app.
+		// Consumers using pull_request_target or pinned workflow refs
+		// evaluate the deposited guard from the previous allowlist for
+		// one PR; document, do not work around.
+		{exact: ".cursor/hooks/deft-cursor-hook-adapter.mjs"},
+		{exact: ".cursor/hooks/deft-cursor-hook-adapter.test.mjs"},
 		{exact: codeqlConfigRelPath},
 		{exact: coreGuardWorkflowRelPath},
 		// Upgrade co-travel unit (#3127 / #3193): path-allow package/lock +

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -766,6 +766,8 @@ func TestCoreGuard_AllowlistAuthoritative(t *testing.T) {
 		".gitattributes",
 		".gitignore",
 		"greptile.json",
+		".cursor/hooks/deft-cursor-hook-adapter.mjs",
+		".cursor/hooks/deft-cursor-hook-adapter.test.mjs",
 		codeqlConfigRelPath,
 		coreGuardWorkflowRelPath,
 		"vbrief/.deft-version",
@@ -778,6 +780,7 @@ func TestCoreGuard_AllowlistAuthoritative(t *testing.T) {
 	}
 	notManaged := []string{
 		"src/main.py",
+		".cursor/hooks/consumer-custom.mjs",
 		"README.md",
 		".deft/core/VERSION",
 		"vbrief/PROJECT-DEFINITION.vbrief.json",

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -94,6 +94,51 @@ describe(".prettierignore allowlist (#2629)", () => {
   });
 });
 
+describe("exact Cursor adapter allowlist (#3393)", () => {
+  const officialAdapterPaths = [
+    ".cursor/hooks/deft-cursor-hook-adapter.mjs",
+    ".cursor/hooks/deft-cursor-hook-adapter.test.mjs",
+  ] as const;
+
+  it("treats the two official adapter paths as installer-managed", () => {
+    for (const path of officialAdapterPaths) {
+      expect(isInstallerManagedPath(path)).toBe(true);
+    }
+    const ere = installerManagedGuardEre();
+    expect(ere).toContain("\\.cursor/hooks/deft-cursor-hook-adapter\\.mjs$");
+    expect(ere).toContain("\\.cursor/hooks/deft-cursor-hook-adapter\\.test\\.mjs$");
+  });
+
+  it("does not add a .cursor/hooks/ prefix matcher", () => {
+    const prefixes = installerManagedMatchers()
+      .map((matcher) => matcher.prefix)
+      .filter((prefix): prefix is string => Boolean(prefix));
+    expect(prefixes.some((prefix) => prefix.startsWith(".cursor/hooks"))).toBe(false);
+    expect(isInstallerManagedPath(".cursor/hooks/consumer-custom.mjs")).toBe(false);
+    expect(isInstallerManagedPath(".cursor/hooks/other-hook.sh")).toBe(false);
+  });
+
+  it("classifies core + official adapter deletion as not mixed app", () => {
+    const result = classifyMixedCoreAndApp([".deft/core/VERSION", ...officialAdapterPaths]);
+    expect(result.wouldFail).toBe(false);
+    expect(result.app).toHaveLength(0);
+    expect(result.installerManaged).toEqual(expect.arrayContaining([...officialAdapterPaths]));
+  });
+
+  it("keeps other .cursor/hooks/ files as app", () => {
+    const result = classifyMixedCoreAndApp([
+      ".deft/core/VERSION",
+      ".cursor/hooks/consumer-custom.mjs",
+    ]);
+    expect(result.wouldFail).toBe(true);
+    expect(result.app).toEqual([".cursor/hooks/consumer-custom.mjs"]);
+  });
+
+  it("assertInstallerAllowlistHonors1430 still passes", () => {
+    expect(() => assertInstallerAllowlistHonors1430()).not.toThrow();
+  });
+});
+
 describe("upgrade co-travel allowlist (#3127)", () => {
   const pinAndStampPaths = [
     "package.json",

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -8,7 +8,7 @@
  * and scope briefs are never installer-managed; if they reappear in
  * `installerManagedMatchers()`, unit tests and deposit-time assert fail closed.
  *
- * Refs #1576, #1453, #1430, #3029, #3030, #3127, #3117, #3193.
+ * Refs #1576, #1453, #1430, #3029, #3030, #3127, #3117, #3193, #3393.
  */
 
 import { execFileSync } from "node:child_process";
@@ -80,6 +80,12 @@ export function installerManagedMatchers(): InstallerManagedMatcher[] {
     { exact: ".claude/settings.json" },
     { exact: ".grok/hooks/deft.json" },
     { exact: ".cursor/hooks.json" },
+    // Official Cursor adapter only (#3393). Exact paths — not a `.cursor/hooks/`
+    // prefix — so consumer-authored hooks stay app. Consumers using
+    // `pull_request_target` or pinned workflow refs evaluate the deposited
+    // guard from the previous allowlist for one PR; document, do not work around.
+    { exact: ".cursor/hooks/deft-cursor-hook-adapter.mjs" },
+    { exact: ".cursor/hooks/deft-cursor-hook-adapter.test.mjs" },
     { exact: ".codex/hooks.json" },
     // Multi-host slash product files only (#3054 / L8 prefer commit).
     // Exact paths — not directory prefixes — so consumer custom commands under


### PR DESCRIPTION
## Summary

Wave 2 of #3378. Classify the two exact official Cursor adapter files as installer-managed so a framework-only update that deletes them is not mixed app. Other files under the hooks directory stay app. No hooks-dir prefix. A code comment names the pull_request_target / pinned-ref one-PR lag.

## Related Issues

Closes #3393
Refs #3378

## Checklist

- [x] /deft:change -- N/A (2 product files + CHANGELOG; not cross-cutting)
- [x] CHANGELOG.md -- added entry under [Unreleased]
- [x] ROADMAP.md -- N/A (child story, not a tracked ROADMAP item)
- [x] Tests pass locally

## Test plan

- [x] pnpm exec vitest run packages/core/src/init-deposit (355 passed, 23 skipped)
- [x] assertInstallerAllowlistHonors1430 stays green
- [x] verify:ac clause walk: 2 verified, 0 failed
- [x] Full task check still running locally under sibling load; CI is the merge chokepoint
