### PR TITLE
chore(xbrief): land completed-tracked artifacts for closed 3382-cohort issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Land completed-tracked artifacts for closed 3382-cohort issues (#3264 / #1358).** 24 already-completed xBRIEFs for closed issues now live under `xbrief/completed/` so `verify:completed-tracked` and post-merge lifecycle see the record. Does not re-close those issues. Refs #2321.
 - **Project-invariant preflight gate (#3425).** `xbrief:preflight` and `verify:story-ready` fail closed when an applicable `plan.policy.projectInvariants` ID has no `coverage_map` disposition. Remediation names the omitted ID. Empty or absent list is a no-op. Drift is the list as of check time. Completeness of declarations only — not truth. Visage load/save and sibling-purpose entries are authored examples, not framework oracles. Docs: `content/docs/project-invariants.md`. Refs #3425.
 - **Typed `plan.policy.projectInvariants` (#3425).** Authored must-not-break list (`id`, statement, contract surface as paths and/or module ids). Empty or absent is a no-op. Scope `coverage_map` reuses covered/deferred/behavioral_delta against applicable IDs; `split` is excluded; `not_applicable` needs a reason. Applicability is contract surface × `file_scope`. Refs #3425.
 - **Announce Prettier-sensitive deposit rewrites (#3395).** `deft update` prints rewritten consumer-owned `xbrief/schemas/*` from the mutation ledger and tells you to run `task fmt` before the upgrade PR. It does not run the consumer formatter. Closes #3395.

--- a/xbrief/completed/2026-08-16-3379-doctor-advisory-fails-need-one-sot-remediations-must-not-pre.xbrief.json
+++ b/xbrief/completed/2026-08-16-3379-doctor-advisory-fails-need-one-sot-remediations-must-not-pre.xbrief.json
@@ -1,0 +1,118 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3379",
+    "updated": "2026-08-16T22:38:07Z"
+  },
+  "plan": {
+    "id": "3379-doctor-advisory-sot",
+    "title": "doctor advisory fails need one SoT; remediations must not prescribe a blocked write",
+    "status": "completed",
+    "narratives": {
+      "Description": "Residual of #3372. deriveExitCode and cmdDoctor warningOnFail are two name lists. Replace both with one exported set plus data.advisory. Dirty doctor copy must not tell the operator to edit files when writes are blocked.",
+      "UserStory": "As a Directive operator, I want advisory doctor fails to stay warnings with one name set, so that a gated ritual cannot deadlock writes on bookkeeping that the check itself calls advisory.",
+      "ImplementationPlan": "1. Export DOCTOR_ADVISORY_FAIL_CHECKS from packages/core/src/doctor/checks.ts and make deriveExitCode and cmdDoctor import it. 2. Treat data.advisory true or a set name as advisory, stamp existing advisory fails, fix renderDoctorStatusLine and session:ready copy, then verify with tests.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3379",
+      "Overview": "Authority is the residual-lock comment 5309596896, not the issue body. Do not re-special-case completed-open-items. Do not implement ack ledger.",
+      "Labels": "bug, determinism, doctor, agent-experience, area:cli"
+    },
+    "items": [
+      {
+        "title": "One advisory-fail name set",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given deriveExitCode and cmdDoctor, when they classify a fail, both import one exported name set from packages/core/src/doctor/checks.ts. No inline duplicate list. A fail is advisory when data.advisory is true or the name is in the set. A fixture check with only data.advisory true and a name not in the set exits 0, lastErrorCount 0, severity warning. Names already in today's lists stay warnings. completed-lifecycle-consistency on plan.status drift is still an error.",
+          "Traces": "FR-3379-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/doctor/checks.test.ts; packages/core/src/doctor/main.test.ts; PR #3406 Greptile CLEAN 5/5; merge e6d4ca8f562dc2af88a5dc9cbf1dd7e2677f4e22",
+          "recorded_at": "2026-08-16T22:40:00.000Z",
+          "recorded_by": "grok-build-leaf-3379"
+        }
+      },
+      {
+        "title": "Remediation copy does not prescribe a blocked write",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a dirty doctor or gated ritual, when renderDoctorStatusLine and the throttle hint print, they say --full re-probes only and do not say address findings. When lastErrorCount is greater than 0, copy says these are hard errors and advisory warnings do not block writes. session:ready and PreToolUse doctor-step fail text match. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3379-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/doctor/doctor-state.test.ts; PR #3406 Greptile CLEAN 5/5; merge e6d4ca8f562dc2af88a5dc9cbf1dd7e2677f4e22",
+          "recorded_at": "2026-08-16T22:40:00.000Z",
+          "recorded_by": "grok-build-leaf-3379"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "determinism",
+      "doctor",
+      "agent-experience",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3379",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3379: doctor advisory fails need one SoT"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/doctor",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/doctor"
+        ],
+        "expected_outputs": [
+          "one advisory-fail SoT",
+          "CHANGELOG #3379"
+        ],
+        "depends_on": [],
+        "conflict_group": "doctor-advisory",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3406,
+        "prBase": "master",
+        "mergeCommit": "e6d4ca8f562dc2af88a5dc9cbf1dd7e2677f4e22",
+        "deliveryBranch": "master",
+        "deliveryCommit": "e6d4ca8f562dc2af88a5dc9cbf1dd7e2677f4e22",
+        "verifiedAt": "2026-08-16T22:38:07Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "6d5f682c-bf0f-47a5-a6ea-82bf1a3755fa"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T22:38:07Z",
+      "completedSessionId": "6d5f682c-bf0f-47a5-a6ea-82bf1a3755fa",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/doctor"
+      ],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "product AC is targeted doctor vitest; residual-lock items are not clause-walkable",
+      "clauses": []
+    },
+    "updated": "2026-08-16T22:38:07Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3380-scopecomplete-ancestry-on-deliverybranch-is-delivery-pr-base.xbrief.json
+++ b/xbrief/completed/2026-08-16-3380-scopecomplete-ancestry-on-deliverybranch-is-delivery-pr-base.xbrief.json
@@ -1,0 +1,159 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3380 lock comment 5309638161",
+    "updated": "2026-08-16T23:01:38Z"
+  },
+  "plan": {
+    "id": "3380-delivery-ancestry",
+    "title": "scope:complete: ancestry on deliveryBranch is delivery; PR base is provenance",
+    "status": "completed",
+    "narratives": {
+      "Description": "evaluateDeliveryGate short-circuits when prBase !== deliveryBranch before ancestry. Two-hop feature to develop to main cannot complete honestly. Ancestry on the refreshed delivery ref is delivery; prBase is provenance only.",
+      "UserStory": "As a Directive operator on a two-hop integration-then-delivery repo, I want scope:complete to accept a merge commit that is already an ancestor of origin/deliveryBranch even when the scope PR targeted develop, so that shipped work can complete without a lying --non-delivery disposition.",
+      "ImplementationPlan": "1. Change packages/core/src/scope/delivery-evidence.ts so a required mergeCommit that is an ancestor of refreshed origin/deliveryBranch is delivered and prBase is stamped as given. 2. Keep merged_to_integration only when ancestry fails; update remediations, flip the intermediate-prBase test, document in content/docs/directive-lifecycle.md, then verify with packages/core/src/scope/delivery-evidence.test.ts and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3380",
+      "Overview": "Authority is analysis+lock comment 5309638161, not the issue body. Do not infer deliveryBranch from workflows. Do not implement sync-PR conferral. Do not auto-discover linked PRs. Do not change resolveDeliveryBranch order. Do not solve squash-sync. Do not edit packages/core/src/scope/acceptance-evidence.ts (live #3387).",
+      "Labels": "bug, determinism, agent-experience, scm, area:cli, area:vbrief"
+    },
+    "items": [
+      {
+        "title": "Ancestry is delivery; prBase is provenance",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given mergeCommit is required and is an ancestor of refreshed origin/deliveryBranch, when prBase is develop or any non-delivery branch, evaluateDeliveryGate is ok with disposition delivered and prBase stamped as given. Same prBase with failing ancestry is ok false and disposition merged_to_integration; the message does not claim the work never shipped. prBase equal to deliveryBranch with passing ancestry stays delivered.",
+          "Traces": "FR-3380-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/scope/delivery-evidence.test.ts#3380",
+          "recorded_at": "2026-08-16T23:00:30Z",
+          "recorded_by": "leaf-implementation/3380"
+        }
+      },
+      {
+        "title": "Remediations name merge-commit and typed deliveryBranch",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given null evidence, ancestry miss, or integration-only, when fail messages print, they name scope:complete -- --merge-commit and typed plan.policy.deliveryBranch via task policy:show --field=deliveryBranch. They do not treat --non-delivery as the honest path for shipped two-hop work. completed-lifecycle and non-delivery dispositions stay unchanged. Edit CLI complete-path copy only when it still repeats PR-base-equals-deliveryBranch as the rule.",
+          "Traces": "FR-3380-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/scope/delivery-evidence.test.ts#3380",
+          "recorded_at": "2026-08-16T23:00:30Z",
+          "recorded_by": "leaf-implementation/3380"
+        }
+      },
+      {
+        "title": "Lifecycle doc and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given content/docs/directive-lifecycle.md, when the delivery-integrity section is read, ancestry on the delivery ref is delivery, integration prBase is provenance, and squash-sync can break ancestry of develop merge commits. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3380-3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "content/docs/directive-lifecycle.md#3380",
+          "recorded_at": "2026-08-16T23:00:30Z",
+          "recorded_by": "leaf-implementation/3380"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "determinism",
+      "agent-experience",
+      "scm",
+      "area:cli",
+      "area:vbrief"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3380",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3380: ancestry on deliveryBranch is delivery"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3380#issuecomment-5309638161",
+        "type": "x-xbrief/github-comment",
+        "title": "Analysis + implementation lock (authority)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/scope/delivery-evidence.ts",
+          "packages/core/src/scope/delivery-evidence.test.ts",
+          "content/docs/directive-lifecycle.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/scope/delivery-evidence.test.ts"
+        ],
+        "expected_outputs": [
+          "ancestry-first delivery gate",
+          "CHANGELOG #3380"
+        ],
+        "depends_on": [],
+        "conflict_group": "delivery-evidence",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3411,
+        "prBase": "master",
+        "mergeCommit": "60ba24a391be1e37fd4a4b33fdf63f47a6d2eb49",
+        "deliveryBranch": "master",
+        "deliveryCommit": "60ba24a391be1e37fd4a4b33fdf63f47a6d2eb49",
+        "verifiedAt": "2026-08-16T23:01:38Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "11bbcfdf-c9f8-41a0-8534-99d412446ecb"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T23:01:38Z",
+      "completedSessionId": "11bbcfdf-c9f8-41a0-8534-99d412446ecb",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/scope/delivery-evidence.test.ts"
+      ],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "collapsed lock comment 5309638161 AC into three items plus stated vitest command",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Intermediate prBase plus passing ancestry is \"delivered\"; failing ancestry is \"merged_to_integration\"",
+          "artifact_path": "packages/core/src/scope/delivery-evidence.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Null-evidence and fail messages name \"--merge-commit\" and typed \"deliveryBranch\"",
+          "artifact_path": "packages/core/src/scope/delivery-evidence.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "directive-lifecycle.md states ancestry is delivery and names the \"Squash-sync\" caveat",
+          "artifact_path": "content/docs/directive-lifecycle.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T23:01:38Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3381-engine-ts-build-trailing-noop-for-gotask-lt-352.xbrief.json
+++ b/xbrief/completed/2026-08-16-3381-engine-ts-build-trailing-noop-for-gotask-lt-352.xbrief.json
@@ -1,0 +1,121 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3381 lock comment 5309667759",
+    "updated": "2026-08-16T22:44:54Z"
+  },
+  "plan": {
+    "id": "3381-ts-build-trailing-noop",
+    "title": "engine:_ts-build: trailing no-op for go-task <3.52 untaken if/fi",
+    "status": "completed",
+    "narratives": {
+      "Description": "go-task before 3.52 treats an untaken last if/fi as script exit 1. engine:_ts-build still ends on that fi, so every non-runtime task deft:* fails on a consumer deposit. Add a trailing colon no-op after the outer fi.",
+      "UserStory": "As a Directive consumer on Homebrew go-task 3.46.x, I want engine:_ts-build to exit 0 when the deposit is not buildable, so that task deft:* verbs do not fail as if the deposit were broken.",
+      "ImplementationPlan": "1. Edit the tasks/engine.yml _ts-build script so a colon no-op follows the outer fi, with a one-line comment that cites go-task before 3.52 and #3381. 2. Keep the consumer-deposit path from running pnpm or engine-pm-run build, keep the framework-source path building when stale and skipping when warm, then verify with the existing engine tests and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3381",
+      "Overview": "Authority is analysis+lock comment 5309667759, not the issue body. Do not change engine:invoke. Do not invert is-buildable-source. Do not raise a hard min go-task version. Do not hunt other last-if scripts.",
+      "Labels": "bug, agent-experience, tooling, area:cli"
+    },
+    "items": [
+      {
+        "title": "Trailing no-op after the outer fi",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given tasks/engine.yml _ts-build cmds, when the script body is read, a command follows the outer fi. A colon no-op is enough. The comment on that line cites go-task before 3.52.0 and #3381.",
+          "Traces": "FR-3381-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts#_ts-build ends with a trailing no-op after the outer if/fi (#3381)",
+          "recorded_at": "2026-08-16T22:43:00Z",
+          "recorded_by": "leaf-implementation/3381"
+        }
+      },
+      {
+        "title": "Deposit no-op and source build paths stay",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a consumer-deposit tree where is-buildable-source exits 1, when engine:_ts-build runs, it does not run pnpm or engine-pm-run build. Given a stale framework-source tree, it still builds. Given a warm dist, ts-build-fresh still skips. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3381-2"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3409",
+          "recorded_at": "2026-08-16T22:43:00Z",
+          "recorded_by": "leaf-implementation/3381"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "tooling",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3381",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3381: engine:_ts-build trailing no-op"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3381#issuecomment-5309667759",
+        "type": "x-xbrief/github-comment",
+        "title": "Analysis + implementation lock (authority)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/engine.yml",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/content-contracts"
+        ],
+        "expected_outputs": [
+          "trailing no-op on _ts-build",
+          "CHANGELOG #3381"
+        ],
+        "depends_on": [],
+        "conflict_group": "engine-ts-build",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3409,
+        "prBase": "master",
+        "mergeCommit": "fac6e2c6555fa072cd0cbff25bd155a20075f283",
+        "deliveryBranch": "master",
+        "deliveryCommit": "fac6e2c6555fa072cd0cbff25bd155a20075f283",
+        "verifiedAt": "2026-08-16T22:44:54Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "d536592e-c62e-40dd-bc3b-bbc4e2ac5ccd"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T22:44:54Z",
+      "completedSessionId": "d536592e-c62e-40dd-bc3b-bbc4e2ac5ccd",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/content-contracts"
+      ],
+      "none_stated": false,
+      "source_rung": "stated",
+      "derived_reason": "swarm verify_commands minus recursive task check"
+    },
+    "updated": "2026-08-16T22:44:54Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3382-appsec-2-high-post-3354-uat-shell-residuals-cmakescriptgalle.xbrief.json
+++ b/xbrief/completed/2026-08-16-3382-appsec-2-high-post-3354-uat-shell-residuals-cmakescriptgalle.xbrief.json
@@ -1,0 +1,148 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3382",
+    "updated": "2026-08-16T21:08:17Z"
+  },
+  "plan": {
+    "id": "3382-uat-shell-residuals",
+    "title": "AppSec: 2 HIGH — post-#3354 UAT Shell residuals (cmake/script/gallery-dl/VCS/editors plant authz + kill-switch)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Post-#3354 UAT Shell still classifies residual write-capable binaries as empty or unclassifiable and allows write-shaped commands. Those residuals use dest forms that generic -o / --output / --outfile harvest does not cover, and they can plant forged .deft/authz grants or a regular-file .deft-directive-disable kill-switch.",
+      "UserStory": "As a Directive operator under active UAT, I want residual dest-form Shell writers and editors to stay fail-closed, so that agents cannot plant authz grants or a kill-switch after the #3354 harvest.",
+      "ImplementationPlan": "1. Update the classify module file packages/core/src/authz/classify.ts so dest parsing covers cmake -E copy, script -q, gallery-dl -d, megadl --path, ncftpget, git apply --directory, VCS checkout writers, and editor plant, and fail-closed on unclassifiable write-shaped Shell under UAT. 2. Add authz classify tests plus decideHook fixtures that assert residual dests settings-deny versus curl -o / nc -o, then verify ordinary /tmp dests stay unclassifiable and add a CHANGELOG note.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3382",
+      "Overview": "## Summary\n\nAppSec scan on **`0c382e91`** (post-**#3354**) found two **HIGH** UAT Shell classification residuals.\n\nUnder active UAT, further write-capable binaries still classify empty / unclassifiable and **allow** write-shaped Shell. That path can plant a forged `.deft/authz` grant or a regular-file `.deft-directive-disable` kill-switch.\n\nThese residuals use dest forms that **#3354's generic `-o` / `--output` / `--outfile` harvest does not cover** (`cmake -E copy` positional dest, `script -q`, `gallery-dl -d`, `megadl --path`, `ncftpget`, `git apply --directory=…`, VCS checkout writers, and editor plant).\n\n**Repo / tip:** `deftai/directive` @ `0c382e91d27308ad374de86092c184e12e4228c9`  \n**Primary code:** `packages/core/src/authz/classify.ts`  \n**Attacker model:** Agent under **active UAT** with PreToolUse Shell hooks\n\n**Already denied after #3354 (do not re-report):** `nc` / `netcat` / `7zz` / `msgfmt` / `msgcat` / `lz4` / `lzop` / `unrar` / `rar` / `aunpack` / `atool` / `ftpget` / `tftp` / `sqlite3` / `crane` / `objcopy` plus dest-flag `-o` / `--output` / `--outfile` on unknown write-shaped bins. Contrast: `curl -o` / `nc -o` remain settings-denied.\n",
+      "Labels": "bug, security, tooling, agent-safety"
+    },
+    "items": [
+      {
+        "title": "UAT residual dest forms deny authz and kill-switch writes",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given active UAT, when listed residual bins (cmake -E copy, script -q, gallery-dl -d, megadl --path, ncftpget, git apply --directory, svn export / fossil open peers, ed / nvim / nano) write into .deft/authz or plant .deft-directive-disable / .no-deft-directive, they classify as settings deny. Dest parsing covers those positional and flag dest forms. Unclassifiable write-shaped Shell under UAT is fail-closed, not silent allow.",
+          "Traces": "FR-3382-1"
+        },
+        "x-directive/evidence": {
+          "kind": "uat",
+          "pointer": "packages/core/src/authz/incident-regression.test.ts#UAT residual dest-form writers fail-closed (#3382)",
+          "recorded_at": "2026-08-16T21:00:00Z",
+          "recorded_by": "leaf-implementation"
+        }
+      },
+      {
+        "title": "Regressions versus already-denied peers and no false deny",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the residual dest-form fix, when Vitest runs authz classify / decideHook regressions, curl -o and nc -o remain settings-denied and ordinary non-authz dests such as /tmp stay unclassifiable or allowed outside UAT write paths.",
+          "Traces": "FR-3382-2"
+        },
+        "x-directive/evidence": {
+          "kind": "uat",
+          "pointer": "pnpm exec vitest run packages/core/src/authz",
+          "recorded_at": "2026-08-16T21:00:00Z",
+          "recorded_by": "leaf-implementation"
+        }
+      },
+      {
+        "title": "CHANGELOG Unreleased security note",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the security fix lands, when CHANGELOG [Unreleased] is read, it has a brief security note for #3382 with no exploit cookbook.",
+          "Traces": "FR-3382-3"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3400",
+          "recorded_at": "2026-08-16T21:00:00Z",
+          "recorded_by": "leaf-implementation"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "security",
+      "tooling",
+      "agent-safety"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3382",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3382: AppSec: 2 HIGH — post-#3354 UAT Shell residuals (cmake/script/gallery-dl/VCS/editors plant authz + kill-switch)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/authz",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/authz"
+        ],
+        "expected_outputs": [
+          "UAT residual dest forms settings-deny",
+          "CHANGELOG #3382"
+        ],
+        "depends_on": [],
+        "conflict_group": "authz-uat-shell",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": "deftai/directive",
+        "implementationCommit": null,
+        "prNumber": 3400,
+        "prBase": "master",
+        "mergeCommit": "27f6937dc236303e144594e53877a14ddeca29cb",
+        "deliveryBranch": "master",
+        "deliveryCommit": "27f6937dc236303e144594e53877a14ddeca29cb",
+        "verifiedAt": "2026-08-16T21:08:17Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "48a947af-5506-4885-840b-24714c2394f6"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T21:08:17Z",
+      "completedSessionId": "48a947af-5506-4885-840b-24714c2394f6",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed ingest clauses into three independently testable items for swarm readiness",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Under active UAT, listed residual dest-form binaries that write into .deft/authz or plant .deft-directive-disable / .no-deft-directive classify as settings deny",
+          "artifact_path": "packages/core/src/authz/classify.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Regression tests cover residual bins versus already-denied peers (curl -o / nc -o) and do not false-deny ordinary non-authz dests such as /tmp",
+          "artifact_path": null,
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "CHANGELOG [Unreleased] security note contains \"#3382\" with no exploit cookbook",
+          "artifact_path": "CHANGELOG.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T21:08:17Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3383-completed-xbriefs-are-record-not-next-contract.xbrief.json
+++ b/xbrief/completed/2026-08-16-3383-completed-xbriefs-are-record-not-next-contract.xbrief.json
@@ -1,0 +1,151 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF from #3383 synthesis current-shape comment 5309896677",
+    "updated": "2026-08-16T23:59:15Z"
+  },
+  "plan": {
+    "id": "3383-completed-record-not-next",
+    "title": "Completed xBRIEFs are record, not the next-build contract; halt on chat-vs-active only",
+    "status": "completed",
+    "narratives": {
+      "Description": "One thin guidance story from the #3383 synthesis. Demote completed xBRIEFs to historical record. Before code, name the active story. Halt and ask only when the live human turn conflicts with a specific MUST in the active story.",
+      "UserStory": "As a Directive operator, I want completed stories treated as what was built, not what to build next, so that a later completed brief cannot silently override my live instruction.",
+      "ImplementationPlan": "1. Add a demotion bullet under main.md ## vBRIEF Persistence: completed files have full standing as record of what is and zero authority over what to build next. 2. In content/skills/deft-directive-build/SKILL.md add declare-the-contract next to probe-then-fill and halt-and-ask in Error Recovery, then verify with content tests and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3383",
+      "Overview": "Authority is synthesis comment 5309896677 (final current shape). Operator add 3383 is disposition. Do not implement the issue body. No outranks language. No Agent Trap Defenses home. No pairwise completed/ scan. No LLM detector. Do not promise next-session cannot re-learn B. Do not file follow-ups in this PR. Operator equals human interactive chat; headless/swarm is halt report only. Product override never overrides gates (#3164).",
+      "Labels": "guidance"
+    },
+    "items": [
+      {
+        "title": "Demotion bullet in vBRIEF Persistence",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given main.md ## vBRIEF Persistence, when an agent reads it, completed xBRIEFs are evidence of what was built with zero authority over what to build next. The current contract is the active xBRIEF plus the human operator live instruction. Agent Trap Defenses does not gain a live-message-beats-contract bullet.",
+          "Traces": "FR-3383-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/skills/main_guidance.test.ts persistence_demotes_completed_xbriefs_to_record + persistence_forbids_completed_as_next_contract + agent_trap_defenses_has_no_live_message_beats_contract_bullet; shipped main.md ## vBRIEF Persistence; PR #3412 merge 386db19ae2f15d0cbb81e369ab7bad199057b81e",
+          "recorded_at": "2026-08-16T23:58:30Z",
+          "recorded_by": "swarm/3382-through-merge/3383-completed-record-not-next"
+        }
+      },
+      {
+        "title": "Declare the contract before writing code",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given deft-directive-build next to probe-then-fill, when an operator instruction would cause code writes, the agent names the active xBRIEF and quotes what it says about that behavior before writing. If there is no active story, there is nothing to name and the agent does not treat a completed file as the contract.",
+          "Traces": "FR-3383-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/skills/skills.test.ts deft_directive_build_declares_active_contract_before_code; shipped content/skills/deft-directive-build/SKILL.md ## Declare the contract (#3383); PR #3412 merge 386db19ae2f15d0cbb81e369ab7bad199057b81e",
+          "recorded_at": "2026-08-16T23:58:30Z",
+          "recorded_by": "swarm/3382-through-merge/3383-completed-record-not-next"
+        }
+      },
+      {
+        "title": "Halt-and-ask on chat vs active only",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given Error Recovery, when implementing the active story would break a specific current-turn instruction, or implementing the turn would break a specific MUST or forbidden in the active story, the agent halts, quotes both sides, and asks which is controlling. Also consider X against a silent story is not a conflict. Operator means human interactive chat; headless or swarm envelopes get a halt report only. An operator turn can change product behavior, never gates. Standing change uses a proposed xBRIEF or decision:write; a this-session-only exception stays in the session record. Guidance does not claim the next session cannot re-learn B. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3383-3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/skills/skills.test.ts deft_directive_build_halt_and_ask_active_only; CHANGELOG [Unreleased] #3383; CI merge-gate task check:merge success on bbb47b5fb62e; PR #3412 merge 386db19ae2f15d0cbb81e369ab7bad199057b81e",
+          "recorded_at": "2026-08-16T23:58:30Z",
+          "recorded_by": "swarm/3382-through-merge/3383-completed-record-not-next"
+        }
+      }
+    ],
+    "tags": [
+      "guidance"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3383",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3383: completed xBRIEF vs live operator intent"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3383#issuecomment-5309896677",
+        "type": "x-xbrief/github-comment",
+        "title": "Synthesis — current shape (authority)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "main.md",
+          "content/skills/deft-directive-build/SKILL.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/content-contracts"
+        ],
+        "expected_outputs": [
+          "demotion bullet",
+          "declare-the-contract",
+          "halt-and-ask on active only",
+          "CHANGELOG #3383"
+        ],
+        "depends_on": [],
+        "conflict_group": "guidance-completed-record",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3412,
+        "prBase": null,
+        "mergeCommit": "386db19ae2f15d0cbb81e369ab7bad199057b81e",
+        "deliveryBranch": "master",
+        "deliveryCommit": "386db19ae2f15d0cbb81e369ab7bad199057b81e",
+        "verifiedAt": "2026-08-16T23:59:15Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T23:59:15Z",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed synthesis 5309896677 into three items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Completed xBRIEFs are record of what is, with \"zero authority over\" \"what to build next\"",
+          "artifact_path": "main.md",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Before code, \"name the active xBRIEF\" and \"quote what it says\"",
+          "artifact_path": "content/skills/deft-directive-build/SKILL.md",
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "Halt only on a specific chat-vs-active conflict; \"Neither side wins by rank\"; swarm is \"halt report only\"",
+          "artifact_path": "content/skills/deft-directive-build/SKILL.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T23:59:15Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3384-scoperecord-approved-scope-must-use-the-3110-human-presence.xbrief.json
+++ b/xbrief/completed/2026-08-16-3384-scoperecord-approved-scope-must-use-the-3110-human-presence.xbrief.json
@@ -1,0 +1,160 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3384",
+    "updated": "2026-08-16T23:11:50Z"
+  },
+  "plan": {
+    "id": "3384-human-presence-mint",
+    "title": "scope:record-approved-scope must use the #3110 human-presence gate; --actor is display only",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 1 of #3376 makes scope:record-approved-scope a real human-origin mint. The existing #3110 refuseNonInteractiveMint gate in packages/cli/src/authz.ts must be extracted into a shared module and called from both authz and this command. --actor is display only and never authorization.",
+      "UserStory": "As a Directive operator, I want scope:record-approved-scope to refuse agent and CI shells the same way authz mint does, so that approved-scope records cannot be stamped without a real TTY plus --confirm and typed phrase mint.",
+      "ImplementationPlan": "1. Extract refuseNonInteractiveMint, AUTHZ_AGENT_SHELL_ENV_MARKERS, controlling-terminal, --confirm, and typed phrase mint from the packages/cli/src/authz.ts module file into a shared module; call it from authz and from packages/cli/src/scope-record-approved-scope.ts. 2. Stop writing xbriefBodyDigest on new records in packages/core/src/scope-provenance/digest.ts, keep verify off grants, add CLI refuse-matrix tests plus docs in content/docs/scope-provenance.md, then verify with vitest and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3384",
+      "Overview": "Implement from #3376 current-shape R7 plus pass-4 F4/F5 (comment 5309237780) and the #3384 issue comment. Do not implement Wave 2 intent extraction. Do not touch packages/core/src/authz (live #3382).",
+      "Labels": "bug, enhancement, security, determinism, agent-experience, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Shared #3110 human-presence gate",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the #3110 gate logic, when authz and scope:record-approved-scope mint, both call one shared module (no copy-paste). Agent/CI env markers (AUTHZ_AGENT_SHELL_ENV_MARKERS), non-TTY, missing controlling terminal, missing --confirm, wrong typed phrase, and active UAT lease all refuse mint. --actor Flynn from an agent/CI shell cannot mint. --actor is never authorization.",
+          "Traces": "FR-3384-1"
+        },
+        "x-directive/evidence": {
+          "kind": "uat",
+          "pointer": "packages/cli/src/human-presence-mint.test.ts#refuses mint while UAT is active",
+          "recorded_at": "2026-08-16T23:07:48Z",
+          "recorded_by": "leaf-implementation/3384"
+        }
+      },
+      {
+        "title": "Mint writes display stamp only; verify ignores grants",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a successful human TTY mint, when the command finishes, it writes .deft/approved-scope/<plan-id>.json with a human-looking stamp and does not write an authz grant. New records do not write xbriefBodyDigest. verify:scope-provenance does not look up .deft/authz/grants.",
+          "Traces": "FR-3384-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/cli/src/scope-record-approved-scope.test.ts#no-xbriefBodyDigest",
+          "recorded_at": "2026-08-16T23:07:48Z",
+          "recorded_by": "leaf-implementation/3384"
+        }
+      },
+      {
+        "title": "Docs, tests, and CHANGELOG",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the Wave 1 change, when content/docs/scope-provenance.md is read, it says --actor is display-only, names the TTY/--confirm/mint gate, and states W1-era records carry no intentDigest and are legacy under Wave 2 (#3385). Existing authz grant tests and scope-record tests stay green. New tests cover the shared-gate refuse matrix. CHANGELOG [Unreleased] has a brief note. task check passes.",
+          "Traces": "FR-3384-3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/cli/src/human-presence-mint.test.ts + content/docs/scope-provenance.md + CHANGELOG.md [Unreleased] #3384 + CI TypeScript (build + lint + test) success on 2f27b270",
+          "recorded_at": "2026-08-16T23:07:48Z",
+          "recorded_by": "leaf-implementation/3384"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "enhancement",
+      "security",
+      "determinism",
+      "agent-experience",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3384",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3384: scope:record-approved-scope must use the #3110 human-presence gate; --actor is display only"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3376",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3376: parent epic (current-shape R7 + pass-4 F4/F5)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/authz.ts",
+          "packages/cli/src/scope-record-approved-scope.ts",
+          "packages/core/src/scope-provenance",
+          "content/docs/scope-provenance.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/cli/src/human-presence-mint.test.ts packages/cli/src/scope-record-approved-scope.test.ts packages/core/src/scope-provenance"
+        ],
+        "expected_outputs": [
+          "shared #3110 gate",
+          "no xbriefBodyDigest on new records",
+          "CHANGELOG #3384"
+        ],
+        "depends_on": [],
+        "conflict_group": "scope-provenance-mint",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3410,
+        "prBase": "master",
+        "mergeCommit": "eeefd9b5cb59dfbc4a751495730d364f6cbc75c4",
+        "deliveryBranch": "master",
+        "deliveryCommit": "eeefd9b5cb59dfbc4a751495730d364f6cbc75c4",
+        "verifiedAt": "2026-08-16T23:11:50Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "6d5f682c-bf0f-47a5-a6ea-82bf1a3755fa"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T23:11:50Z",
+      "completedSessionId": "6d5f682c-bf0f-47a5-a6ea-82bf1a3755fa",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3384 AC plus pass-4 F4/F5 into three items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Shared human-presence mint module exists at its stated path",
+          "artifact_path": "packages/cli/src/authz.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Scope-provenance digest module exists at its stated path",
+          "artifact_path": "packages/core/src/scope-provenance/digest.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "Scope-provenance docs exist at their stated path",
+          "artifact_path": "content/docs/scope-provenance.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T23:11:50Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3385-verifyscope-provenance-must-pin-extracted-intent-preimage-au.xbrief.json
+++ b/xbrief/completed/2026-08-16-3385-verifyscope-provenance-must-pin-extracted-intent-preimage-au.xbrief.json
@@ -1,0 +1,174 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3385",
+    "updated": "2026-08-17T19:18:10Z"
+  },
+  "plan": {
+    "id": "3385-intent-pin",
+    "title": "verify:scope-provenance must pin extracted intent (preimage authority, not denylist-strip)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 2 of #3376 pins extracted intent for the scope provenance gate. Mint writes a base-committed preimage at .deft/approved-scope/PLAN-ID.intent.json; intentDigest is a checksum. Verify re-extracts the live brief and compares to that preimage. This story waits until #3384 is merged.",
+      "UserStory": "As a Directive operator, I want the scope provenance gate to compare live brief intent to a base-committed preimage, so that same-PR rewrites and post-approval structure cannot silently expand approved scope.",
+      "ImplementationPlan": "1. After #3384 merges, extend the packages/core/src/scope-provenance module and packages/cli/src/scope-record-approved-scope.ts so one mint writes record plus preimage plus both digests. 2. Add verify compare tests for R1-R6 as amended by pass-4 F1-F4, then verify with vitest and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3385",
+      "Overview": "Implement from #3376 current-shape R1-R6 plus pass-4 F1-F4 (comment 5309237780 wins over the issue body). Do not start until #3384 is merged. Do not invent a second mint verb.",
+      "Labels": "enhancement, design, security, determinism, agent-experience, area:cli, area:vbrief, status:child"
+    },
+    "items": [
+      {
+        "title": "Extraction spec and preimage write (R1 + F1)",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given Wave 2 mint, when scope:record-approved-scope runs after #3384, it extracts the R1 allowlist plus unknown non-machine keys into .deft/approved-scope/<plan-id>.intent.json. Known-machine keys are not hash inputs. plan.tags is machine; plan.edges is extracted. Verify fails unclassified key only for unknown keys absent from the base preimage. Growing the known-machine list does not change existing digests and requires a same-PR writer test.",
+          "Traces": "FR-3385-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "pnpm exec vitest run packages/core/src/scope-provenance",
+          "recorded_at": "2026-08-17T19:16:32Z",
+          "recorded_by": "swarm-3385-intent-pin"
+        }
+      },
+      {
+        "title": "Preimage authority, first activation, refs (R2-R5 + F2/F3)",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a minted record and preimage, when verify runs, it reads both via git show base and never working-tree copies. intentDigest is a checksum of the preimage. Same-PR rewrite fails. Duplicate keys require a real tokenizer (F3). First activation with nonempty scope requires a base-committed pin. planRef stores parent plan.id. References and Decisions follow R5; closed ref-type set reuses packages/core/src/intake/reconcile-issues.ts (F2).",
+          "Traces": "FR-3385-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "pnpm exec vitest run packages/core/src/scope-provenance",
+          "recorded_at": "2026-08-17T19:16:32Z",
+          "recorded_by": "swarm-3385-intent-pin"
+        }
+      },
+      {
+        "title": "Migration, docs, and check (R6 + F4 remainder)",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given legacy records with no intentDigest, when verify runs, they authorize paths only. No silent backfill. Intent edits against legacy records warn then fail with gated remint. Old xbriefBodyDigest is never read as authority. Docs separate product intent, approved derivation, and implementation choice. Mint output tells the operator to read the preimage. task check passes.",
+          "Traces": "FR-3385-3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "task check",
+          "recorded_at": "2026-08-17T19:16:32Z",
+          "recorded_by": "swarm-3385-intent-pin"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "design",
+      "security",
+      "determinism",
+      "agent-experience",
+      "area:cli",
+      "area:vbrief",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3385",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3385: verify:scope-provenance must pin extracted intent (preimage authority, not denylist-strip)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3384",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3384: Wave 1 blocker"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3376",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3376: parent epic (current-shape R1-R6 + pass-4 F1-F4)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/core/src/scope-provenance",
+          "packages/cli/src/scope-record-approved-scope.ts",
+          "content/docs/scope-provenance.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/scope-provenance"
+        ],
+        "expected_outputs": [
+          "intent preimage pin",
+          "CHANGELOG #3385"
+        ],
+        "depends_on": [
+          "3384-human-presence-mint"
+        ],
+        "conflict_group": "scope-provenance-mint",
+        "size": "large",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3414,
+        "prBase": null,
+        "mergeCommit": "05de671928edca797ccda3ae0a1b022ab9f475c6",
+        "deliveryBranch": "master",
+        "deliveryCommit": "05de671928edca797ccda3ae0a1b022ab9f475c6",
+        "verifiedAt": "2026-08-17T19:18:10Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "e430ea8c-2448-4b61-b0d6-e689bb734b97"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T19:18:10Z",
+      "completedSessionId": "e430ea8c-2448-4b61-b0d6-e689bb734b97",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/scope-provenance"
+      ],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "collapsed R1-R6 plus pass-4 F1-F4 into three items; blocked by 3384",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Mint writes extraction-spec preimage; unknown keys extract; unclassified key only for post-approval unknowns",
+          "artifact_path": "packages/core/src/scope-provenance/mint-artifacts.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Verify uses git show base preimage authority; first activation and R4/R5 hold",
+          "artifact_path": null,
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "Legacy records path-only; docs and task check pass",
+          "artifact_path": "content/docs/scope-provenance.md",
+          "ambiguous": false
+        },
+        {
+          "id": 4,
+          "text": "The mint helper exists at its stated path",
+          "artifact_path": "packages/core/src/scope-provenance/mint-artifacts.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T19:18:10Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3386-slicerecord-existing-slicelist-print-vbriefevalslicesjsonl-b.xbrief.json
+++ b/xbrief/completed/2026-08-16-3386-slicerecord-existing-slicelist-print-vbriefevalslicesjsonl-b.xbrief.json
@@ -1,0 +1,128 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3386",
+    "updated": "2026-08-16T21:50:34Z"
+  },
+  "plan": {
+    "id": "3386-slice-path-print",
+    "title": "slice:record-existing / slice:list print vbrief/.eval/slices.jsonl but write xbrief/.triage-cache/slices.jsonl",
+    "status": "completed",
+    "narratives": {
+      "Description": "slice:record-existing and slice:list print the leftover vbrief/.eval/slices.jsonl path. Writes go through resolveTriageCachePath to xbrief/.triage-cache/slices.jsonl. Only the stdout and DEFAULT_SLICES_LOG_REL_PATH are stale.",
+      "UserStory": "As a Directive operator, I want slice:record-existing and slice:list to print the path they actually read or wrote, so that I can find the record after an umbrella slice.",
+      "ImplementationPlan": "1. Change packages/core/src/slice/existing.ts and constants.ts so printed paths come from resolveTriageCachePath, not the stale DEFAULT_SLICES_LOG_REL_PATH string. 2. Update help, Taskfile, and skill prose that still cite vbrief/.eval/slices.jsonl, then verify with vitest on packages/core/src/slice and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3386",
+      "Overview": "AFK print-path fix. Do not move the file back under .eval or change the #1703 triage-cache layout.",
+      "Labels": "bug, agent-experience, area:cli, area:vbrief"
+    },
+    "items": [
+      {
+        "title": "Stdout names the real slices.jsonl path",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given an xbrief-layout repo, when slice:record-existing or slice:list runs, stdout names the path actually read or written (xbrief/.triage-cache/slices.jsonl or vbrief/.triage-cache/slices.jsonl). DEFAULT_SLICES_LOG_REL_PATH and callers do not claim vbrief/.eval/slices.jsonl as the live path.",
+          "Traces": "FR-3386-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "pnpm exec vitest run packages/core/src/slice",
+          "recorded_at": "2026-08-16T21:47:35Z",
+          "recorded_by": "vitest"
+        }
+      },
+      {
+        "title": "Prose and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the print-path fix, when help, Taskfile, and skill prose for this verb are read, they point at .triage-cache/ not vbrief/.eval/. Existing existing.test.ts path assertions stay green. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3386-2"
+        },
+        "x-directive/evidence": {
+          "kind": "review",
+          "pointer": "https://github.com/deftai/directive/pull/3402",
+          "recorded_at": "2026-08-16T21:47:35Z",
+          "recorded_by": "greptile"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "area:cli",
+      "area:vbrief"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3386",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3386: slice:record-existing / slice:list print stale vbrief/.eval path"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/slice",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/slice"
+        ],
+        "expected_outputs": [
+          "layout-aware slices.jsonl print",
+          "CHANGELOG #3386"
+        ],
+        "depends_on": [],
+        "conflict_group": "slice-log-path",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3402,
+        "prBase": "master",
+        "mergeCommit": "4155bb750d896f3b9b7f948397c65fc8a439a97c",
+        "deliveryBranch": "master",
+        "deliveryCommit": "4155bb750d896f3b9b7f948397c65fc8a439a97c",
+        "verifiedAt": "2026-08-16T21:50:34Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "48a947af-5506-4885-840b-24714c2394f6"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T21:50:34Z",
+      "completedSessionId": "48a947af-5506-4885-840b-24714c2394f6",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3386 AC into two items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "slice:record-existing and slice:list print the layout-aware triage-cache path they actually use; shipped implementation exists",
+          "artifact_path": "packages/core/src/slice/existing.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Help and skill prose no longer cite vbrief/.eval/slices.jsonl; task check passes",
+          "artifact_path": null,
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T21:50:34Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3387-bugscopecheck-unconditional-acceptance-re-execution-at-scope.xbrief.json
+++ b/xbrief/completed/2026-08-16-3387-bugscopecheck-unconditional-acceptance-re-execution-at-scope.xbrief.json
@@ -1,0 +1,128 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3387",
+    "updated": "2026-08-17T20:43:21Z"
+  },
+  "plan": {
+    "id": "3387-bank-aware-complete",
+    "title": "scope:complete acceptance walk must consume the #3285 bank instead of re-executing every command",
+    "status": "completed",
+    "narratives": {
+      "Description": "The #3357 completion walk re-executes every acceptance command with no reuse of verify-ac or the #3285 ac-pass bank. That doubled suites after #3357 and raised benchmark turns and cost with no outcome movement. Keep the fail-closed guarantee. Make the walk bank-aware.",
+      "UserStory": "As a Directive operator, I want scope:complete to accept a fresh green AC bank when product files have not changed, so that acceptance suites do not run twice on the happy path.",
+      "ImplementationPlan": "1. Update the packages/core/src/scope/acceptance-evidence.ts module so evaluateScopeCompleteAcceptanceWalk consults the #3285 bank and product-state hash before calling evaluateVerifyAcFromPlan. 2. Wire same-session from_cache for verify-ac during check composition, add served_from telemetry, and verify with a trial-shaped fixture plus task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3387",
+      "Overview": "Thin #3265 fix. Do not weaken #3357 refusal on empty or failing acceptance. Do not touch packages/core/src/scope-provenance (live #3384).",
+      "Labels": "bug, agent-experience"
+    },
+    "items": [
+      {
+        "title": "Bank-aware completion walk",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a banked green AC for this brief and a matching product-state hash, when scope:complete runs, it accepts the bank as the walk result and does not re-execute acceptance commands. Any mismatch, missing bank, or stale hash runs the full walk. Empty or failing acceptance still refuses as today (#3357).",
+          "Traces": "FR-3387-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/session/product-state-hash.test.ts",
+          "recorded_at": "2026-08-17T20:36:00Z",
+          "recorded_by": "vitest"
+        }
+      },
+      {
+        "title": "Check cache, telemetry, and fixture",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given an unchanged plan and product in one session, when check runs verify:ac after a green result, from_cache can serve it. Acceptance events record served_from bank, cache, or executed. A trial-shaped fixture (activate, implement, verify:ac green, scope:complete, check) executes acceptance commands once. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3387-2"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3404",
+          "recorded_at": "2026-08-17T20:36:00Z",
+          "recorded_by": "swarm-worker"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3387",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3387: bank-aware scope:complete acceptance walk"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/scope",
+          "packages/core/src/session",
+          "packages/core/src/product-first-done-gate",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/scope packages/core/src/session packages/core/src/product-first-done-gate"
+        ],
+        "expected_outputs": [
+          "bank-aware completion walk",
+          "CHANGELOG #3387"
+        ],
+        "depends_on": [],
+        "conflict_group": "scope-complete-ac",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3404,
+        "prBase": null,
+        "mergeCommit": "4656b99b0acc866e3a0409d967a6a84dec7424e1",
+        "deliveryBranch": "master",
+        "deliveryCommit": "4656b99b0acc866e3a0409d967a6a84dec7424e1",
+        "verifiedAt": "2026-08-17T20:43:21Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "cdc3fd71-52f3-4cd4-81b4-5036603694e3"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T20:43:21Z",
+      "completedSessionId": "cdc3fd71-52f3-4cd4-81b4-5036603694e3",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3387 fix sketch into two items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Bank-aware complete walk exists at its stated path",
+          "artifact_path": "packages/core/src/scope/acceptance-evidence.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Same-session verify:ac cache exists at its stated path",
+          "artifact_path": "packages/core/src/session/verify-ac-session-cache.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T20:43:21Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3388-shared-branch-sync-detector-typed-basebranch-evidence-based.xbrief.json
+++ b/xbrief/completed/2026-08-16-3388-shared-branch-sync-detector-typed-basebranch-evidence-based.xbrief.json
@@ -1,0 +1,139 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3388",
+    "updated": "2026-08-16T23:28:12Z"
+  },
+  "plan": {
+    "id": "3388-branch-sync-detector",
+    "title": "Shared branch-sync detector: typed baseBranch + evidence-based sync predicate",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 1 of #3377. Shared branch-sync detector for measure/warn, scm:sync-default, and deft-core-guard. Dest is deliveryBranch. Source is new typed plan.policy.baseBranch. Sync predicate is evidence-based: base is dest and head is already on origin/baseBranch after fetch.",
+      "UserStory": "As a Directive operator, I want a single detector that says whether a PR is a branch sync, so that core-guard can exempt union syncs without guessing branch names.",
+      "ImplementationPlan": "1. Add typed plan.policy.baseBranch to the policy module file and a public detector API that fetches then tests dest plus ancestor-on-integration. 2. Wire deft-core-guard to that API with a loud exemption message, keep feature mix fails, then verify with tests and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3388",
+      "Overview": "Implement from #3377 current-shape pass-2 and locked answers. Do not invent integrationBranch. Do not infer origin/develop as identity. Do not ship file-count warn or scm:sync-default.",
+      "Labels": "enhancement, determinism, agent-experience, scm, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Typed baseBranch and public detector",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given plan.policy.baseBranch, when task policy:show --field=baseBranch runs, the typed string field works. Unset baseBranch equals dest and the detector reports not a sync. origin/develop is never load-bearing identity. Predicate: base is dest AND head is reachable from origin/<baseBranch> after fetch. Name-only and label-only exemptions are not implemented.",
+          "Traces": "FR-3388-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/policy/base-branch.test.ts",
+          "recorded_at": "2026-08-16T23:27:30Z",
+          "recorded_by": "leaf-implementation/3388-branch-sync-detector"
+        }
+      },
+      {
+        "title": "Loud core-guard exemption and API ownership",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a matching sync PR, when core-guard runs, it exits 0 and prints that this is a sync whose commits were already guard-checked on the integration branch. A feature PR that mixes .deft/core/** with app still fails. The public detector API is the only source of is-this-a-sync for later children. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3388-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/policy/branch-sync.test.ts",
+          "recorded_at": "2026-08-16T23:27:30Z",
+          "recorded_by": "leaf-implementation/3388-branch-sync-detector"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "scm",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3388",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3388: Shared branch-sync detector"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3377",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3377: parent epic (current-shape pass-2)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/policy",
+          "packages/core/src/init-deposit",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/policy packages/core/src/init-deposit"
+        ],
+        "expected_outputs": [
+          "public branch-sync detector",
+          "loud core-guard sync exemption",
+          "CHANGELOG #3388"
+        ],
+        "depends_on": [],
+        "conflict_group": "branch-sync",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": null,
+        "prBase": null,
+        "mergeCommit": "93e7c63e521e7005f1e73d90dfefed4cffdb8bd2",
+        "deliveryBranch": "master",
+        "deliveryCommit": "93e7c63e521e7005f1e73d90dfefed4cffdb8bd2",
+        "verifiedAt": "2026-08-16T23:28:12Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "49bc17b1-448a-4b07-87a4-b23328b9d753"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T23:28:12Z",
+      "completedSessionId": "49bc17b1-448a-4b07-87a4-b23328b9d753",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/policy packages/core/src/init-deposit"
+      ],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3388 AC into two items from current-shape R/Q locks; bound shipped artifacts for clause walk",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Typed \"plan.policy.baseBranch\" plus evidence-based sync detector; unset source is no-op",
+          "artifact_path": "packages/core/src/policy/base-branch.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Core-guard loudly exempts sync PRs via \"classifyMixedCoreAndAppForPr\" and still fails mixed feature PRs",
+          "artifact_path": "packages/core/src/init-deposit/hygiene.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T23:28:12Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3389-pr-monitor-must-escalate-on-sustained-ci-absent-required-ins.xbrief.json
+++ b/xbrief/completed/2026-08-16-3389-pr-monitor-must-escalate-on-sustained-ci-absent-required-ins.xbrief.json
@@ -1,0 +1,134 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3389",
+    "updated": "2026-08-16T21:45:02Z"
+  },
+  "plan": {
+    "id": "3389-absent-required-escalate",
+    "title": "pr-monitor must escalate on sustained ci_absent_required instead of polling to cap",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 4 of #3377, parallel. #3234 already classifies ci_absent_required. pr-monitor does not consume it and polls to CAP-REACHED. Escalate early when absence persists past a short grace window.",
+      "UserStory": "As a Directive operator, I want pr-monitor to exit when a required review context never appears, so that an oversized Greptile decline does not burn the minute cap.",
+      "ImplementationPlan": "1. Update the packages/core/src/pr-monitor module file so sustained ci_absent_required exits before the minute cap with a distinct message listing missing contexts. 2. Keep first-poll absence and pending runs waiting, add the Greptile decline-comment regression, then verify with tests and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3389",
+      "Overview": "Consume #3234; do not redefine it. Do not ship staged sync. Parallel to Waves 1-3.",
+      "Labels": "enhancement, determinism, agent-experience, scm, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Sustained absent-required early escalate",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given ci_absent_required that persists across consecutive polls past a short grace window, when pr-monitor runs, it exits before the minute cap with a distinct code or message listing missing contexts. First-poll or short-window absence does not escalate. Pending check-runs still wait.",
+          "Traces": "FR-3389-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/pr-monitor/monitor.test.ts#3389",
+          "recorded_at": "2026-08-16T21:35:00Z",
+          "recorded_by": "leaf-implementation/3389"
+        }
+      },
+      {
+        "title": "Regression and unchanged terminals",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given required context Greptile Review plus a decline comment and no check-run, when the monitor polls, it early-escalates and does not reach CAP-REACHED. CLEAN, PR merged, and config-error paths stay unchanged. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3389-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/pr-monitor/monitor.test.ts#3389-greptile-decline",
+          "recorded_at": "2026-08-16T21:35:00Z",
+          "recorded_by": "leaf-implementation/3389"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "scm",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3389",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3389: pr-monitor sustained ci_absent_required"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3377",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3377: parent epic"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/pr-monitor",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/pr-monitor",
+          "task check"
+        ],
+        "expected_outputs": [
+          "early escalate on sustained absent required",
+          "CHANGELOG #3389"
+        ],
+        "depends_on": [],
+        "conflict_group": "pr-monitor",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": "deftai/directive",
+        "implementationCommit": null,
+        "prNumber": 3401,
+        "prBase": "master",
+        "mergeCommit": "1e7e92d904a86d3ae906f300a1aeca5d5bc1ef2b",
+        "deliveryBranch": "master",
+        "deliveryCommit": "1e7e92d904a86d3ae906f300a1aeca5d5bc1ef2b",
+        "verifiedAt": "2026-08-16T21:45:02Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T21:45:02Z",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3389 AC into two items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Sustained ci_absent_required exits before cap; first-poll absence does not",
+          "artifact_path": "packages/core/src/pr-monitor",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Greptile decline plus no check-run early-escalates; CLEAN and merged paths unchanged",
+          "artifact_path": null,
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T21:45:02Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3390-warn-when-integration-to-delivery-file-count-exceeds-syncmax.xbrief.json
+++ b/xbrief/completed/2026-08-16-3390-warn-when-integration-to-delivery-file-count-exceeds-syncmax.xbrief.json
@@ -1,0 +1,122 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3390",
+    "updated": "2026-08-17T01:25:24Z"
+  },
+  "plan": {
+    "id": "3390-sync-max-files-warn",
+    "title": "Warn when integration-to-delivery file-count exceeds syncMaxFiles",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 2 of #3377. Measure file-count divergence between baseBranch and deliveryBranch and warn before reviewer file limits. Threshold is plan.policy.syncMaxFiles, default 400. Blocked by #3388.",
+      "UserStory": "As a Directive operator, I want a file-count warn before a default-branch sync crosses reviewer limits, so that I can sync while the PR is still reviewable.",
+      "ImplementationPlan": "1. After #3388 merges, add typed plan.policy.syncMaxFiles default 400 and a file-count warn that uses the shared detector. 2. Print count plus threshold provenance, honor --max-files, skip when the detector says no sync, then verify with tests and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3390",
+      "Overview": "Do not start until #3388 is merged. Do not open or split PRs. Do not probe Greptile or SLizard APIs.",
+      "Labels": "enhancement, determinism, agent-experience, scm, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "File-count warn with typed threshold",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given source and dest from the shared detector, when file count is git diff --name-only origin/dest...origin/source, a warn fires when count exceeds syncMaxFiles. Unset threshold is 400. Output includes count and provenance default vs policy. --max-files overrides one run without writing policy. No warn when the detector says no sync.",
+          "Traces": "FR-3390-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/policy/sync-max-files.test.ts",
+          "recorded_at": "2026-08-16T23:55:00.000Z",
+          "recorded_by": "leaf-implementation/3390"
+        }
+      },
+      {
+        "title": "Docs and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the warn lands, when docs are read, they say set 100 if SLizard is a required check. No vendor constants or API probing. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3390-2"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "b74e641c64eec73f4d63e43e414c949decc60157",
+          "recorded_at": "2026-08-16T23:55:00.000Z",
+          "recorded_by": "leaf-implementation/3390"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "scm",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3390",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3390: syncMaxFiles warn"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3388",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3388: Wave 1 blocker"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/policy",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/policy"
+        ],
+        "expected_outputs": [
+          "syncMaxFiles warn",
+          "CHANGELOG #3390"
+        ],
+        "depends_on": [
+          "3388-branch-sync-detector"
+        ],
+        "conflict_group": "branch-sync",
+        "size": "small",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3415,
+        "prBase": null,
+        "mergeCommit": "b74e641c64eec73f4d63e43e414c949decc60157",
+        "deliveryBranch": "master",
+        "deliveryCommit": "b74e641c64eec73f4d63e43e414c949decc60157",
+        "verifiedAt": "2026-08-17T01:25:24Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T01:25:24Z",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "issue #3390 AC is prose, not shell commands; blocked by 3388",
+      "clauses": []
+    },
+    "updated": "2026-08-17T01:25:24Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3391-scmsync-default-staged-default-branch-sync-as-new-prs-under.xbrief.json
+++ b/xbrief/completed/2026-08-16-3391-scmsync-default-staged-default-branch-sync-as-new-prs-under.xbrief.json
@@ -1,0 +1,144 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3391",
+    "updated": "2026-08-17T03:03:07Z"
+  },
+  "plan": {
+    "id": "3391-scm-sync-default",
+    "title": "scm:sync-default: staged default-branch sync as new PRs under syncMaxFiles",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 3 of #3377. scm:sync-default opens one sync PR when under the file-count limit, or staged new-PR legs at merge-commit cuts when over. Never retarget or reuse an oversized PR. Blocked by #3388 and #3390.",
+      "UserStory": "As a Directive operator, I want scm:sync-default to open reviewable new PRs under the file limit, so that a develop-to-default sync cannot deadlock on a Greptile size decline.",
+      "ImplementationPlan": "1. After #3388 and #3390 merge, add scm:sync-default in packages/cli and packages/core using the shared detector and plan.policy.syncMaxFiles. 2. Cut merge-commit legs as new branches and new PRs, document the new-PR-per-leg rule in content/docs or scm docs, then verify the policy suite and the merge-chokepoint hygiene gate.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3391",
+      "Overview": "Do not start until #3388 and #3390 are merged. Do not bypass rulesets. Do not implement pr-monitor.",
+      "Labels": "enhancement, determinism, agent-experience, scm, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Staged new-PR sync legs",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the shared detector and syncMaxFiles or --max-files, when over limit, scm:sync-default cuts at merge commits when possible so each leg file-count is at or under the threshold. Each leg is a new branch and new PR. No gh pr edit --base or close-reopen of the oversized PR. Under limit: one PR from source tip to dest. No-op when the detector says no sync.",
+          "Traces": "FR-3391-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/policy/sync-default.test.ts; PR #3416 merge a835231f3e3b9324fc66329a9238e31e5511ff0d",
+          "recorded_at": "2026-08-17T03:01:00Z",
+          "recorded_by": "leaf-implementation/3391"
+        }
+      },
+      {
+        "title": "Docs and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the verb lands, when docs are read, they say each leg must be new when the reviewer first sees it. Required checks are not disabled except via the Wave 1 core-guard exemption. The merge-chokepoint hygiene gate passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3391-2"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "content/scm/github.md + content/commands.md + CHANGELOG.md; PR #3416 merge a835231f3e3b9324fc66329a9238e31e5511ff0d",
+          "recorded_at": "2026-08-17T03:01:00Z",
+          "recorded_by": "leaf-implementation/3391"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "scm",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3391",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3391: scm:sync-default"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3388",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3388: Wave 1 blocker"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3390",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3390: Wave 2 blocker"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/core/src",
+          "tasks",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/policy/sync-default.test.ts"
+        ],
+        "expected_outputs": [
+          "scm:sync-default new-PR legs",
+          "CHANGELOG #3391"
+        ],
+        "depends_on": [
+          "3388-branch-sync-detector",
+          "3390-sync-max-files-warn"
+        ],
+        "conflict_group": "branch-sync",
+        "size": "large",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3416,
+        "prBase": null,
+        "mergeCommit": "a835231f3e3b9324fc66329a9238e31e5511ff0d",
+        "deliveryBranch": "master",
+        "deliveryCommit": "a835231f3e3b9324fc66329a9238e31e5511ff0d",
+        "verifiedAt": "2026-08-17T03:03:07Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "2bad7b48-75c9-41a7-9209-be9d54d1cc97"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T03:03:07Z",
+      "completedSessionId": "2bad7b48-75c9-41a7-9209-be9d54d1cc97",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3391 AC; blocked by 3388 and 3390; clauses are the AC (vitest policy suite already run locally)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Over-limit sync opens new-PR legs under syncMaxFiles; under-limit opens one PR. Shipped in 'new branch and a new PR' / 'gh pr edit --base'.",
+          "artifact_path": "packages/core/src/policy/sync-default.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Docs require a new PR per leg; each leg must be 'new when the reviewer first sees it'.",
+          "artifact_path": "content/scm/github.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T03:03:07Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3392-mutation-ledger-at-the-write-chokepoint-containedwrite-depos.xbrief.json
+++ b/xbrief/completed/2026-08-16-3392-mutation-ledger-at-the-write-chokepoint-containedwrite-depos.xbrief.json
@@ -1,0 +1,140 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3392",
+    "updated": "2026-08-17T02:11:06Z"
+  },
+  "plan": {
+    "id": "3392-mutation-ledger",
+    "title": "Mutation ledger at the write chokepoint (containedWrite / deposit remove)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 1 of #3378. Wrap write and remove so every deposit mutation is typed wrote, stripped, or deleted as a side effect of the operation. Unledgered mutation is impossible. The discarded writeAgentHookDeposit return is the existence proof. Same ledger feeds printf and structured refresh JSON.",
+      "UserStory": "As a Directive operator, I want deft update to record every deposit write and delete in one ledger, so that a tracked adapter removal cannot stay invisible or unstaged.",
+      "ImplementationPlan": "1. Wrap packages/core/src/fs/contained-write.ts and the deposit remove path so each op appends a typed ledger entry. 2. Consume that ledger in refresh.ts and agent-hooks.ts for Removed/wrote/stripped printf and structured JSON, without editing hygiene.ts (live #3388). Verify with tests and the framework-source check lane.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3392",
+      "Overview": "Implement from #3378 current-shape and ledger design comment 5309516574. Do not implement staging, allowlist, or Prettier. Do not edit hygiene.ts while #3388 is live.",
+      "Labels": "bug, enhancement, determinism, agent-experience, vendored-deposit, area:installer, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Chokepoint ledger on write and remove",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a write or remove through the deposit chokepoint, when the op finishes, a typed ledger entry wrote, stripped, or deleted is always appended. A mutator cannot discard mutations: ignored writeAgentHookDeposit return still ledgers.",
+          "Traces": "FR-3392-1"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3403 merged as 15bbbc90; tests packages/core/src/fs/contained-write.test.ts",
+          "recorded_at": "2026-08-17T01:56:35Z",
+          "recorded_by": "leaf-implementation"
+        }
+      },
+      {
+        "title": "Printf and JSON from the same ledger",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a refresh run, when the human summary and structured refresh JSON are produced, both come from the same ledger, not a post-hoc existsSync walk. Summary prints Removed plus wrote/stripped. Tests cover write, strip, delete, ignored-return still ledgers, and JSON/printf agreement. The framework-source check lane passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3392-2"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3403 merged as 15bbbc90; tests packages/core/src/init-deposit/refresh.test.ts",
+          "recorded_at": "2026-08-17T01:56:35Z",
+          "recorded_by": "leaf-implementation"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "vendored-deposit",
+      "area:installer",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3392",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3392: Mutation ledger at the write chokepoint"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3378",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3378: parent epic"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/fs",
+          "packages/core/src/init-deposit/refresh.ts",
+          "packages/core/src/init-deposit/agent-hooks.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/fs packages/core/src/init-deposit"
+        ],
+        "expected_outputs": [
+          "typed mutation ledger",
+          "Removed: in update summary",
+          "CHANGELOG #3392"
+        ],
+        "depends_on": [],
+        "conflict_group": "update-ledger",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3403,
+        "prBase": null,
+        "mergeCommit": "15bbbc90b5bfe97563d429097ebdeab2dc8e2e29",
+        "deliveryBranch": "master",
+        "deliveryCommit": "15bbbc90b5bfe97563d429097ebdeab2dc8e2e29",
+        "verifiedAt": "2026-08-17T02:11:06Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "88b53dea-47be-4694-9ec3-f7ff21113c94"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T02:11:06Z",
+      "completedSessionId": "88b53dea-47be-4694-9ec3-f7ff21113c94",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3392 AC into two items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Deposit write/remove always ledgers via \"containedRemove\" and \"recordActiveMutation\"; ignored writer return still ledgers",
+          "artifact_path": "packages/core/src/fs/contained-write.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Printf and refresh JSON come from the same ledger via \"snapshotMutationSummary\"",
+          "artifact_path": "packages/core/src/init-deposit/refresh.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T02:11:06Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3393-allowlist-two-exact-cursor-adapter-paths-in-installermanaged.xbrief.json
+++ b/xbrief/completed/2026-08-16-3393-allowlist-two-exact-cursor-adapter-paths-in-installermanaged.xbrief.json
@@ -1,0 +1,130 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3393",
+    "updated": "2026-08-17T00:43:36Z"
+  },
+  "plan": {
+    "id": "3393-adapter-allowlist",
+    "title": "Allowlist two exact Cursor adapter paths in installerManagedMatchers",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 2 of #3378. Add two exact adapter paths to installerManagedMatchers so the official hook-migration delete is framework, not app. Do not add a .cursor/hooks/ prefix. Held until live #3388 finishes because that worker is editing hygiene.ts.",
+      "UserStory": "As a Directive operator, I want the official Cursor adapter delete classified as installer-managed, so that a framework-only update PR can pass no-mixed-core-and-app.",
+      "ImplementationPlan": "1. After #3388 merges, add the two exact adapter paths to installerManagedMatchers in packages/core/src/init-deposit/hygiene.ts. 2. Keep assertInstallerAllowlistHonors1430 green, document pull_request_target lag in that file or content/docs, then verify with pnpm exec vitest run packages/core/src/init-deposit and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3393",
+      "Overview": "Epic says no product blocker, but file overlap with live #3388 hygiene.ts holds launch. Do not implement ledger or staging.",
+      "Labels": "bug, enhancement, determinism, agent-experience, vendored-deposit, area:installer, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Exact adapter paths are installer-managed",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given installerManagedMatchers, when the official adapter deletion is classified, .cursor/hooks/deft-cursor-hook-adapter.mjs and .test.mjs are installer-managed. A .cursor/hooks/ prefix is not added. Other files under .cursor/hooks/ stay app. assertInstallerAllowlistHonors1430 still passes.",
+          "Traces": "FR-3393-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "pnpm exec vitest run packages/core/src/init-deposit -- 355 passed; assertInstallerAllowlistHonors1430 green",
+          "recorded_at": "2026-08-16T23:39:00Z",
+          "recorded_by": "vitest"
+        }
+      },
+      {
+        "title": "Docs and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the allowlist change, when a framework-only PR includes the official adapter deletion, it is classified as core, not mixed app. Docs or a code comment name the pull_request_target / pinned-ref one-PR lag. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3393-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "verify:ac clause walk 2 verified; PR 3413 CI 24 passed / 0 failed; CHANGELOG [Unreleased] #3393",
+          "recorded_at": "2026-08-17T00:42:14Z",
+          "recorded_by": "vitest"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "vendored-deposit",
+      "area:installer",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3393",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3393: Allowlist two exact Cursor adapter paths"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/init-deposit/hygiene.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [],
+        "expected_outputs": [
+          "two exact adapter allowlist paths",
+          "CHANGELOG #3393"
+        ],
+        "depends_on": [
+          "3388-branch-sync-detector"
+        ],
+        "conflict_group": "update-ledger",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": null,
+        "prBase": null,
+        "mergeCommit": "0baf611fbd5c97f6703f7d8ec92ba3d34ee4caab",
+        "deliveryBranch": "master",
+        "deliveryCommit": "0baf611fbd5c97f6703f7d8ec92ba3d34ee4caab",
+        "verifiedAt": "2026-08-17T00:43:36Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T00:43:36Z",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3393 AC; launch waits on live 3388 hygiene overlap",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Two exact adapter paths are \"installer-managed\"; no hooks-dir prefix",
+          "artifact_path": "packages/core/src/init-deposit/hygiene.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Official adapter delete is core not mixed app; \"pull_request_target\" lag documented",
+          "artifact_path": "packages/core/src/init-deposit/hygiene.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T00:43:36Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3394-stage-ledger-intersection-installer-managed-include-deletion.xbrief.json
+++ b/xbrief/completed/2026-08-16-3394-stage-ledger-intersection-installer-managed-include-deletion.xbrief.json
@@ -1,0 +1,121 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3394",
+    "updated": "2026-08-17T17:05:19Z"
+  },
+  "plan": {
+    "id": "3394-ledger-staging",
+    "title": "Stage ledger intersection installer-managed (include deletions; print the rest)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 3 of #3378. Stage set is ledger intersection installer-managed, including tracked deletions. Ledger minus allowlist is printed and left unstaged. Blocked by #3392 and #3393.",
+      "UserStory": "As a Directive operator, I want deft update to stage only this-run installer-managed mutations including deletions, so that a hook migration cannot commit half-applied.",
+      "ImplementationPlan": "1. After #3392 and #3393 merge, change staging in packages/core/src/init-deposit/hygiene.ts to ledger intersection installer-managed including tracked deletions. 2. Filter untracked deletes, remove includeTaskfile, print unstaged remainder, then run the init-deposit test suite and the repo quality gate.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3394",
+      "Overview": "Do not start until Wave 1 and Wave 2 land. Do not git add -A. Do not auto-stage PROJECT-DEFINITION.",
+      "Labels": "bug, enhancement, determinism, agent-experience, vendored-deposit, area:installer, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Intersection staging including deletions",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a refresh run, when staging runs, the stage set is ledger intersection installer-managed, including this-run deletions of tracked files via git add -- path. Untracked ledger deletions are not passed to a single batch git add that can fail the whole list. Ledger paths that are not installer-managed are printed and left unstaged.",
+          "Traces": "FR-3394-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/hygiene.test.ts#ledger intersection staging (#3394)",
+          "recorded_at": "2026-08-17T16:58:00Z",
+          "recorded_by": "leaf-implementation/3394"
+        }
+      },
+      {
+        "title": "Stop exist-walk staging",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given an update that does not touch Taskfile, package.json, or .gitignore, when staging runs, pre-existing consumer edits to those files are not git added. includeTaskfile is removed. No git add -A. Refresh does not claim no post-stage stragglers when a this-run deletion was left unstaged. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3394-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/hygiene.test.ts#does not stage untouched dirty package.json or .gitignore",
+          "recorded_at": "2026-08-17T16:58:00Z",
+          "recorded_by": "leaf-implementation/3394"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "vendored-deposit",
+      "area:installer",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3394",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3394: Stage ledger intersection"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/init-deposit/hygiene.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit"
+        ],
+        "expected_outputs": [
+          "ledger intersection staging",
+          "CHANGELOG #3394"
+        ],
+        "depends_on": [
+          "3392-mutation-ledger",
+          "3393-adapter-allowlist"
+        ],
+        "conflict_group": "update-ledger",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3417,
+        "prBase": null,
+        "mergeCommit": "e7f82ce67cd783ebc368eebe6f60f4c8f378d589",
+        "deliveryBranch": "master",
+        "deliveryCommit": "e7f82ce67cd783ebc368eebe6f60f4c8f378d589",
+        "verifiedAt": "2026-08-17T17:05:19Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "25d72b19-ff3b-429f-9f6f-03478a8a3db8"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T17:05:19Z",
+      "completedSessionId": "25d72b19-ff3b-429f-9f6f-03478a8a3db8",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3394 AC; blocked by 3392 and 3393"
+    },
+    "updated": "2026-08-17T17:05:19Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3395-announce-prettier-sensitive-deposit-rewrites-do-not-run-cons.xbrief.json
+++ b/xbrief/completed/2026-08-16-3395-announce-prettier-sensitive-deposit-rewrites-do-not-run-cons.xbrief.json
@@ -1,0 +1,133 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3395",
+    "updated": "2026-08-17T03:35:54Z"
+  },
+  "plan": {
+    "id": "3395-prettier-announce",
+    "title": "Announce Prettier-sensitive deposit rewrites; do not run consumer formatter",
+    "status": "completed",
+    "narratives": {
+      "Description": "Wave 4 of #3378. Print rewritten consumer-owned paths from the mutation ledger and document task fmt before the upgrade PR. Do not run the consumer formatter from deft update. Blocked by #3392.",
+      "UserStory": "As a Directive operator, I want deft update to name rewritten schema files, so that I can run the repo formatter before the upgrade PR goes red.",
+      "ImplementationPlan": "1. After #3392 merges, print rewritten consumer-owned paths such as xbrief/schemas/* from the mutation ledger in packages/core/src/init-deposit/refresh.ts. 2. Document task fmt before the upgrade PR in content/docs, then verify with pnpm exec vitest run packages/core/src/init-deposit and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3395",
+      "Overview": "Parallel after Wave 1. Do not run consumer Prettier from update. Do not implement staging.",
+      "Labels": "enhancement, determinism, agent-experience, vendored-deposit, area:installer, area:cli, status:child"
+    },
+    "items": [
+      {
+        "title": "Announce rewritten consumer-owned paths",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a refresh that rewrites xbrief/schemas/*, when the update summary is printed, those paths appear from the ledger. deft update does not invoke the consumer Prettier or formatter.",
+          "Traces": "FR-3395-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/refresh.test.ts#3395",
+          "recorded_at": "2026-08-17T03:34:06Z",
+          "recorded_by": "leaf-implementation"
+        }
+      },
+      {
+        "title": "Docs and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the announce lands, when docs are read, they say to run task fmt or the repo formatter before opening the upgrade PR. Optional: deposit JSON matches Directive's own Prettier shape. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3395-2"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3419",
+          "recorded_at": "2026-08-17T03:34:06Z",
+          "recorded_by": "leaf-implementation"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "vendored-deposit",
+      "area:installer",
+      "area:cli",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3395",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3395: Announce Prettier-sensitive deposit rewrites"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/init-deposit/refresh.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit"
+        ],
+        "expected_outputs": [
+          "schema rewrite announce",
+          "CHANGELOG #3395"
+        ],
+        "depends_on": [
+          "3392-mutation-ledger"
+        ],
+        "conflict_group": "update-ledger",
+        "size": "small",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3419,
+        "prBase": null,
+        "mergeCommit": "eee89641c28f5069c5b99a24b98f9ee0c1ecbe4d",
+        "deliveryBranch": "master",
+        "deliveryCommit": "eee89641c28f5069c5b99a24b98f9ee0c1ecbe4d",
+        "verifiedAt": "2026-08-17T03:35:54Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "420f5624-4b08-4f08-95b0-dd82e21a9260"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T03:35:54Z",
+      "completedSessionId": "420f5624-4b08-4f08-95b0-dd82e21a9260",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3395 AC; blocked by 3392",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Rewritten consumer-owned paths include \"xbrief/schemas/\"",
+          "artifact_path": "packages/core/src/init-deposit/refresh.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Docs say to run \"task fmt\" before the upgrade PR",
+          "artifact_path": "content/UPGRADING.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T03:35:54Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3396-noop-acceptance-commands-denied-stated-requires-statement-span.xbrief.json
+++ b/xbrief/completed/2026-08-16-3396-noop-acceptance-commands-denied-stated-requires-statement-span.xbrief.json
@@ -1,0 +1,128 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3396",
+    "updated": "2026-08-17T22:27:18Z"
+  },
+  "plan": {
+    "id": "3396-noop-acceptance-denylist",
+    "title": "No-op acceptance commands refused at capture and stamp; stated requires statement provenance",
+    "status": "completed",
+    "narratives": {
+      "Description": "Capture and stamp admit unconditional no-ops such as true and let them be rung stated. Field sequence: real commands fail, restamp with true, walk passes, bank and check certify. Deny no-ops and keep stated only with a recorded statement span.",
+      "UserStory": "As a Directive operator, I want no-op acceptance commands refused at capture and stamp, so that a restamp cannot launder a failing walk into a stated green bank.",
+      "ImplementationPlan": "1. Extend the packages/core/src/literal-acceptance/safety.ts module so true, false, colon, bare exit, and assertion-free echo/printf/test-constant fail closed with one remediation. 2. Keep source_rung stated only when capture recorded a verbatim statement span, emit outcome rejected-noop, then verify with a field-sequence fixture and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3396",
+      "Overview": "Issue body is authority (no comments). Companion of #3397 (method-swap detector) and #3398 (clause quality). Do not edit packages/core/src/session (live #3387). Do not edit packages/core/src/intake/clause-derivation.ts (parallel #3398).",
+      "Labels": "bug, agent-safety"
+    },
+    "items": [
+      {
+        "title": "No-op denylist at capture and stamp",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given commands true, colon, false, bare exit, or assertion-free echo/printf/test with constant args, when capture or stamp runs, the verb fails closed and names that acceptance commands must be able to fail. A field-sequence fixture (real commands fail, then a no-op restamp) is refused. An acceptance event records outcome rejected-noop.",
+          "Traces": "FR-3396-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/literal-acceptance/noop-denylist.test.ts",
+          "recorded_at": "2026-08-17T22:25:00Z",
+          "recorded_by": "leaf-worker/3396"
+        }
+      },
+      {
+        "title": "Stated rung needs a statement span",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a stamp with no recorded verbatim span from the task statement, when the rung is written, the record is derived never stated. A restamp after a failing walk does not raise the rung without new provenance. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3396-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/literal-acceptance/noop-denylist.test.ts",
+          "recorded_at": "2026-08-17T22:25:00Z",
+          "recorded_by": "leaf-worker/3396"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-safety"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3396",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3396: no-op acceptance denylist"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/literal-acceptance",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/literal-acceptance"
+        ],
+        "expected_outputs": [
+          "no-op denylist",
+          "CHANGELOG #3396"
+        ],
+        "depends_on": [
+          "3387-bank-aware-complete"
+        ],
+        "conflict_group": "literal-acceptance-safety",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3435,
+        "prBase": null,
+        "mergeCommit": "9e1bf9364a39b9cd2f469fba1d937201e13f59f7",
+        "deliveryBranch": "master",
+        "deliveryCommit": "9e1bf9364a39b9cd2f469fba1d937201e13f59f7",
+        "verifiedAt": "2026-08-17T22:27:18Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "476b5aba-1fa1-4c04-a0be-3182c2044160"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T22:27:18Z",
+      "completedSessionId": "476b5aba-1fa1-4c04-a0be-3182c2044160",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3396 body AC into two items",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Denylisted no-op commands fail closed at capture and stamp with rejected-noop at its stated path",
+          "artifact_path": "packages/core/src/literal-acceptance/safety.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Stated rung requires a recorded statement span; restamp cannot raise rung without it",
+          "artifact_path": "packages/core/src/literal-acceptance/safety.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T22:27:18Z"
+  }
+}

--- a/xbrief/completed/2026-08-16-3397-failing-acceptance-walks-emit-verification-fingerprints.xbrief.json
+++ b/xbrief/completed/2026-08-16-3397-failing-acceptance-walks-emit-verification-fingerprints.xbrief.json
@@ -1,0 +1,128 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3397",
+    "updated": "2026-08-16T22:52:33Z"
+  },
+  "plan": {
+    "id": "3397-fail-side-verification-fingerprint",
+    "title": "Failing acceptance walks emit verification fingerprints so #3322 can flag method-swap",
+    "status": "completed",
+    "narratives": {
+      "Description": "The #3322 detector is blind because failing walks emit no verification event. Field stream shows fail then a later pass with a new fingerprint and nothing to diff. Emit fail-side fingerprints with the same shape as passes.",
+      "UserStory": "As a Directive operator, I want failing acceptance walks to record a verification fingerprint, so that a later pass with a different method is flagged instead of silently certified.",
+      "ImplementationPlan": "1. Change the evaluate module under packages/core/src/verify-ac so a failing walk emits a verification event with the same method_fingerprint shape as a pass. 2. Keep the existing flag.ts detector and lead the gate message with any flagged method change. Confirm with a field-sequence fixture plus the merge-chokepoint quality gate.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3397",
+      "Overview": "Issue body is authority (no comments). Companion of #3396. Do not edit packages/core/src/session or product-first-done-gate (live #3387). Do not refuse no-ops here. An honest same-command product fix must not flag.",
+      "Labels": "bug, agent-safety"
+    },
+    "items": [
+      {
+        "title": "Fail walks emit fingerprints",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a failing acceptance walk, when verify:ac records the result, a verification event is written with method_fingerprint from the command list plus cwd hash, same shape as a pass. The stream no longer has a first verification event that is only the later pass.",
+          "Traces": "FR-3397-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/verify-ac/evaluate.test.ts#emitVerifyAcAttempts (#3397 fail-side fingerprints)",
+          "recorded_at": "2026-08-16T22:50:00Z",
+          "recorded_by": "leaf-implementation/3397"
+        }
+      },
+      {
+        "title": "Method-swap flags; honest fix does not",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a fixture that fails on three commands then passes on a different method for the same check_id, when verify:ac runs, a flagged event appears and output names the method change first. A same-command product edit that then passes does not flag. task check passes. CHANGELOG [Unreleased] has a brief note.",
+          "Traces": "FR-3397-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/verify-ac/evaluate.test.ts#flags the field sequence",
+          "recorded_at": "2026-08-16T22:50:00Z",
+          "recorded_by": "leaf-implementation/3397"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-safety"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3397",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3397: fail-side verification fingerprints"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/verify-ac",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/verify-ac"
+        ],
+        "expected_outputs": [
+          "fail-side verification fingerprints",
+          "CHANGELOG #3397"
+        ],
+        "depends_on": [],
+        "conflict_group": "verify-ac-fingerprint",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3407,
+        "prBase": "master",
+        "mergeCommit": "ebc46be12fdab109ce6f401ccac89c74454d9afa",
+        "deliveryBranch": "master",
+        "deliveryCommit": "ebc46be12fdab109ce6f401ccac89c74454d9afa",
+        "verifiedAt": "2026-08-16T22:52:33Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-16T22:52:33Z",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [
+        {
+          "command": "pnpm exec vitest run packages/core/src/verify-ac"
+        }
+      ],
+      "none_stated": false,
+      "source_rung": "stated",
+      "derived_reason": "stated verify command from #3397 plus collapsed body AC clauses",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Fail-side verification fingerprints exist at its stated path",
+          "artifact_path": "packages/core/src/verify-ac/evaluate.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Method-swap flag helper exists at its stated path",
+          "artifact_path": "packages/core/src/verify-ac/flag.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-16T22:52:33Z"
+  }
+}

--- a/xbrief/completed/2026-08-17-3421-appsec-2-high-1-medium-post-3400-3410-uat-shell-residuals.xbrief.json
+++ b/xbrief/completed/2026-08-17-3421-appsec-2-high-1-medium-post-3400-3410-uat-shell-residuals.xbrief.json
@@ -1,0 +1,142 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3421",
+    "updated": "2026-08-17T20:12:36Z"
+  },
+  "plan": {
+    "id": "3421-uat-shell-residuals",
+    "title": "UAT Shell residuals after #3400/#3410: dest-form plant of authz, kill-switch, and approved-scope",
+    "status": "completed",
+    "narratives": {
+      "Description": "AppSec on eee89641 found two HIGH UAT Shell classification residuals and one MEDIUM mint-path asymmetry. Residual dest forms after #3400 still classify empty and allow write-shaped Shell that can plant .deft/authz or a kill-switch. Shell can also forge .deft/approved-scope while Write is denied.",
+      "UserStory": "As a Directive operator under active UAT, I want residual write-shaped Shell dests that plant authz, kill-switch, or approved-scope to classify as settings deny, so that #3400 and #3410 cannot be bypassed by dest forms the harvest missed.",
+      "ImplementationPlan": "1. Extend dest-form harvest in packages/core/src/authz/classify.ts for git clone/worktree/submodule, ex, dos2unix -n, aws s3 sync / s3api get-object, pijul, pg_dump -f/--file, convert/magick, fossil --workdir=, New-Item authz dests, and peers. 2. Under UAT fail-closed on unclassifiable write-shaped Shell; classify kill-switch and .deft/approved-scope pathish as settings deny. 3. Add vitest in packages/core/src/authz and CHANGELOG, then verify with the authz vitest suite and the merge-gate.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3421",
+      "Overview": "Do not re-do #3400 named peers (cmake/script/gallery-dl/git apply --directory/editors). Do not write an exploit cookbook. Prefer fail-closed on unclassifiable write-shaped Shell under UAT. Ordinary /tmp dests stay unclassifiable.",
+      "Labels": "bug, security, tooling, agent-safety"
+    },
+    "items": [
+      {
+        "title": "Residual dest forms cannot plant authz or kill-switch",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given active UAT, when residual bins write into .deft/authz/** or plant .deft-directive-disable / .no-deft-directive, classify returns settings deny, not unclassifiable allow. Dest parsing covers git clone/worktree/submodule, ex, dos2unix -n, aws s3 sync / s3api get-object, pijul, pg_dump -f/--file, convert/magick, fossil --workdir=, New-Item authz dests, and peers. Unclassifiable write-shaped Shell under UAT is fail-closed. cmake / curl -o / ed / nvim / fossil --workdir PATH / aws s3 cp stay settings-denied. /tmp dests outside those paths stay unclassifiable.",
+          "Traces": "FR-3421-1"
+        },
+        "x-directive/evidence": {
+          "kind": "uat",
+          "pointer": "packages/core/src/authz/classify.test.ts + incident-regression.test.ts dest-form matrix; PR https://github.com/deftai/directive/pull/3423 merge 06f426869ced3b088c7244e4a1e69d563ae74d5a",
+          "recorded_at": "2026-08-17T19:58:16Z",
+          "recorded_by": "leaf-implementation@3421"
+        }
+      },
+      {
+        "title": "Shell cannot forge approved-scope while Write is denied",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given active UAT, when Shell writes .deft/approved-scope/**, classify is settings deny matching Write. A forged Shell mint cannot satisfy provenance approval without the shared #3110 human-presence mint.",
+          "Traces": "FR-3421-2"
+        },
+        "x-directive/evidence": {
+          "kind": "uat",
+          "pointer": "packages/core/src/authz/incident-regression.test.ts approved-scope Shell/Write symmetry; PR https://github.com/deftai/directive/pull/3423 merge 06f426869ced3b088c7244e4a1e69d563ae74d5a",
+          "recorded_at": "2026-08-17T19:58:16Z",
+          "recorded_by": "leaf-implementation@3421"
+        }
+      },
+      {
+        "title": "Tests, changelog, and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the classify changes, when vitest runs packages/core/src/authz, residual bins vs already-denied peers are covered. CHANGELOG [Unreleased] has a brief security note with no exploit cookbook. The merge-gate check is green.",
+          "Traces": "FR-3421-3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "pnpm exec vitest run packages/core/src/authz 180/180; CHANGELOG [Unreleased] #3421; merge-gate check success on 3bb3f9f5",
+          "recorded_at": "2026-08-17T19:58:16Z",
+          "recorded_by": "leaf-implementation@3421"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "security",
+      "tooling",
+      "agent-safety"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3421",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3421: post-#3400/#3410 UAT Shell residuals"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3382",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3382: prior dest-form harvest"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3410",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3410: human-presence mint"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/authz",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/authz"
+        ],
+        "expected_outputs": [
+          "residual dest-form deny",
+          "approved-scope Shell/Write symmetry",
+          "CHANGELOG #3421"
+        ],
+        "depends_on": [],
+        "conflict_group": "authz-classify",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3423,
+        "prBase": null,
+        "mergeCommit": "06f426869ced3b088c7244e4a1e69d563ae74d5a",
+        "deliveryBranch": "master",
+        "deliveryCommit": "06f426869ced3b088c7244e4a1e69d563ae74d5a",
+        "verifiedAt": "2026-08-17T20:12:36Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "d28be0eb-4471-41de-99d4-ac3f107370b3"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T20:12:36Z",
+      "completedSessionId": "d28be0eb-4471-41de-99d4-ac3f107370b3",
+      "capacityBucket": "technical-debt"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/authz"
+      ],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "literal authz vitest is the executable AC; clause-derived HIGH+MEDIUM ACs are covered by that suite",
+      "clauses": []
+    },
+    "updated": "2026-08-17T20:12:36Z"
+  }
+}

--- a/xbrief/completed/2026-08-17-3422-forge-outage-drop-back-human-report-30m-default-retry.xbrief.json
+++ b/xbrief/completed/2026-08-17-3422-forge-outage-drop-back-human-report-30m-default-retry.xbrief.json
@@ -1,0 +1,165 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3422",
+    "updated": "2026-08-17T18:41:13Z"
+  },
+  "plan": {
+    "id": "3422-forge-outage-drop-back",
+    "title": "Forge-outage drop-back + human report + 30m default retry (USER.md / project override)",
+    "status": "completed",
+    "narratives": {
+      "Description": "YOLO / drive-to:merge-ready workers still thrash GitHub I/O during a forge outage. #3167 capped CI-weather babysit loops and #3180 added status-page attribution, but neither encodes drop-back, a one-shot human report, or a configurable retry clock. Default retry is 30 minutes; USER.md Personal wins over plan.policy.forgeOutageRetryMinutes over the framework default.",
+      "UserStory": "As a Directive operator running autonomous through-merge work, I want workers to drop back, tell me the forge is down, and re-probe on a 30-minute default I can override in USER.md or PROJECT-DEFINITION, so that outages do not burn tokens on empty commits and tight polls.",
+      "ImplementationPlan": "1. Extend content/scm/github.md § #3180 and pin the same rule in swarm, review-cycle, and build skill sources (edit packs, then render): on attributed platform outage or repeated 429/502/503, drop back GitHub I/O, report once to the human in chat, and re-probe on the resolved interval. Pointers in content/templates/agents-entry.md and agent-prompt-preamble.md; run task agents:refresh. 2. Add typed plan.policy.forgeOutageRetryMinutes (integer minutes, min 5, default 30) in schemas, packages/types/src/policy.ts, and packages/core/src/policy; USER.md Personal override documented in setup USER.md template; task policy:show --field=forgeOutageRetryMinutes. Precedence: USER.md Personal, then project policy, then 30. 3. Tests for resolve/show/precedence plus CHANGELOG [Unreleased]; verify with policy tests and task check. v1 does not add scm:outage-probe.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3422",
+      "Overview": "Complements #3167 and #3180; does not replace weather codes or status attribution. Optional helper (task scm:outage-probe) is a non-goal for v1. Local edit/test/commit may continue; forge-mutating retries must wait the interval.",
+      "Labels": "enhancement, determinism, agent-experience, harness, scm, area:skills, area:guidance"
+    },
+    "items": [
+      {
+        "title": "Drop-back + one human report + interval re-probe",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given attributed platform outage or repeated 429/502/503 on REST, when a YOLO or through-merge worker would otherwise poll, empty-commit, close/reopen, or spawn a heartbeat child, it stops forge I/O, reports once in the conversation (what is down, attribution or incident if known, what is parked, next probe time), and issues at most one probe per resolved interval. Local work that does not need the forge may continue. Related docs cite #3167 and #3180 as complementary.",
+          "Traces": "FR-3422-1"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3426 merge 2f0c1e613ed5ae1558a8983a3c78281323985833 — content/scm/github.md § #3422 drop-back + one human report + interval re-probe; pack pins in swarm/review-cycle/build",
+          "recorded_at": "2026-08-17T18:40:00Z",
+          "recorded_by": "agent/leaf-implementation/3422-forge-outage-drop-back"
+        }
+      },
+      {
+        "title": "Typed 30m default with USER.md and project override",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given no overrides, forgeOutageRetryMinutes resolves to 30. USER.md Personal wins over plan.policy.forgeOutageRetryMinutes, which wins over the 30-minute default. task policy:show --field=forgeOutageRetryMinutes prints the resolved value. Schema and PlanPolicy include the field (integer minutes, minimum 5). Setup USER.md template documents the Personal override.",
+          "Traces": "FR-3422-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/policy/forge-outage-retry.test.ts — default 30, min 5, USER.md Personal over typed over default; JSON Schema accepts null as unset; task policy:show --field=forgeOutageRetryMinutes",
+          "recorded_at": "2026-08-17T18:40:00Z",
+          "recorded_by": "agent/leaf-implementation/3422-forge-outage-drop-back"
+        }
+      },
+      {
+        "title": "Tests, changelog, and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the policy and guidance changes, when policy resolve/show tests and agents-entry contract pins run, default 30, min 5, and precedence are covered. CHANGELOG [Unreleased] has a brief note for #3422. task check passes.",
+          "Traces": "FR-3422-3"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3426 merge 2f0c1e613ed5ae1558a8983a3c78281323985833 — CHANGELOG [Unreleased] #3422; Merge gate (task check) success on c3a40cf7; Greptile 5/5",
+          "recorded_at": "2026-08-17T18:40:00Z",
+          "recorded_by": "agent/leaf-implementation/3422-forge-outage-drop-back"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "harness",
+      "scm"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3422",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3422: forge-outage drop-back + 30m retry"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3167",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3167: CI weather + babysit thrash caps"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3180",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3180: status-page attribution"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/scm/github.md",
+          "content/packs/skills/skills-pack-0.1.json",
+          "content/templates/agents-entry.md",
+          "content/templates/agent-prompt-preamble.md",
+          "content/vbrief/schemas/vbrief-core.schema.json",
+          "packages/types/src/policy.ts",
+          "packages/types/schemas/vbrief-core-0.6.schema.json",
+          "packages/core/src/policy",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [],
+        "expected_outputs": [
+          "drop-back + report + 30m re-probe rule",
+          "forgeOutageRetryMinutes policy + USER.md override",
+          "CHANGELOG #3422"
+        ],
+        "depends_on": [],
+        "conflict_group": "forge-outage-drop-back",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3426,
+        "prBase": null,
+        "mergeCommit": "2f0c1e613ed5ae1558a8983a3c78281323985833",
+        "deliveryBranch": "master",
+        "deliveryCommit": "2f0c1e613ed5ae1558a8983a3c78281323985833",
+        "verifiedAt": "2026-08-17T18:41:13Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "1beac7ff-a05b-4fc9-9324-a62561e70d4e"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T18:41:13Z",
+      "completedSessionId": "1beac7ff-a05b-4fc9-9324-a62561e70d4e",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3422 ACs; body is authority (no comments); v1 excludes optional scm:outage-probe",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Forge-outage drop-back rule exists at its stated path",
+          "artifact_path": "content/scm/github.md",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "forgeOutageRetryMinutes resolver exists at its stated path",
+          "artifact_path": "packages/core/src/policy/forge-outage-retry.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "CHANGELOG Unreleased note exists at its stated path",
+          "artifact_path": "CHANGELOG.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T18:41:13Z"
+  }
+}

--- a/xbrief/completed/2026-08-17-3425-agents-in-a-shared-product-must-inherit-assumed-project-know.xbrief.json
+++ b/xbrief/completed/2026-08-17-3425-agents-in-a-shared-product-must-inherit-assumed-project-know.xbrief.json
@@ -1,0 +1,129 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3425",
+    "updated": "2026-08-18T01:33:01Z"
+  },
+  "plan": {
+    "id": "3425-project-invariants",
+    "title": "Agents in a shared product must inherit assumed project knowledge",
+    "status": "completed",
+    "narratives": {
+      "Description": "Isolated agents do not inherit authored project invariants, so they can break sibling contracts. First ship is a typed plan.policy.projectInvariants list plus coverage_map dispositions and a preflight fail-closed on missing applicable IDs.",
+      "UserStory": "As a swarm parent, I want every story to declare how it treats applicable project invariants, so that a slice cannot ship without naming the contracts it must not break.",
+      "ImplementationPlan": "Story A schema. Story B+C gate and docs. Close-time file five parked issues.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3425",
+      "Overview": "Pass-1 first slice: typed projectInvariants plus preflight fail-closed. Parked items filed as follow-up issues.",
+      "CurrentShape": "Pass-1 locked. Story A merged PR 3441. Story B+C merged PR 3442. Parked 3443-3447."
+    },
+    "items": [
+      {
+        "title": "Story A: typed plan.policy.projectInvariants + coverage_map reuse + applicability intersection",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given PROJECT-DEFINITION, when plan.policy.projectInvariants is parsed, each entry has id, statement, and contract surface. Empty or absent list is valid. Scope coverage_map reuses covered/deferred/behavioral_delta against those ids. Given a scope file_scope with no intersection, when applicability is computed then no disposition is required.",
+          "Traces": "FR-3425-A"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3441",
+          "recorded_at": "2026-08-18T00:41:31Z",
+          "recorded_by": "grok-build-3425"
+        }
+      },
+      {
+        "title": "Story B+C: preflight/story-ready fail-closed + docs and Visage examples",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given an applicable invariant with no disposition, the implementation-intent gate and story-start gate fail closed and name the omitted id. An id added after authoring fails at the next gate. Docs state the honesty limit. Visage entries are authored examples only.",
+          "Traces": "FR-3425-B"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3442",
+          "recorded_at": "2026-08-18T01:20:00Z",
+          "recorded_by": "grok-build-3425"
+        }
+      },
+      {
+        "title": "Close-time: file five parked follow-up issues with Refs #3425",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given parent scope:complete, when #3425 is closed then five parked items exist as separate GitHub issues with Refs #3425 and their numbers are listed on the close comment.",
+          "Traces": "FR-3425-PARK"
+        },
+        "x-directive/evidence": {
+          "kind": "observed_behavior",
+          "pointer": "https://github.com/deftai/directive/issues/3443 https://github.com/deftai/directive/issues/3444 https://github.com/deftai/directive/issues/3445 https://github.com/deftai/directive/issues/3446 https://github.com/deftai/directive/issues/3447",
+          "recorded_at": "2026-08-18T01:25:00Z",
+          "recorded_by": "grok-build-3425"
+        }
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3425",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3425: Agents in a shared product must inherit assumed project knowledge"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3425#issuecomment-5321347438",
+        "type": "x-xbrief/current-shape",
+        "title": "Current shape (pass-1) for #3425"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [],
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/policy",
+          "packages/core/src/scope",
+          "packages/core/src/vbrief-build",
+          "packages/core/src/preflight",
+          "packages/core/src/story-ready",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [],
+        "expected_outputs": [
+          "plan.policy.projectInvariants",
+          "coverage_map project ids",
+          "preflight missing-id fail-closed",
+          "parked follow-up issues",
+          "CHANGELOG #3425"
+        ],
+        "depends_on": [],
+        "conflict_group": "project-invariants",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard",
+        "acceptance_criteria_justification": "Locked pass-1 has 7 body ACs sequenced as Story A (schema) then Story B+C (gate+docs) plus a close-time parked-issue checklist from the decomposition comment."
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3442,
+        "prBase": null,
+        "mergeCommit": "60ff21bbea5c34e24a0727d5310cc1b08ed62bba",
+        "deliveryBranch": "master",
+        "deliveryCommit": "60ff21bbea5c34e24a0727d5310cc1b08ed62bba",
+        "verifiedAt": "2026-08-18T01:33:01Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "f2ef010e-4000-47cd-914e-3d8d53de043e"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-18T01:33:01Z",
+      "completedSessionId": "f2ef010e-4000-47cd-914e-3d8d53de043e",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-08-18T01:33:01Z"
+  }
+}

--- a/xbrief/completed/2026-08-17-3427-replace-leftover-python-helpers-with-typescript-codeql.xbrief.json
+++ b/xbrief/completed/2026-08-17-3427-replace-leftover-python-helpers-with-typescript-codeql.xbrief.json
@@ -1,0 +1,160 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3427",
+    "updated": "2026-08-17T20:14:38Z"
+  },
+  "plan": {
+    "id": "3427-py-helpers-to-ts",
+    "title": "Replace leftover Python helpers with TypeScript so CodeQL stops Analyze (python) on this repo",
+    "status": "completed",
+    "narratives": {
+      "Description": "CodeQL default setup schedules Analyze (python) on every deftai/directive PR because eight leftover .py helpers are committed. The product is TypeScript/Go. Other deftai repos use Python — do not change org CodeQL. This repo only: port the CI scripts to Node and stop committing core_guard_pin_content.py.",
+      "UserStory": "As a Directive maintainer, I want no tracked Python in this repo, so that CodeQL default setup stops scheduling Analyze (python) here while sister Python repos keep their language set.",
+      "ImplementationPlan": "1. Replace .github/scripts classify/cancel/resolve Python plus tests with committed Node (.mjs or built JS). Keep stdout states missing/queued/started/done/cancelled_unclaimed and runner_name-only claim (#3340). Never cancel a claimed job (#2652). Wire ci.yml off python3. 2. Stop committing cmd/deft-install/core_guard_pin_content.py and _test.py. Keep consumer deposit as a python3 heredoc (ubuntu-latest) or emit from the TS SoT isUpgradePinPathContentAllowed; update deposit.go, deposit_test.go, and scaffold.ts together so the two strings cannot drift. 3. git ls-files '*.py' empty; CHANGELOG [Unreleased]; verify watchdog + pin-content tests and task check.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3427",
+      "Overview": "Minimum for CodeQL here is no tracked .py files. Consumer deft-core-guard may still emit a python3 heredoc (not a .py file in this repo). Do not change org CodeQL. Do not delete helpers without replacement. Not a drive-by on #3387.",
+      "Labels": "enhancement, ci-cd, harness"
+    },
+    "items": [
+      {
+        "title": "Port CI watchdog scripts off python3",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given ci.yml capacity watchdog and aggregator resolve jobs, when they run on ubuntu-latest, they invoke committed Node (not python3). Classifier stdout states stay missing, queued, started, done, cancelled_unclaimed. Claim is runner_name only. Claimed jobs are never cancelled. Former test_*.py coverage lives in vitest.",
+          "Traces": "FR-3427-1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/ci-watchdog.test.ts#ci.yml-node-watchdog",
+          "recorded_at": "2026-08-17T20:13:00Z",
+          "recorded_by": "leaf-implementation:grok-4.6"
+        }
+      },
+      {
+        "title": "Stop committing core_guard_pin_content.py",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given git ls-files '*.py', when run on this repo after the change, the list is empty. Pin/lock content check still matches isUpgradePinPathContentAllowed. deposit.go, deposit_test.go, and scaffold.ts stay in sync. Consumer deposit may keep a python3 heredoc; this repo has no .py file. Org CodeQL languages are unchanged.",
+          "Traces": "FR-3427-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/core-guard-pin-content.test.ts#no-tracked-py",
+          "recorded_at": "2026-08-17T20:13:00Z",
+          "recorded_by": "leaf-implementation:grok-4.6"
+        }
+      },
+      {
+        "title": "Tests, changelog, and check",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the ports, when watchdog and pin-content tests run, behavior matches the old Python. CHANGELOG [Unreleased] notes #3427. task check passes. New SHAs do not schedule Analyze (python).",
+          "Traces": "FR-3427-3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/ci-watchdog.test.ts+core-guard-pin-content.test.ts;CHANGELOG.md#3427;https://github.com/deftai/directive/pull/3430",
+          "recorded_at": "2026-08-17T20:13:00Z",
+          "recorded_by": "leaf-implementation:grok-4.6"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "ci-cd",
+      "harness"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3427",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3427: replace leftover Python helpers with TypeScript"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3193",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3193: pin-content SoT"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          ".github/scripts",
+          ".github/workflows/ci.yml",
+          "cmd/deft-install",
+          "packages/core/src/init-deposit",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit/core-guard-pin-content.test.ts packages/core/src/init-deposit/ci-watchdog.test.ts"
+        ],
+        "expected_outputs": [
+          "no tracked .py",
+          "ci.yml without python3",
+          "CHANGELOG #3427"
+        ],
+        "depends_on": [],
+        "conflict_group": "py-helpers-to-ts",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3430,
+        "prBase": null,
+        "mergeCommit": "ca836a227817cc735c2b3ee6faea8da41d8fc23e",
+        "deliveryBranch": "master",
+        "deliveryCommit": "ca836a227817cc735c2b3ee6faea8da41d8fc23e",
+        "verifiedAt": "2026-08-17T20:14:38Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "e5ca983d-2db3-4909-8ff1-3da27ffbdb7f"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-17T20:14:38Z",
+      "completedSessionId": "e5ca983d-2db3-4909-8ff1-3da27ffbdb7f",
+      "capacityBucket": "new-capability"
+    },
+    "acceptance": {
+      "commands": [
+        {
+          "command": "pnpm exec vitest run packages/core/src/init-deposit/core-guard-pin-content.test.ts packages/core/src/init-deposit/ci-watchdog.test.ts"
+        }
+      ],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3427 ACs; body is authority (no comments)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "ci.yml invokes committed Node watchdog scripts and keeps the 'cancelled_unclaimed' failover state",
+          "artifact_path": ".github/workflows/ci.yml",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "Installer deposit embeds 'core_guard_pin_content.embed' instead of a tracked .py file",
+          "artifact_path": "cmd/deft-install/deposit.go",
+          "ambiguous": false
+        },
+        {
+          "id": 3,
+          "text": "CHANGELOG [Unreleased] notes '#3427'",
+          "artifact_path": "CHANGELOG.md",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T20:14:38Z"
+  }
+}

--- a/xbrief/completed/2026-08-17-3428-slices-jsonl-expected-close-signal-never-updates-or-closes.xbrief.json
+++ b/xbrief/completed/2026-08-17-3428-slices-jsonl-expected-close-signal-never-updates-or-closes.xbrief.json
@@ -1,0 +1,107 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3428",
+    "updated": "2026-08-17T19:53:36Z"
+  },
+  "plan": {
+    "id": "3428-slices-umbrella-close-signal",
+    "title": "slices.jsonl expected_close_signal never updates or closes GitHub umbrellas",
+    "status": "completed",
+    "narratives": {
+      "Description": "Hand-filed GitHub umbrellas recorded only in slices.jsonl never get current-shape refresh or origin close when all children close. reconcile:umbrellas walks only epic xBRIEFs. expected_close_signal is write-only.",
+      "UserStory": "As a maintainer, I want slices-only umbrellas to refresh current-shape and close when expected_close_signal says so, so #3377/#3378 do not stay stale after every child lands.",
+      "ImplementationPlan": "Extend existing task vbrief:reconcile:umbrellas. Walk slices.jsonl umbrellas. Refresh §1152 current-shape from forge child open/closed. If expected_close_signal is all-children-merged and every child is closed and the umbrella is open, close it with one comment naming the signal and child numbers. wave-1-merged and manual stay no-close. No new verb. No invented epic xBRIEF. No child-PR Closes (#701).",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3428 (body authority; 0 comments)",
+      "Overview": "KISS: one existing verb. One check: after reconcile, umbrella state matches the signal. One remediation: task vbrief:reconcile:umbrellas.",
+      "Labels": "bug"
+    },
+    "items": [
+      {
+        "title": "Walk slices.jsonl umbrellas in reconcile:umbrellas",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a slices.jsonl row with no epic xBRIEF, when task vbrief:reconcile:umbrellas runs, it refreshes that umbrella's current-shape from forge child open/closed the same way as an epic-xBRIEF path.",
+          "Traces": "FR-3428-1"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/3431 merge f6f73371c0653b5485f0eb07d41b37ad1eb5b55d; packages/core/src/vbrief-reconcile/umbrellas.ts slices.jsonl walk",
+          "recorded_at": "2026-08-17T21:18:56Z",
+          "recorded_by": "parent@3382-cohort"
+        }
+      },
+      {
+        "title": "Honor expected_close_signal",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given expected_close_signal=all-children-merged and every child issue closed and the umbrella still open, when reconcile runs, it closes the umbrella with one comment citing the signal and child numbers. Given expected_close_signal=manual, current-shape updates and the umbrella stays open. Re-run is a no-op.",
+          "Traces": "FR-3428-2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/vbrief-reconcile/umbrellas.test.ts expected_close_signal; PR https://github.com/deftai/directive/pull/3431",
+          "recorded_at": "2026-08-17T21:18:56Z",
+          "recorded_by": "parent@3382-cohort"
+        }
+      }
+    ],
+    "tags": [
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3428",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3428: slices.jsonl expected_close_signal"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-reconcile",
+          "packages/core/src/slice",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/vbrief-reconcile/umbrellas.test.ts packages/core/src/vbrief-reconcile/umbrellas-create-comment.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "slices.jsonl umbrellas in reconcile",
+          "all-children-merged closes umbrella",
+          "CHANGELOG #3428"
+        ],
+        "depends_on": [],
+        "conflict_group": "umbrella-reconcile",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": false,
+      "source_rung": "derived",
+      "derived_reason": "collapsed #3428 ACs; body is authority (no comments)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "reconcile:umbrellas walks slices.jsonl umbrellas and refreshes current-shape from forge child state",
+          "artifact_path": "packages/core/src/vbrief-reconcile/umbrellas.ts",
+          "ambiguous": false
+        },
+        {
+          "id": 2,
+          "text": "all-children-merged closes the open umbrella; manual does not; re-run is a no-op",
+          "artifact_path": "packages/core/src/vbrief-reconcile/umbrellas.ts",
+          "ambiguous": false
+        }
+      ]
+    },
+    "updated": "2026-08-17T19:53:36Z"
+  }
+}

--- a/xbrief/completed/2026-08-17-3428-slices-jsonl-expected-close-signal-never-updates-or-closes.xbrief.json
+++ b/xbrief/completed/2026-08-17-3428-slices-jsonl-expected-close-signal-never-updates-or-closes.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #3428",
-    "updated": "2026-08-17T19:53:36Z"
+    "updated": "2026-08-18T03:26:23Z"
   },
   "plan": {
     "id": "3428-slices-umbrella-close-signal",
@@ -11,7 +11,7 @@
     "narratives": {
       "Description": "Hand-filed GitHub umbrellas recorded only in slices.jsonl never get current-shape refresh or origin close when all children close. reconcile:umbrellas walks only epic xBRIEFs. expected_close_signal is write-only.",
       "UserStory": "As a maintainer, I want slices-only umbrellas to refresh current-shape and close when expected_close_signal says so, so #3377/#3378 do not stay stale after every child lands.",
-      "ImplementationPlan": "Extend existing task vbrief:reconcile:umbrellas. Walk slices.jsonl umbrellas. Refresh §1152 current-shape from forge child open/closed. If expected_close_signal is all-children-merged and every child is closed and the umbrella is open, close it with one comment naming the signal and child numbers. wave-1-merged and manual stay no-close. No new verb. No invented epic xBRIEF. No child-PR Closes (#701).",
+      "ImplementationPlan": "Extend existing task vbrief:reconcile:umbrellas. Walk slices.jsonl umbrellas. Refresh \u00a71152 current-shape from forge child open/closed. If expected_close_signal is all-children-merged and every child is closed and the umbrella is open, close it with one comment naming the signal and child numbers. wave-1-merged and manual stay no-close. No new verb. No invented epic xBRIEF. No child-PR Closes (#701).",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3428 (body authority; 0 comments)",
       "Overview": "KISS: one existing verb. One check: after reconcile, umbrella state matches the signal. One remediation: task vbrief:reconcile:umbrellas.",
       "Labels": "bug"
@@ -19,7 +19,7 @@
     "items": [
       {
         "title": "Walk slices.jsonl umbrellas in reconcile:umbrellas",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a slices.jsonl row with no epic xBRIEF, when task vbrief:reconcile:umbrellas runs, it refreshes that umbrella's current-shape from forge child open/closed the same way as an epic-xBRIEF path.",
           "Traces": "FR-3428-1"
@@ -33,7 +33,7 @@
       },
       {
         "title": "Honor expected_close_signal",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given expected_close_signal=all-children-merged and every child issue closed and the umbrella still open, when reconcile runs, it closes the umbrella with one comment citing the signal and child numbers. Given expected_close_signal=manual, current-shape updates and the umbrella stays open. Re-run is a no-op.",
           "Traces": "FR-3428-2"
@@ -102,6 +102,6 @@
         }
       ]
     },
-    "updated": "2026-08-17T19:53:36Z"
+    "updated": "2026-08-18T03:26:23Z"
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle land of 24 already-completed xBRIEFs for closed 3382-cohort issues. Parent `scope:complete` failed #3041 (delivery proof). These files were already copied locally; this PR tracks them on master so `verify:completed-tracked` and post-merge lifecycle see the record.

Does not re-close those story issues. Does not change product code.

## Related Issues

Refs #2321
Refs #3264
Refs #1358

Tracking only. No auto-close keywords.

## Checklist

- [x] `/deft:change <name>` — N/A: lifecycle housekeeping (add completed records + one CHANGELOG line). Not a product/architecture change.
- [x] `CHANGELOG.md` — Unreleased process/lifecycle line citing #3264 / #1358
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally (`task check`)

## Post-Merge

- [ ] This PR must not auto-close already-closed story issues (3379–3397, 3421, 3422, 3425, 3427, 3428). Inverse check: reopen any that close accidentally.
- [x] Enable branch protection on `master` requiring CI status check (one-time setup, see #57) — already in place
