### PR TITLE
fix(cli): accumulate repeated feedback:file --context flags (#3454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`feedback:file` repeated `--context` flags accumulate (#3454).** Collected values join with newlines so `context` stays a string. Closes #3454.
 - **`deft update --dry-run` leads with deposit vs content version skew (#3437).** When the recorded install manifest and the content package disagree, that line is first (`manifest X -> content Y`). `--json` adds `previous_version`, `content_version`, and `deposit_refresh_pending`. No file-level plan (`strategy` / `planned_paths` / `planned_file_count`) — that waits on #3462. Refs #3437. Prior art: halted PR 3453.
 - **Init-deposit dest deletes go through the write chokepoint (#3456).** Named dest deletes and temp cleanups use `containedRemove`. Schema projection validates planned content, not stale dest a skipped write would replace. Plan-mode / `deft update --dry-run` leaves the tree unchanged (keystone hash). Closes #3456. Refs #3392, #3437.
 - **Occupancy lock races (#3433).** Release re-reads under the occupancy lock so close-out cannot delete a replacement claim. Lock wait unlinks only a lock this waiter acquired, or a lock whose owner PID is proven dead — not a live writer.

--- a/packages/core/src/value/feedback-file.test.ts
+++ b/packages/core/src/value/feedback-file.test.ts
@@ -227,6 +227,21 @@ describe("feedback-file CLI", () => {
     expect(parsed.confirm).toBe(true);
   });
 
+  it("accumulates two space-separated --context flags", () => {
+    const parsed = parseFeedbackFileArgs(["--context", "first", "--context", "second"]);
+    expect(parsed.context).toBe("first\nsecond");
+  });
+
+  it("accumulates two --context= flags", () => {
+    const parsed = parseFeedbackFileArgs(["--context=first", "--context=second"]);
+    expect(parsed.context).toBe("first\nsecond");
+  });
+
+  it("keeps prior --context when a later flag has no value", () => {
+    const parsed = parseFeedbackFileArgs(["--context", "kept", "--context"]);
+    expect(parsed.context).toBe("kept");
+  });
+
   it("returns config error when summary missing", () => {
     expect(feedbackFileMain([])).toBe(2);
   });

--- a/packages/core/src/value/feedback-file.ts
+++ b/packages/core/src/value/feedback-file.ts
@@ -337,10 +337,18 @@ export interface FeedbackFileCliArgs {
   error?: string;
 }
 
+/** Join repeated --context values; schema stays `context?: string` (#3454). */
+const CONTEXT_JOIN = "\n";
+
+function appendContextValue(collected: string[], value: string | undefined): void {
+  if (typeof value === "string") collected.push(value);
+}
+
 /** Parse argv for feedback:file. */
 export function parseFeedbackFileArgs(argv: readonly string[]): FeedbackFileCliArgs {
   const out: FeedbackFileCliArgs = {};
   const positionals: string[] = [];
+  const contextValues: string[] = [];
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i] as string;
     if (arg === "--confirm") out.confirm = true;
@@ -351,9 +359,9 @@ export function parseFeedbackFileArgs(argv: readonly string[]): FeedbackFileCliA
     } else if (arg?.startsWith("--summary=")) {
       out.summary = arg.slice("--summary=".length);
     } else if (arg === "--context") {
-      out.context = argv[++i];
+      appendContextValue(contextValues, argv[++i]);
     } else if (arg?.startsWith("--context=")) {
-      out.context = arg.slice("--context=".length);
+      appendContextValue(contextValues, arg.slice("--context=".length));
     } else if (arg === "--expected") {
       out.expected = argv[++i];
     } else if (arg?.startsWith("--expected=")) {
@@ -384,6 +392,9 @@ export function parseFeedbackFileArgs(argv: readonly string[]): FeedbackFileCliA
   }
   if ((out.summary === undefined || out.summary.trim().length === 0) && positionals.length > 0) {
     out.summary = positionals.join(" ");
+  }
+  if (contextValues.length > 0) {
+    out.context = contextValues.join(CONTEXT_JOIN);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Repeated --context / --context= flags on feedback:file now accumulate and join with newlines instead of last-wins. The existing context?: string schema stays a string.

## Related Issues

Closes #3454

## Checklist

- [x] /deft:change -- N/A (under 3 files; not cross-cutting)
- [x] CHANGELOG.md -- added entry under [Unreleased]
- [x] ROADMAP.md -- N/A
- [x] Tests pass locally

## Test plan

- pnpm exec vitest run packages/core/src/value/feedback-file.test.ts (22 passed)
- task check (1002 test files passed, 6 skipped; 14027 tests passed, 149 skipped; coverage 88.83%)
