### PR TITLE
fix(init-deposit): stage ledger intersection including tracked deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`deft update` stages only this-run installer-managed ledger paths, including tracked deletions (#3394).** Ledger minus allowlist is printed and left unstaged. Untracked deletes are filtered so they cannot fail the batch. Pre-existing consumer edits to Taskfile, package.json, or .gitignore are not staged. Closes #3394. Refs #3378, #3392, #3393.
+
 ### Fixed
 
 - **Official Cursor adapter deletes no longer trip mixed-core-and-app (#3393).** A framework-only update that removes the retired hook adapter is installer-managed, not app. Other consumer hooks stay app-owned. Consumers on `pull_request_target` or pinned workflow refs see the old guard for one PR. Closes #3393. Refs #3378.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Obsolete xbrief schema delete is ledgered so update can stage it (#3418).** `syncConsumerXbriefSchemas` removes dest-only `vbrief-core.schema.json` through `containedRemove`. Ledger intersection can `git add` the tracked deletion. Closes #3418. Refs #3394, #3392.
+
 - **Official Cursor adapter deletes no longer trip mixed-core-and-app (#3393).** A framework-only update that removes the retired hook adapter is installer-managed, not app. Other consumer hooks stay app-owned. Consumers on `pull_request_target` or pinned workflow refs see the old guard for one PR. Closes #3393. Refs #3378.
 
 - **`scope:record-approved-scope` uses the #3110 human-presence mint gate (#3384).** Shared TTY / controlling-terminal / `--confirm` / typed `mint` / agent-CI refuse; `--actor` is display-only. New records omit `xbriefBodyDigest`. Wave 1 records have no `intentDigest` and are legacy under #3385. Closes #3384. Refs #3376, #3110.

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -11,7 +11,11 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { runWithMutationLedger, snapshotMutationSummary } from "../fs/mutation-ledger.js";
+import {
+  activeMutationLedger,
+  runWithMutationLedger,
+  snapshotMutationSummary,
+} from "../fs/mutation-ledger.js";
 import { detectBranchSync, formatBranchSyncExemptionMessage } from "../policy/branch-sync.js";
 import {
   assertInstallerAllowlistHonors1430,
@@ -26,6 +30,7 @@ import {
   type InstallerManagedMatcher,
   installerManagedGuardEre,
   installerManagedMatchers,
+  isCoreStagePath,
   isDepositGeneratedMetadata,
   isDirectiveDependencyKey,
   isInstallerManagedPath,
@@ -38,6 +43,7 @@ import {
   prunePackageAbsentDepositPaths,
   pruneStrayDepositPaths,
   reconcileDepositToContentPackage,
+  splitLedgerForStaging,
   stageFrameworkPaths,
 } from "./hygiene.js";
 import { CANONICAL_TASKFILE_INCLUDE } from "./scaffold.js";
@@ -63,7 +69,7 @@ describe("installer-managed allowlist (#1576)", () => {
     }
   });
 
-  it("includes Taskfile.yml in framework stage paths when present", () => {
+  it("includes Taskfile.yml in exist-walk stage paths when present (#3394)", () => {
     const root = mkdtempSync(join(tmpdir(), "hygiene-stage-"));
     try {
       mkdirSync(join(root, ".deft", "core"), { recursive: true });
@@ -74,14 +80,10 @@ describe("installer-managed allowlist (#1576)", () => {
         "version: '3'\ntasks:\n  hello:\n    cmds: [echo hi]\n",
         "utf8",
       );
-      const paths = frameworkStagePaths(root, join(root, ".deft", "core"), {
-        includeTaskfile: true,
-      });
+      const paths = frameworkStagePaths(root, join(root, ".deft", "core"));
       expect(paths).toContain("Taskfile.yml");
       expect(paths).toContain(".deft/core");
       expect(paths).toContain("AGENTS.md");
-      // When the include was not wired this run, Taskfile.yml is excluded.
-      expect(frameworkStagePaths(root, join(root, ".deft", "core"))).not.toContain("Taskfile.yml");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1001,7 +1003,7 @@ describe("scoped staging", () => {
     );
     expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain("build:");
 
-    const { stagedPaths } = depositStagePaths(project, { includeTaskfile: true });
+    const { stagedPaths } = depositStagePaths(project);
     expect(stagedPaths).toContain("Taskfile.yml");
 
     const porcelain = execFileSync("git", ["status", "--porcelain"], {
@@ -1040,7 +1042,7 @@ describe("scoped staging", () => {
     // Only Taskfile.yml is modified after baseline; AGENTS.md / .deft/core are clean.
     expect(ensureTaskfile(project, { printf: () => {} })).toBe(true);
 
-    const { stagePaths, stagedPaths } = depositStagePaths(project, { includeTaskfile: true });
+    const { stagePaths, stagedPaths } = depositStagePaths(project);
     expect(stagePaths).toContain("AGENTS.md");
     expect(stagedPaths).toContain("Taskfile.yml");
     expect(stagedPaths).not.toContain("AGENTS.md");
@@ -1072,7 +1074,7 @@ describe("scoped staging", () => {
     expect(cached).not.toContain(".deft/core/main.md");
   });
 
-  it("does not stage Taskfile.yml when the include was not wired this run (#1576)", async () => {
+  it("does not stage a dirty Taskfile.yml that this-run ledger did not mutate (#3394)", () => {
     const project = freshRoot("hygiene-unwired-taskfile-");
 
     mkdirSync(join(project, ".deft", "core"), { recursive: true });
@@ -1085,19 +1087,21 @@ describe("scoped staging", () => {
     );
     initGitRepo(project);
 
-    // Simulate an interactive run: the user edits their own Taskfile.yml, but
-    // the installer never wired the deft include (includeTaskfile omitted).
     writeFileSync(
       join(project, "Taskfile.yml"),
       "version: '3'\ntasks:\n  build:\n    cmds: [npm run build]\n  test:\n    cmds: [npm test]\n",
       "utf8",
     );
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n\nupdated\n", "utf8");
 
-    const { stagePaths, stagedPaths } = depositStagePaths(project);
+    const { stagePaths, stagedPaths } = runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("wrote", join(project, "AGENTS.md"));
+      return depositStagePaths(project);
+    });
     expect(stagePaths).not.toContain("Taskfile.yml");
     expect(stagedPaths).not.toContain("Taskfile.yml");
+    expect(stagedPaths).toContain("AGENTS.md");
 
-    // The user's Taskfile.yml edit is left un-staged for them to handle.
     const porcelain = execFileSync("git", ["status", "--porcelain"], {
       cwd: project,
       encoding: "utf8",
@@ -1113,6 +1117,193 @@ describe("scoped staging", () => {
     const result = stageFrameworkPaths(project, paths, { gitPorcelain: () => null });
     expect(result.staged).toBe(false);
     expect(existsSync(join(project, ".deft", "core", "main.md"))).toBe(true);
+  });
+});
+
+describe("ledger intersection staging (#3394)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshRoot(prefix: string): string {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    created.push(root);
+    return root;
+  }
+
+  function initGitRepo(root: string): void {
+    execFileSync("git", ["init"], { cwd: root });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
+    execFileSync("git", ["add", "-A"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "baseline"], { cwd: root });
+  }
+
+  const adapterRel = ".cursor/hooks/deft-cursor-hook-adapter.mjs";
+
+  it("treats .deft/core paths as stageable", () => {
+    expect(isCoreStagePath(".deft/core")).toBe(true);
+    expect(isCoreStagePath(".deft/core/VERSION")).toBe(true);
+    expect(isCoreStagePath("xbrief/PROJECT-DEFINITION.xbrief.json")).toBe(false);
+  });
+
+  it("splits ledger into allowlist/core vs remainder and skips untracked deletes", () => {
+    const split = splitLedgerForStaging(
+      {
+        wrote: ["AGENTS.md", "xbrief/PROJECT-DEFINITION.xbrief.json"],
+        stripped: [],
+        deleted: [adapterRel, "Taskfile.yml"],
+        mutations: [],
+      },
+      new Set([adapterRel]),
+    );
+    expect(split.stagePaths).toEqual(expect.arrayContaining(["AGENTS.md", adapterRel]));
+    expect(split.stagePaths).not.toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(split.stagePaths).not.toContain("Taskfile.yml");
+    expect(split.unstagedRemainder).toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(split.skippedUntrackedDeletes).toContain("Taskfile.yml");
+  });
+
+  it("stages a tracked adapter delete as D", () => {
+    const project = freshRoot("hygiene-ledger-adapter-d-");
+    mkdirSync(join(project, ".cursor", "hooks"), { recursive: true });
+    writeFileSync(join(project, adapterRel), "export {}\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    initGitRepo(project);
+    rmSync(join(project, adapterRel));
+
+    const result = runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("deleted", join(project, adapterRel));
+      return depositStagePaths(project);
+    });
+
+    expect(result.stagePaths).toContain(adapterRel);
+    expect(result.stagedPaths).toContain(adapterRel);
+    const cached = execFileSync("git", ["diff", "--cached", "--name-status"], {
+      cwd: project,
+      encoding: "utf8",
+    });
+    expect(cached).toMatch(new RegExp(`D\\s+${adapterRel.replace(/\./g, "\\.")}`));
+  });
+
+  it("does not let an untracked delete abort other staging", () => {
+    const project = freshRoot("hygiene-ledger-untracked-del-");
+    mkdirSync(join(project, ".deft", "core"), { recursive: true });
+    writeFileSync(join(project, ".deft", "core", "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    initGitRepo(project);
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n\nupdated\n", "utf8");
+
+    const added: string[][] = [];
+    const result = runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("wrote", join(project, "AGENTS.md"));
+      activeMutationLedger()?.record("deleted", join(project, adapterRel));
+      return depositStagePaths(project, {
+        runGitAdd: (root, paths) => {
+          added.push([...paths]);
+          execFileSync("git", ["add", "--", ...paths], { cwd: root });
+        },
+      });
+    });
+
+    expect(result.skippedUntrackedDeletes).toContain(adapterRel);
+    expect(result.stagedPaths).toContain("AGENTS.md");
+    expect(added.flat()).not.toContain(adapterRel);
+    expect(added.flat()).toContain("AGENTS.md");
+  });
+
+  it("prints PROJECT-DEFINITION writes and leaves them unstaged", () => {
+    const project = freshRoot("hygiene-ledger-pd-");
+    mkdirSync(join(project, ".deft", "core"), { recursive: true });
+    mkdirSync(join(project, "xbrief"), { recursive: true });
+    writeFileSync(join(project, ".deft", "core", "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    writeFileSync(join(project, "xbrief", "PROJECT-DEFINITION.xbrief.json"), "{}\n", "utf8");
+    initGitRepo(project);
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n\nupdated\n", "utf8");
+    writeFileSync(
+      join(project, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      '{"ok":true}\n',
+      "utf8",
+    );
+
+    const lines: string[] = [];
+    const result = runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("wrote", join(project, "AGENTS.md"));
+      activeMutationLedger()?.record(
+        "wrote",
+        join(project, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      );
+      return depositStagePaths(project, { printf: (text) => lines.push(text) });
+    });
+
+    expect(result.unstagedRemainder).toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(result.stagedPaths).not.toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(result.stagedPaths).toContain("AGENTS.md");
+    expect(lines.join("")).toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(lines.join("")).toContain("Left unstaged");
+
+    const cached = execFileSync("git", ["diff", "--cached", "--name-only"], {
+      cwd: project,
+      encoding: "utf8",
+    });
+    expect(cached).toContain("AGENTS.md");
+    expect(cached).not.toContain("PROJECT-DEFINITION");
+  });
+
+  it("does not stage untouched dirty package.json or .gitignore", () => {
+    const project = freshRoot("hygiene-ledger-untouched-");
+    mkdirSync(join(project, ".deft", "core"), { recursive: true });
+    writeFileSync(join(project, ".deft", "core", "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    writeFileSync(join(project, "package.json"), '{"name":"app"}\n', "utf8");
+    writeFileSync(join(project, ".gitignore"), "node_modules/\n", "utf8");
+    initGitRepo(project);
+
+    writeFileSync(join(project, "package.json"), '{"name":"app","private":true}\n', "utf8");
+    writeFileSync(join(project, ".gitignore"), "node_modules/\ndist/\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n\nupdated\n", "utf8");
+
+    const result = runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("wrote", join(project, "AGENTS.md"));
+      return depositStagePaths(project);
+    });
+
+    expect(result.stagePaths).toEqual(["AGENTS.md"]);
+    expect(result.stagedPaths).toEqual(["AGENTS.md"]);
+    const cached = execFileSync("git", ["diff", "--cached", "--name-only"], {
+      cwd: project,
+      encoding: "utf8",
+    });
+    expect(cached).toContain("AGENTS.md");
+    expect(cached).not.toContain("package.json");
+    expect(cached).not.toContain(".gitignore");
+  });
+
+  it("never invokes git add -A", () => {
+    const project = freshRoot("hygiene-ledger-no-add-a-");
+    mkdirSync(join(project, ".deft", "core"), { recursive: true });
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    initGitRepo(project);
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n\nupdated\n", "utf8");
+
+    const argv: string[][] = [];
+    runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("wrote", join(project, "AGENTS.md"));
+      depositStagePaths(project, {
+        runGitAdd: (_root, paths) => {
+          argv.push(["add", "--", ...paths]);
+        },
+      });
+    });
+    expect(argv).toHaveLength(1);
+    expect(argv[0]?.includes("-A")).toBe(false);
+    expect(argv[0]?.[0]).toBe("add");
+    expect(argv[0]?.[1]).toBe("--");
   });
 });
 

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -37,6 +37,7 @@ import {
   isPackageJsonDirectivePinOnlyDiff,
   isPackageLockDirectivePinFollowThrough,
   isPnpmLockDirectivePinFollowThrough,
+  isTrackedDeletePath,
   isUpgradePinPathContentAllowed,
   isYarnLockDirectivePinFollowThrough,
   pnpmLockRootDirectDeps,
@@ -1168,6 +1169,24 @@ describe("ledger intersection staging (#3394)", () => {
     expect(split.skippedUntrackedDeletes).toContain("Taskfile.yml");
   });
 
+  it("treats a ledgered directory as tracked when ls-files returns descendants", () => {
+    expect(isTrackedDeletePath(".deft/core/scripts", new Set([".deft/core/scripts/run.py"]))).toBe(
+      true,
+    );
+    expect(isTrackedDeletePath(".deft/core/scripts", new Set([".deft/core/VERSION"]))).toBe(false);
+    const split = splitLedgerForStaging(
+      {
+        wrote: [],
+        stripped: [],
+        deleted: [".deft/core/scripts"],
+        mutations: [],
+      },
+      new Set([".deft/core/scripts/run.py"]),
+    );
+    expect(split.stagePaths).toContain(".deft/core/scripts");
+    expect(split.skippedUntrackedDeletes).not.toContain(".deft/core/scripts");
+  });
+
   it("stages a tracked adapter delete as D", () => {
     const project = freshRoot("hygiene-ledger-adapter-d-");
     mkdirSync(join(project, ".cursor", "hooks"), { recursive: true });
@@ -1187,7 +1206,33 @@ describe("ledger intersection staging (#3394)", () => {
       cwd: project,
       encoding: "utf8",
     });
-    expect(cached).toMatch(new RegExp(`D\\s+${adapterRel.replace(/\./g, "\\.")}`));
+    const deletedLine = cached.split(/\r?\n/).find((row) => row.includes(adapterRel)) ?? "";
+    expect(deletedLine.startsWith("D")).toBe(true);
+  });
+
+  it("stages a tracked directory prune via descendant ls-files hits", () => {
+    const project = freshRoot("hygiene-ledger-dir-d-");
+    mkdirSync(join(project, ".deft", "core", "scripts"), { recursive: true });
+    writeFileSync(join(project, ".deft", "core", "scripts", "run.py"), "print(1)\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    initGitRepo(project);
+    rmSync(join(project, ".deft", "core", "scripts"), { recursive: true, force: true });
+
+    const result = runWithMutationLedger(project, () => {
+      activeMutationLedger()?.record("deleted", join(project, ".deft", "core", "scripts"));
+      return depositStagePaths(project);
+    });
+
+    expect(result.stagePaths).toContain(".deft/core/scripts");
+    expect(result.skippedUntrackedDeletes).not.toContain(".deft/core/scripts");
+    const cached = execFileSync("git", ["diff", "--cached", "--name-status"], {
+      cwd: project,
+      encoding: "utf8",
+    });
+    expect(cached).toContain(".deft/core/scripts/run.py");
+    const deletedLine =
+      cached.split(/\r?\n/).find((row) => row.includes(".deft/core/scripts/run.py")) ?? "";
+    expect(deletedLine.startsWith("D")).toBe(true);
   });
 
   it("does not let an untracked delete abort other staging", () => {

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -48,6 +48,7 @@ import {
   stageFrameworkPaths,
 } from "./hygiene.js";
 import { CANONICAL_TASKFILE_INCLUDE } from "./scaffold.js";
+import { syncConsumerXbriefSchemas } from "./xbrief-projections.js";
 
 describe("installer-managed allowlist (#1576)", () => {
   it("treats Taskfile.yml as installer-managed", () => {
@@ -1349,6 +1350,36 @@ describe("ledger intersection staging (#3394)", () => {
     expect(argv[0]?.includes("-A")).toBe(false);
     expect(argv[0]?.[0]).toBe("add");
     expect(argv[0]?.[1]).toBe("--");
+  });
+
+  it("stages a tracked obsolete schema delete as D (#3418)", () => {
+    const project = freshRoot("hygiene-ledger-schema-d-");
+    const deftDir = join(project, ".deft", "core");
+    mkdirSync(join(deftDir, "vbrief", "schemas"), { recursive: true });
+    mkdirSync(join(project, "xbrief", "schemas"), { recursive: true });
+    writeFileSync(
+      join(deftDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"),
+      "current\n",
+      "utf8",
+    );
+    writeFileSync(join(project, "xbrief", "schemas", "vbrief-core.schema.json"), "stale\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    initGitRepo(project);
+
+    const result = runWithMutationLedger(project, () => {
+      syncConsumerXbriefSchemas(project, deftDir);
+      return depositStagePaths(project);
+    });
+
+    const schemaRel = "xbrief/schemas/vbrief-core.schema.json";
+    expect(result.stagePaths).toContain(schemaRel);
+    expect(result.stagedPaths).toContain(schemaRel);
+    const cached = execFileSync("git", ["diff", "--cached", "--name-status"], {
+      cwd: project,
+      encoding: "utf8",
+    });
+    const deletedLine = cached.split(/\r?\n/).find((row) => row.includes(schemaRel)) ?? "";
+    expect(deletedLine.startsWith("D")).toBe(true);
   });
 });
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -920,9 +920,24 @@ export interface LedgerStageSplit {
 }
 
 /**
+ * True when `git ls-files` named the path or a descendant (directory prune).
+ * Exact-only membership misses a ledgered directory whose tracked children
+ * are the ls-files hits (#3394 Greptile).
+ */
+export function isTrackedDeletePath(path: string, trackedDeletes: ReadonlySet<string>): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  if (trackedDeletes.has(normalized)) return true;
+  const prefix = normalized.endsWith("/") ? normalized : `${normalized}/`;
+  for (const tracked of trackedDeletes) {
+    if (tracked === normalized || tracked.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
  * Split this-run ledger paths into stageable (allowlist or core) vs remainder.
- * Deleted paths not present in `trackedDeletes` are skipped so one untracked
- * delete cannot fail a batch `git add` (#3394).
+ * Deleted paths not present in `trackedDeletes` (or under a tracked prefix)
+ * are skipped so one untracked delete cannot fail a batch `git add` (#3394).
  */
 export function splitLedgerForStaging(
   summary: MutationSummary,
@@ -942,7 +957,7 @@ export function splitLedgerForStaging(
       unstagedRemainder.push(path);
       return;
     }
-    if (deleted.has(path) && !trackedDeletes.has(path)) {
+    if (deleted.has(path) && !isTrackedDeletePath(path, trackedDeletes)) {
       skippedUntrackedDeletes.push(path);
       return;
     }

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -16,6 +16,11 @@ import { existsSync, readdirSync } from "node:fs";
 import { readdir, rm, stat } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { containedRemove } from "../fs/contained-write.js";
+import {
+  activeMutationLedger,
+  type MutationSummary,
+  snapshotMutationSummary,
+} from "../fs/mutation-ledger.js";
 import { applyCoreGuardWithBranchSync, type BranchSyncDetection } from "../policy/branch-sync.js";
 import { gitPorcelain } from "../story-ready/git.js";
 import { CANONICAL_INSTALL_ROOT, type InitDepositIo } from "./constants.js";
@@ -889,20 +894,65 @@ export function classifyMixedCoreAndAppContentAware(
 
 export interface FrameworkStagePathsOptions {
   /**
-   * Include the vendored `.deft/core` payload in the stage set. Defaults to
-   * `true` for init and real payload swaps. No-op updates set this to `false`
-   * so CRLF-only core noise cannot be staged while safe projections are repaired.
+   * Include the vendored `.deft/core` payload in the exist-walk stage set.
+   * Defaults to `true`. Ignored when a mutation ledger is bound (#3394) —
+   * core paths stage only if they appear on this-run ledger.
    */
   readonly includeCore?: boolean;
   /**
-   * Include the project-root ``Taskfile.yml`` in the stage set. Defaults to
-   * ``false``: unlike the other allowlisted paths, ``Taskfile.yml`` is a
-   * consumer-owned file that merely *contains* an installer-managed include
-   * block, so it must only be staged when the installer actually wired that
-   * block this run -- otherwise an unrelated user edit would be silently
-   * ``git add``ed (#1576 review).
+   * Unused (#3394). Ledger intersection stages Taskfile.yml only when this run
+   * mutated it. Kept so existing callers compile. Exist-walk (no ledger) stages
+   * Taskfile.yml when the file exists — do not reintroduce the include skip.
    */
   readonly includeTaskfile?: boolean;
+}
+
+/** True for the vendored payload tree (not the installer-managed allowlist). */
+export function isCoreStagePath(path: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  return normalized === ".deft/core" || normalized.startsWith(".deft/core/");
+}
+
+export interface LedgerStageSplit {
+  readonly stagePaths: string[];
+  readonly unstagedRemainder: string[];
+  readonly skippedUntrackedDeletes: string[];
+}
+
+/**
+ * Split this-run ledger paths into stageable (allowlist or core) vs remainder.
+ * Deleted paths not present in `trackedDeletes` are skipped so one untracked
+ * delete cannot fail a batch `git add` (#3394).
+ */
+export function splitLedgerForStaging(
+  summary: MutationSummary,
+  trackedDeletes: ReadonlySet<string> = new Set(),
+): LedgerStageSplit {
+  const seen = new Set<string>();
+  const stagePaths: string[] = [];
+  const unstagedRemainder: string[] = [];
+  const skippedUntrackedDeletes: string[] = [];
+  const deleted = new Set(summary.deleted.map((path) => path.replace(/\\/g, "/")));
+
+  const visit = (raw: string): void => {
+    const path = raw.replace(/\\/g, "/");
+    if (!path || seen.has(path)) return;
+    seen.add(path);
+    if (!isInstallerManagedPath(path) && !isCoreStagePath(path)) {
+      unstagedRemainder.push(path);
+      return;
+    }
+    if (deleted.has(path) && !trackedDeletes.has(path)) {
+      skippedUntrackedDeletes.push(path);
+      return;
+    }
+    stagePaths.push(path);
+  };
+
+  for (const path of summary.wrote) visit(path);
+  for (const path of summary.stripped) visit(path);
+  for (const path of summary.deleted) visit(path);
+  return { stagePaths, unstagedRemainder, skippedUntrackedDeletes };
 }
 
 export function frameworkStagePaths(
@@ -931,7 +981,6 @@ export function frameworkStagePaths(
   }
 
   for (const matcher of installerManagedMatchers()) {
-    if (matcher.exact === "Taskfile.yml" && !options.includeTaskfile) continue;
     if (matcher.exact) {
       add(matcher.exact);
     } else if (matcher.prefix) {
@@ -958,7 +1007,7 @@ export function stageFrameworkPaths(
   const runGitAdd =
     seams.runGitAdd ??
     ((root: string, stagePaths: readonly string[]) => {
-      execFileSync("git", ["add", ...stagePaths], {
+      execFileSync("git", ["add", "--", ...stagePaths], {
         cwd: root,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
@@ -1222,39 +1271,56 @@ export async function pruneStrayDepositPaths(
 
 export const COMMIT_HYGIENE_BRANCH_NAME = "chore/deft-framework-upgrade";
 
+export function printUnstagedLedgerRemainder(
+  io: InitDepositIo,
+  remainder: readonly string[],
+): void {
+  if (remainder.length === 0) return;
+  io.printf("Left unstaged (not installer-managed this run; do not git add -A):\n");
+  for (const path of remainder) {
+    io.printf(`  ${path}\n`);
+  }
+}
+
 export function printCommitGuidance(
   io: InitDepositIo,
   paths: readonly string[],
   staged: boolean,
+  unstagedRemainder: readonly string[] = [],
 ): void {
-  if (paths.length === 0) return;
-  const addCmd = `git add ${paths.join(" ")}`;
-  io.printf(
-    "\nCommit hygiene (#1453, #1671, #3127, #3193): keep the framework upgrade in its OWN branch/PR.\n",
-  );
-  io.printf("Do NOT use `git add -A` -- mixing the payload with product/app files trips the\n");
-  io.printf("deft-core-guard CI check.\n");
-  io.printf(
-    "One upgrade PR MAY co-travel: .deft/core/** + installer-managed deposits + package.json\n",
-  );
-  io.printf(
-    "pin/lock (Directive pin-only + lock follow-through, #3193) + .deft/GENERATION.json.\n",
-  );
-  io.printf("True app/product paths still require a separate PR.\n");
-  if (staged) {
-    io.printf("The installer already staged ONLY these framework + installer-managed paths:\n");
-    io.printf(`  ${addCmd}\n`);
-  } else {
-    io.printf("Stage ONLY these framework + installer-managed paths:\n");
-    io.printf(`  ${addCmd}\n`);
+  if (paths.length === 0 && unstagedRemainder.length === 0) return;
+  if (paths.length > 0) {
+    const addCmd = `git add -- ${paths.join(" ")}`;
+    io.printf(
+      "\nCommit hygiene (#1453, #1671, #3127, #3193, #3394): keep the framework upgrade in its OWN branch/PR.\n",
+    );
+    io.printf("Do NOT use `git add -A` -- mixing the payload with product/app files trips the\n");
+    io.printf("deft-core-guard CI check.\n");
+    io.printf(
+      "One upgrade PR MAY co-travel: .deft/core/** + installer-managed deposits + package.json\n",
+    );
+    io.printf(
+      "pin/lock (Directive pin-only + lock follow-through, #3193) + .deft/GENERATION.json.\n",
+    );
+    io.printf("True app/product paths still require a separate PR.\n");
+    if (staged) {
+      io.printf("The installer already staged ONLY these framework + installer-managed paths:\n");
+      io.printf(`  ${addCmd}\n`);
+    } else {
+      io.printf("Stage ONLY these framework + installer-managed paths:\n");
+      io.printf(`  ${addCmd}\n`);
+    }
+    io.printf("Then take the framework deposit through the full PR lifecycle so deft-core-guard\n");
+    io.printf("evaluates a clean, standalone upgrade PR:\n");
+    io.printf(`  1. Branch: git switch -c ${COMMIT_HYGIENE_BRANCH_NAME}\n`);
+    io.printf('  2. Commit: git commit -m "chore(deft): update framework payload"\n');
+    io.printf(`  3. Push:   git push -u origin ${COMMIT_HYGIENE_BRANCH_NAME}\n`);
+    io.printf('  4. PR:     gh pr create --fill --title "chore(deft): update framework payload"\n');
+    io.printf(
+      "  5. Merge:  gh pr merge --squash --delete-branch   # after deft-core-guard passes\n",
+    );
   }
-  io.printf("Then take the framework deposit through the full PR lifecycle so deft-core-guard\n");
-  io.printf("evaluates a clean, standalone upgrade PR:\n");
-  io.printf(`  1. Branch: git switch -c ${COMMIT_HYGIENE_BRANCH_NAME}\n`);
-  io.printf('  2. Commit: git commit -m "chore(deft): update framework payload"\n');
-  io.printf(`  3. Push:   git push -u origin ${COMMIT_HYGIENE_BRANCH_NAME}\n`);
-  io.printf('  4. PR:     gh pr create --fill --title "chore(deft): update framework payload"\n');
-  io.printf("  5. Merge:  gh pr merge --squash --delete-branch   # after deft-core-guard passes\n");
+  printUnstagedLedgerRemainder(io, unstagedRemainder);
 }
 
 function defaultCachedNames(projectDir: string): string[] {
@@ -1293,6 +1359,28 @@ export interface DepositStagePathsOptions
   extends StageFrameworkPathsSeams,
     FrameworkStagePathsOptions {
   readCachedNames?: (projectDir: string) => string[];
+  /** `git ls-files` seam for filtering untracked ledger deletions (#3394). */
+  readTrackedNames?: (projectDir: string, paths: readonly string[]) => string[];
+  /** Explicit this-run ledger. Defaults to the bound snapshot. */
+  mutations?: MutationSummary;
+  printf?: (text: string) => void;
+}
+
+function defaultTrackedNames(projectDir: string, paths: readonly string[]): string[] {
+  if (paths.length === 0) return [];
+  try {
+    const out = execFileSync("git", ["ls-files", "-z", "--", ...paths], {
+      cwd: projectDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return out
+      .split("\0")
+      .map((entry) => entry.trim().replace(/\\/g, "/"))
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
 }
 
 export function depositStagePaths(
@@ -1302,12 +1390,35 @@ export function depositStagePaths(
   stagePaths: string[];
   staged: boolean;
   stagedPaths: string[];
+  unstagedRemainder: string[];
+  skippedUntrackedDeletes: string[];
 } {
-  const deftDir = join(projectDir, CANONICAL_INSTALL_ROOT);
-  const stagePaths = frameworkStagePaths(projectDir, deftDir, {
-    includeCore: options.includeCore,
-    includeTaskfile: options.includeTaskfile ?? false,
-  });
+  const summary = options.mutations ?? snapshotMutationSummary();
+  const ledgerBound = options.mutations !== undefined || activeMutationLedger() !== undefined;
+
+  let stagePaths: string[];
+  let unstagedRemainder: string[] = [];
+  let skippedUntrackedDeletes: string[] = [];
+
+  if (ledgerBound) {
+    const readTracked = options.readTrackedNames ?? defaultTrackedNames;
+    const tracked = new Set(readTracked(projectDir, summary.deleted));
+    const split = splitLedgerForStaging(summary, tracked);
+    stagePaths = split.stagePaths;
+    unstagedRemainder = split.unstagedRemainder;
+    skippedUntrackedDeletes = split.skippedUntrackedDeletes;
+  } else {
+    const deftDir = join(projectDir, CANONICAL_INSTALL_ROOT);
+    stagePaths = frameworkStagePaths(projectDir, deftDir, {
+      includeCore: options.includeCore,
+    });
+  }
+
+  const leftover = [...unstagedRemainder, ...skippedUntrackedDeletes];
+  if (leftover.length > 0 && options.printf) {
+    printUnstagedLedgerRemainder({ printf: options.printf }, leftover);
+  }
+
   const { staged } = stageFrameworkPaths(projectDir, stagePaths, options);
   const readCachedNames = options.readCachedNames ?? defaultCachedNames;
   const cachedNames = staged ? readCachedNames(projectDir) : [];
@@ -1315,5 +1426,7 @@ export function depositStagePaths(
     stagePaths,
     staged,
     stagedPaths: staged ? actuallyStagedPaths(stagePaths, cachedNames) : [],
+    unstagedRemainder,
+    skippedUntrackedDeletes,
   };
 }

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -160,6 +160,7 @@ describe("printRefreshSideEffects", () => {
     );
     expect(lines.join("")).toContain("AGENTS.md refresh side effects (#1671)");
     expect(lines.join("")).toContain(".deft/core/VERSION");
+    expect(lines.join("")).not.toContain("no post-stage stragglers");
   });
 
   it("prints only the Windows hint for CRLF-only core noise", () => {
@@ -992,7 +993,12 @@ describe("runRefreshDeposit", () => {
       ready: true,
       live_status: "functional",
     });
-    expect(payload.staged_paths).toEqual(expect.arrayContaining(["Taskfile.yml", ".deft/core"]));
+    expect(payload.staged_paths).toEqual(expect.arrayContaining(["Taskfile.yml"]));
+    expect(
+      (payload.staged_paths as string[]).some(
+        (path) => path === ".deft/core" || path.startsWith(".deft/core/"),
+      ),
+    ).toBe(true);
 
     const porcelain = execFileSync("git", ["status", "--porcelain"], {
       cwd: project,

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -499,8 +499,8 @@ export function printRefreshSideEffects(io: InitDepositIo, effects: RefreshSideE
   }
   io.printf("\nAGENTS.md refresh side effects (#1671): the refresh and framework payload swap\n");
   io.printf("left these framework files with uncommitted changes -- they belong in the\n");
-  io.printf("framework deposit commit (the installer stages them before printing the\n");
-  io.printf("`git add` list below, so there are no post-stage stragglers):\n");
+  io.printf("framework deposit commit (the installer stages this-run installer-managed\n");
+  io.printf("paths; ledger remainder stays unstaged):\n");
   for (const file of effects.files) {
     io.printf(`  ${file}\n`);
   }
@@ -815,13 +815,14 @@ export async function runRefreshDeposit(
     const stagedResult = depositStagePaths(projectDir, {
       includeTaskfile: taskfileWired,
       includeCore: !alreadyCurrent,
+      printf: (text) => io.printf(text),
     });
     stagedPaths = stagedResult.stagedPaths;
     if (!alreadyCurrent) {
       printCommitGuidance(io, stagedResult.stagePaths, stagedResult.staged);
     } else if (stagedResult.stagedPaths.length > 0) {
       io.printf("\nUpdated installer-managed projections for the current framework deposit:\n");
-      io.printf(`  git add ${stagedResult.stagedPaths.join(" ")}\n`);
+      io.printf(`  git add -- ${stagedResult.stagedPaths.join(" ")}\n`);
     }
   }
 

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { runWithMutationLedger, snapshotMutationSummary } from "../fs/mutation-ledger.js";
 import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import {
   assertProjectedSchemaDescriptionsRooted,
@@ -104,6 +105,21 @@ describe("xbrief consumer projections (#2595)", () => {
     const file = join(project, "not-a-schema-dir");
     writeFileSync(file, "plain file\n", "utf8");
     expect(() => assertProjectedSchemaDescriptionsRooted(project, file)).not.toThrow();
+  });
+
+  it("ledgers obsolete schema delete through containedRemove (#3418)", () => {
+    const { project, deftDir } = fixture();
+    const consumerSchemas = join(project, "xbrief", "schemas");
+    mkdirSync(consumerSchemas, { recursive: true });
+    writeFileSync(join(consumerSchemas, "vbrief-core.schema.json"), "stale\n", "utf8");
+
+    const summary = runWithMutationLedger(project, () => {
+      expect(syncConsumerXbriefSchemas(project, deftDir)).toBe(true);
+      return snapshotMutationSummary();
+    });
+
+    expect(existsSync(join(consumerSchemas, "vbrief-core.schema.json"))).toBe(false);
+    expect(summary.deleted).toContain("xbrief/schemas/vbrief-core.schema.json");
   });
 
   it("self-check runs after obsolete vbrief-core.schema.json is removed", () => {

--- a/packages/core/src/init-deposit/xbrief-projections.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.ts
@@ -6,9 +6,9 @@
  * these repairs.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
-import { containedWrite } from "../fs/contained-write.js";
+import { containedRemove, containedWrite } from "../fs/contained-write.js";
 import { assertDestinationNotSymlink } from "../fs/projection-containment.js";
 import { resolveLifecycleRoot } from "../layout/resolve.js";
 import { DEV_FALLBACK } from "../platform/constants.js";
@@ -124,9 +124,7 @@ export function syncConsumerXbriefSchemas(projectDir: string, deftDir: string): 
   }
 
   const obsoleteDestination = join(destinationDir, OBSOLETE_CORE_SCHEMA);
-  assertDestinationNotSymlink(projectDir, obsoleteDestination);
-  if (existsSync(obsoleteDestination)) {
-    rmSync(obsoleteDestination, { force: true });
+  if (containedRemove({ root: projectDir, target: obsoleteDestination }).removed) {
     changed = true;
   }
 


### PR DESCRIPTION
## Summary

deft update now stages only this-run ledger paths that are installer-managed (or .deft/core/**), including tracked deletions via git add --. Ledger remainder (PROJECT-DEFINITION / #2822) is printed and left unstaged. Untracked deletes are filtered with git ls-files so they cannot fail the batch. The includeTaskfile exist-walk special case is gone.

Residual: obsolete xbrief/schemas/vbrief-core.schema.json delete now goes through containedRemove so the bound ledger records it and intersection staging can add the tracked D.

## Test plan

- [x] pnpm exec vitest run packages/core/src/init-deposit/xbrief-projections.test.ts packages/core/src/init-deposit/hygiene.test.ts (94 passed, 3 skipped)
- [x] Tracked adapter delete stages as D
- [x] Untracked allowlisted delete does not abort other staging
- [x] PD write printed, not staged
- [x] Dirty Taskfile / package.json / .gitignore not staged unless on the ledger
- [x] No git add -A
- [x] Obsolete schema delete is ledgered and stages as D
- [x] task check:framework-source (full suite + coverage; verify:ac skipped because this brief's swarm.verify_commands includes `task check` and deadlocks)

Closes #3394
Closes #3418
Refs #3378 #3392 #3393
