### PR TITLE
feat(check): emit coarse flushed progress from ts:check-lane (#3470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ts:check-lane emits coarse flushed progress during the vitest suite (#3470).** After the #3188 start line, the lane prints percent/count ticks every 20% of collected files (`ts:check-lane 20% (412/2060 files)`). Line-buffered via `writeSync`; pass/fail is unchanged. Closes #3470.
 - **Worktree occupancy lease (#3433).** Mutation `session:start` / `session:ready` claim gitignored `.deft/occupancy.json`. A second mutation session on the same tree fails closed. Same-session re-arm heartbeats and keeps `DEFT_SESSION_ID`. Steal with `occupancy:steal --confirm --occupant`. Expired heartbeat (20 min) is free. PreToolUse denies product-path writes for a foreign live occupant. `swarm:launch` claims `intent: swarm`; finalize/complete-cohort release. Closes #3433.
 - **Land completed-tracked artifacts for closed 3382-cohort issues (#3264 / #1358).** 24 already-completed xBRIEFs for closed issues now live under `xbrief/completed/` so `verify:completed-tracked` and post-merge lifecycle see the record. Does not re-close those issues. Refs #2321.
 - **Land remaining completed-tracked artifacts for closed 3382-cohort issues (#3264 / #1358).** Ten completed xBRIEFs (3398, 3399, 3424, 3429, 3433, 3448, 3456, 3462 salvage, 3462 port, 3464/tier-1) and the superseded #3437 cancelled brief. Does not re-close those issues. Refs #2321.

--- a/packages/core/src/ts-check-lane/index.ts
+++ b/packages/core/src/ts-check-lane/index.ts
@@ -1,3 +1,18 @@
+export type {
+  ProgressLineSink,
+  ProgressTick,
+  WriteFlushedLineOptions,
+} from "./progress.js";
+export {
+  buildTestLaneCommand,
+  formatProgressLine,
+  nextProgressTick,
+  PROGRESS_BAND_PERCENT,
+  PROGRESS_REPORTER_RELATIVE_PATH,
+  PROGRESS_UNIT,
+  writeFlushedLine,
+} from "./progress.js";
+export { TsCheckLaneProgressReporter } from "./progress-reporter.js";
 export type { LaneRunner, ResolvePnpmOptions, RunnerResult, RunTsLaneOptions } from "./run-lane.js";
 export {
   LANE_COMMANDS,

--- a/packages/core/src/ts-check-lane/index.ts
+++ b/packages/core/src/ts-check-lane/index.ts
@@ -10,6 +10,7 @@ export {
   PROGRESS_BAND_PERCENT,
   PROGRESS_REPORTER_RELATIVE_PATH,
   PROGRESS_UNIT,
+  resolveTestLaneCommand,
   writeFlushedLine,
 } from "./progress.js";
 export { TsCheckLaneProgressReporter } from "./progress-reporter.js";

--- a/packages/core/src/ts-check-lane/progress-reporter.test.ts
+++ b/packages/core/src/ts-check-lane/progress-reporter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { TsCheckLaneProgressReporter } from "./progress-reporter.js";
+
+describe("TsCheckLaneProgressReporter", () => {
+  it("emits flushed 20% bands as modules finish", () => {
+    const writes: string[] = [];
+    let flushes = 0;
+    const reporter = new TsCheckLaneProgressReporter({
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      flush: () => {
+        flushes += 1;
+      },
+    });
+
+    reporter.onTestRunStart(Array.from({ length: 5 }, () => ({})));
+    for (let i = 0; i < 5; i += 1) {
+      reporter.onTestModuleEnd();
+    }
+
+    expect(writes).toEqual([
+      "ts:check-lane 20% (1/5 files)\n",
+      "ts:check-lane 40% (2/5 files)\n",
+      "ts:check-lane 60% (3/5 files)\n",
+      "ts:check-lane 80% (4/5 files)\n",
+      "ts:check-lane 100% (5/5 files)\n",
+    ]);
+    expect(flushes).toBe(5);
+    expect(writes.some((line) => line.includes("describe") || line.includes("it("))).toBe(false);
+  });
+
+  it("ignores vitest reporter options that are not a write sink", () => {
+    const reporter = new TsCheckLaneProgressReporter({ outputFile: "unused.json" });
+    expect(() => reporter.onTestRunStart([{}])).not.toThrow();
+  });
+
+  it("stays silent when the file total is unknown", () => {
+    const writes: string[] = [];
+    const reporter = new TsCheckLaneProgressReporter({
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+    });
+    reporter.onTestRunStart([]);
+    reporter.onTestModuleEnd();
+    expect(writes).toEqual([]);
+  });
+});

--- a/packages/core/src/ts-check-lane/progress-reporter.ts
+++ b/packages/core/src/ts-check-lane/progress-reporter.ts
@@ -1,0 +1,51 @@
+/**
+ * Vitest reporter that emits coarse flushed progress for ts:check-lane (#3470).
+ *
+ * Wired from the lane via `--reporter` so vitest.config.ts stays unchanged.
+ * Does not print test names and does not change pass/fail.
+ */
+
+import {
+  formatProgressLine,
+  nextProgressTick,
+  type ProgressLineSink,
+  writeFlushedLine,
+} from "./progress.js";
+
+function isLineSink(value: unknown): value is ProgressLineSink {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as ProgressLineSink).write === "function"
+  );
+}
+
+export class TsCheckLaneProgressReporter {
+  private total = 0;
+  private completed = 0;
+  private lastEmittedPercent = 0;
+  private readonly sink?: ProgressLineSink;
+
+  constructor(sink?: unknown) {
+    // Vitest constructs reporters with its options object; only tests pass a sink.
+    this.sink = isLineSink(sink) ? sink : undefined;
+  }
+
+  onTestRunStart(specifications: ReadonlyArray<unknown> = []): void {
+    this.total = specifications.length;
+    this.completed = 0;
+    this.lastEmittedPercent = 0;
+  }
+
+  onTestModuleEnd(): void {
+    this.completed += 1;
+    const tick = nextProgressTick(this.completed, this.total, this.lastEmittedPercent);
+    if (tick === null) {
+      return;
+    }
+    this.lastEmittedPercent = tick.percent;
+    writeFlushedLine(formatProgressLine(tick), this.sink);
+  }
+}
+
+export default TsCheckLaneProgressReporter;

--- a/packages/core/src/ts-check-lane/progress.test.ts
+++ b/packages/core/src/ts-check-lane/progress.test.ts
@@ -7,8 +7,27 @@ import {
   formatProgressLine,
   nextProgressTick,
   PROGRESS_BAND_PERCENT,
+  PROGRESS_REPORTER_RELATIVE_PATH,
+  resolveTestLaneCommand,
   writeFlushedLine,
 } from "./progress.js";
+
+describe("resolveTestLaneCommand", () => {
+  it("omits the reporter when the source file is absent", () => {
+    expect(resolveTestLaneCommand("/consumer", () => false)).toEqual(["run", "test"]);
+  });
+
+  it("wires the reporter when the source file exists", () => {
+    expect(resolveTestLaneCommand("/repo", () => true)).toEqual([
+      "run",
+      "test",
+      "--reporter",
+      PROGRESS_REPORTER_RELATIVE_PATH,
+      "--reporter",
+      "default",
+    ]);
+  });
+});
 
 describe("nextProgressTick", () => {
   it("re-exports the band from the barrel", () => {

--- a/packages/core/src/ts-check-lane/progress.test.ts
+++ b/packages/core/src/ts-check-lane/progress.test.ts
@@ -1,0 +1,104 @@
+import { closeSync, openSync, readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PROGRESS_BAND_PERCENT as EXPORTED_BAND } from "./index.js";
+import {
+  formatProgressLine,
+  nextProgressTick,
+  PROGRESS_BAND_PERCENT,
+  writeFlushedLine,
+} from "./progress.js";
+
+describe("nextProgressTick", () => {
+  it("re-exports the band from the barrel", () => {
+    expect(EXPORTED_BAND).toBe(PROGRESS_BAND_PERCENT);
+  });
+
+  it("skips empty or incomplete work", () => {
+    expect(nextProgressTick(0, 10, 0)).toBeNull();
+    expect(nextProgressTick(1, 0, 0)).toBeNull();
+    expect(nextProgressTick(-1, 10, 0)).toBeNull();
+    expect(nextProgressTick(1, 10, 0, 0)).toBeNull();
+    expect(nextProgressTick(Number.NaN, 10, 0)).toBeNull();
+  });
+
+  it("emits the first crossed band and ignores intra-band updates", () => {
+    expect(nextProgressTick(1, 10, 0)).toBeNull();
+    expect(nextProgressTick(2, 10, 0)).toEqual({ percent: 20, completed: 2, total: 10 });
+    expect(nextProgressTick(3, 10, 20)).toBeNull();
+    expect(nextProgressTick(4, 10, 20)).toEqual({ percent: 40, completed: 4, total: 10 });
+  });
+
+  it("clamps completed-over-total to 100%", () => {
+    expect(nextProgressTick(12, 10, 80)).toEqual({ percent: 100, completed: 12, total: 10 });
+  });
+
+  it("never emits a decreasing or duplicate band for 50 totals", () => {
+    for (let i = 0; i < 50; i += 1) {
+      const total = 1 + ((i * 37) % 200);
+      let last = 0;
+      for (let completed = 0; completed <= total + 3; completed += 1) {
+        const tick = nextProgressTick(completed, total, last);
+        if (tick === null) {
+          continue;
+        }
+        expect(tick.percent).toBeGreaterThan(last);
+        expect(tick.percent % PROGRESS_BAND_PERCENT).toBe(0);
+        expect(tick.percent).toBeLessThanOrEqual(100);
+        last = tick.percent;
+      }
+    }
+  });
+});
+
+describe("formatProgressLine / writeFlushedLine", () => {
+  it("formats the issue example and flushes immediately", () => {
+    const writes: string[] = [];
+    let flushes = 0;
+    const line = formatProgressLine({ percent: 20, completed: 412, total: 2060 });
+    expect(line).toBe("ts:check-lane 20% (412/2060 files)");
+    writeFlushedLine(line, {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      flush: () => {
+        flushes += 1;
+      },
+    });
+    expect(writes).toEqual(["ts:check-lane 20% (412/2060 files)\n"]);
+    expect(flushes).toBe(1);
+  });
+
+  it("falls back to writeSync when sink.write is missing", () => {
+    const calls: Array<[number, string]> = [];
+    writeFlushedLine("ts:check-lane 20% (1/5 files)", {} as never, {
+      syncWrite: (fd, payload) => {
+        calls.push([fd, payload]);
+      },
+    });
+    expect(calls).toEqual([[1, "ts:check-lane 20% (1/5 files)\n"]]);
+  });
+
+  it("writeSyncs to stdout when no sink is given", () => {
+    const calls: Array<[number, string]> = [];
+    writeFlushedLine("ts:check-lane 20% (1/5 files)", undefined, {
+      syncWrite: (fd, payload) => {
+        calls.push([fd, payload]);
+      },
+    });
+    expect(calls).toEqual([[1, "ts:check-lane 20% (1/5 files)\n"]]);
+  });
+
+  it("keeps an existing trailing newline and writeSyncs to the given fd", () => {
+    const path = join(tmpdir(), `3470-progress-${process.pid}.txt`);
+    const fd = openSync(path, "w");
+    try {
+      writeFlushedLine("already-terminated\n", undefined, { fd });
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(path, "utf8")).toBe("already-terminated\n");
+    unlinkSync(path);
+  });
+});

--- a/packages/core/src/ts-check-lane/progress.ts
+++ b/packages/core/src/ts-check-lane/progress.ts
@@ -1,0 +1,85 @@
+/**
+ * Coarse percent/count ticks for ts:check-lane (#3470).
+ *
+ * Band math is independent of vitest so tests can cover cadence and flush
+ * without running the suite.
+ */
+
+import { writeSync } from "node:fs";
+
+/** Relative to the repo root; wired onto `pnpm run test` from the lane. */
+export const PROGRESS_REPORTER_RELATIVE_PATH =
+  "packages/core/src/ts-check-lane/progress-reporter.ts";
+
+/** One line every 20% of known files -- coarse enough for a log snapshot. */
+export const PROGRESS_BAND_PERCENT = 20;
+
+export const PROGRESS_UNIT = "files";
+
+export interface ProgressTick {
+  readonly percent: number;
+  readonly completed: number;
+  readonly total: number;
+}
+
+export interface ProgressLineSink {
+  write(chunk: string): void;
+  flush?: () => void;
+}
+
+export function nextProgressTick(
+  completed: number,
+  total: number,
+  lastEmittedPercent: number,
+  bandPercent: number = PROGRESS_BAND_PERCENT,
+): ProgressTick | null {
+  if (
+    !Number.isFinite(completed) ||
+    !Number.isFinite(total) ||
+    !Number.isFinite(lastEmittedPercent)
+  ) {
+    return null;
+  }
+  if (total <= 0 || completed <= 0 || bandPercent <= 0) {
+    return null;
+  }
+  const raw = Math.min(100, Math.floor((completed / total) * 100));
+  const band = Math.floor(raw / bandPercent) * bandPercent;
+  if (band < bandPercent || band <= lastEmittedPercent) {
+    return null;
+  }
+  return { percent: band, completed, total };
+}
+
+export function formatProgressLine(tick: ProgressTick, unit: string = PROGRESS_UNIT): string {
+  return `ts:check-lane ${tick.percent}% (${tick.completed}/${tick.total} ${unit})`;
+}
+
+export interface WriteFlushedLineOptions {
+  readonly fd?: number;
+  readonly syncWrite?: (fd: number, payload: string) => void;
+}
+
+/** writeSync so a non-TTY capture sees each tick immediately (#1353). */
+export function writeFlushedLine(
+  line: string,
+  sink?: ProgressLineSink,
+  options: WriteFlushedLineOptions = {},
+): void {
+  const payload = line.endsWith("\n") ? line : `${line}\n`;
+  if (sink !== undefined && typeof sink.write === "function") {
+    sink.write(payload);
+    sink.flush?.();
+    return;
+  }
+  const syncWrite = options.syncWrite ?? writeSync;
+  syncWrite(options.fd ?? 1, payload);
+}
+
+export function buildTestLaneCommand(
+  reporterPath: string = PROGRESS_REPORTER_RELATIVE_PATH,
+): readonly string[] {
+  // Do not insert a standalone "--": pnpm forwards it to vitest, which then
+  // treats later --reporter flags as file filters (#3470).
+  return ["run", "test", "--reporter", reporterPath, "--reporter", "default"];
+}

--- a/packages/core/src/ts-check-lane/progress.ts
+++ b/packages/core/src/ts-check-lane/progress.ts
@@ -5,7 +5,8 @@
  * without running the suite.
  */
 
-import { writeSync } from "node:fs";
+import { existsSync, writeSync } from "node:fs";
+import { join } from "node:path";
 
 /** Relative to the repo root; wired onto `pnpm run test` from the lane. */
 export const PROGRESS_REPORTER_RELATIVE_PATH =
@@ -82,4 +83,16 @@ export function buildTestLaneCommand(
   // Do not insert a standalone "--": pnpm forwards it to vitest, which then
   // treats later --reporter flags as file filters (#3470).
   return ["run", "test", "--reporter", reporterPath, "--reporter", "default"];
+}
+
+/** Attach the reporter only when the source file is present (framework checkout). */
+export function resolveTestLaneCommand(
+  projectRoot: string,
+  exists: (path: string) => boolean = existsSync,
+): readonly string[] {
+  const reporterAbs = join(projectRoot, ...PROGRESS_REPORTER_RELATIVE_PATH.split("/"));
+  if (!exists(reporterAbs)) {
+    return ["run", "test"];
+  }
+  return buildTestLaneCommand();
 }

--- a/packages/core/src/ts-check-lane/run-lane.test.ts
+++ b/packages/core/src/ts-check-lane/run-lane.test.ts
@@ -5,6 +5,14 @@ import {
   RELEASE_PREFLIGHT_ENV,
 } from "../release/constants.js";
 import {
+  buildTestLaneCommand,
+  formatProgressLine,
+  nextProgressTick,
+  PROGRESS_REPORTER_RELATIVE_PATH,
+  writeFlushedLine,
+} from "./progress.js";
+import { TsCheckLaneProgressReporter } from "./progress-reporter.js";
+import {
   LANE_COMMANDS,
   resolvePnpm,
   runTsLane,
@@ -113,7 +121,7 @@ describe("runTsLane", () => {
       expect(runner.calls.map((c) => c.argv)).toEqual([
         ["/usr/bin/pnpm", "run", "lint"],
         ["/usr/bin/pnpm", "run", "build"],
-        ["/usr/bin/pnpm", "run", "test"],
+        ["/usr/bin/pnpm", ...buildTestLaneCommand()],
       ]);
       // Debt env is only active during the test step.
       expect(seenDebt).toEqual([undefined, undefined, "2618"]);
@@ -125,6 +133,42 @@ describe("runTsLane", () => {
         process.env.DEFT_TS_LANE_COVERAGE_DEBT = prior;
       }
     }
+  });
+
+  it("restores a prior DEFT_TS_LANE_COVERAGE_DEBT after the test step", () => {
+    const runner = new Runner([0, 0, 0]);
+    const prior = process.env.DEFT_TS_LANE_COVERAGE_DEBT;
+    process.env.DEFT_TS_LANE_COVERAGE_DEBT = "keep-me";
+    try {
+      const rc = runTsLane("/repo", {
+        pnpm: "/usr/bin/pnpm",
+        runner: runner.run,
+        out: () => undefined,
+        env: {
+          [COVERAGE_DEBT_ENV]: "2618",
+          [RELEASE_PREFLIGHT_ENV]: "1",
+        },
+      });
+      expect(rc).toBe(0);
+      expect(process.env.DEFT_TS_LANE_COVERAGE_DEBT).toBe("keep-me");
+    } finally {
+      if (prior === undefined) {
+        delete process.env.DEFT_TS_LANE_COVERAGE_DEBT;
+      } else {
+        process.env.DEFT_TS_LANE_COVERAGE_DEBT = prior;
+      }
+    }
+  });
+
+  it("wires a flushed vitest progress reporter onto the test command (#3470)", () => {
+    expect(LANE_COMMANDS[2]).toEqual([
+      "run",
+      "test",
+      "--reporter",
+      PROGRESS_REPORTER_RELATIVE_PATH,
+      "--reporter",
+      "default",
+    ]);
   });
 
   it("fails fast on the first non-zero exit", () => {
@@ -241,5 +285,67 @@ describe("resolvePnpm", () => {
       exists: (p) => p === "/usr/bin/pnpm",
     });
     expect(found).toBe("/usr/bin/pnpm");
+  });
+});
+
+describe("ts:check-lane progress ticks (#3470)", () => {
+  it("emits at least two flushed band lines without test names", () => {
+    const writes: string[] = [];
+    let flushes = 0;
+    const sink = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      flush: () => {
+        flushes += 1;
+      },
+    };
+
+    const first = nextProgressTick(412, 2060, 0);
+    const second = nextProgressTick(824, 2060, first?.percent ?? 0);
+    expect(first).toEqual({ percent: 20, completed: 412, total: 2060 });
+    expect(second).toEqual({ percent: 40, completed: 824, total: 2060 });
+    if (first === null || second === null) {
+      throw new Error("expected two progress ticks");
+    }
+    expect(formatProgressLine(first)).toBe("ts:check-lane 20% (412/2060 files)");
+    expect(formatProgressLine(second)).toBe("ts:check-lane 40% (824/2060 files)");
+
+    writeFlushedLine(formatProgressLine(first), sink);
+    writeFlushedLine(formatProgressLine(second), sink);
+
+    expect(writes).toEqual([
+      "ts:check-lane 20% (412/2060 files)\n",
+      "ts:check-lane 40% (824/2060 files)\n",
+    ]);
+    expect(flushes).toBe(2);
+    expect(writes.every((line) => !line.includes("should") && !line.includes(".test.ts"))).toBe(
+      true,
+    );
+  });
+
+  it("drives two flushed ticks from the vitest reporter hooks", () => {
+    const writes: string[] = [];
+    let flushes = 0;
+    const reporter = new TsCheckLaneProgressReporter({
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      flush: () => {
+        flushes += 1;
+      },
+    });
+
+    reporter.onTestRunStart(Array.from({ length: 10 }, () => ({})));
+    reporter.onTestModuleEnd();
+    reporter.onTestModuleEnd();
+    reporter.onTestModuleEnd();
+    reporter.onTestModuleEnd();
+
+    expect(writes).toEqual([
+      "ts:check-lane 20% (2/10 files)\n",
+      "ts:check-lane 40% (4/10 files)\n",
+    ]);
+    expect(flushes).toBe(2);
   });
 });

--- a/packages/core/src/ts-check-lane/run-lane.test.ts
+++ b/packages/core/src/ts-check-lane/run-lane.test.ts
@@ -87,6 +87,7 @@ describe("runTsLane", () => {
       pnpm: "/usr/bin/pnpm",
       runner: runner.run,
       out: () => undefined,
+      reporterExists: () => true,
     });
 
     expect(rc).toBe(0);
@@ -111,6 +112,7 @@ describe("runTsLane", () => {
         pnpm: "/usr/bin/pnpm",
         runner: wrapped,
         out: () => undefined,
+        reporterExists: () => true,
         env: {
           [COVERAGE_DEBT_ENV]: "2618",
           [RELEASE_PREFLIGHT_ENV]: "1",
@@ -158,6 +160,18 @@ describe("runTsLane", () => {
         process.env.DEFT_TS_LANE_COVERAGE_DEBT = prior;
       }
     }
+  });
+
+  it("omits the reporter when the checkout has no reporter source file", () => {
+    const runner = new Runner([0, 0, 0]);
+    const rc = runTsLane("/consumer", {
+      pnpm: "/usr/bin/pnpm",
+      runner: runner.run,
+      out: () => undefined,
+      reporterExists: () => false,
+    });
+    expect(rc).toBe(0);
+    expect(runner.calls[2]?.argv).toEqual(["/usr/bin/pnpm", "run", "test"]);
   });
 
   it("wires a flushed vitest progress reporter onto the test command (#3470)", () => {

--- a/packages/core/src/ts-check-lane/run-lane.ts
+++ b/packages/core/src/ts-check-lane/run-lane.ts
@@ -22,7 +22,7 @@ import { existsSync } from "node:fs";
 import { posix, win32 } from "node:path";
 import { BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV } from "../release/constants.js";
 import { resolveCoverageDebtIssue } from "../vitest-runner/coverage-debt.js";
-import { buildTestLaneCommand } from "./progress.js";
+import { buildTestLaneCommand, resolveTestLaneCommand } from "./progress.js";
 
 /** Release Step-5 vars that must not leak into vitest via inherited pnpm env (#2434). */
 const TS_LANE_POISON_ENV_KEYS = [BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV] as const;
@@ -75,6 +75,8 @@ export interface RunTsLaneOptions {
    * DEFT_RELEASE_PREFLIGHT (#2618). Defaults to process.env.
    */
   readonly env?: NodeJS.ProcessEnv;
+  /** Injected reporter-file probe (defaults to existsSync). */
+  readonly reporterExists?: (path: string) => boolean;
 }
 
 /** Windows command shims (.cmd/.bat) need a shell; native executables do not. */
@@ -157,7 +159,9 @@ export function runTsLane(projectRoot: string, options: RunTsLaneOptions): numbe
   }
 
   for (const command of LANE_COMMANDS) {
-    const argv = [pnpm, ...command];
+    const resolved =
+      command[1] === "test" ? resolveTestLaneCommand(projectRoot, options.reporterExists) : command;
+    const argv = [pnpm, ...resolved];
     // Soft-pass via lane-private env (vitest 3 CAC rejects unknown CLI debt tokens).
     // vitest.config reads DEFT_TS_LANE_COVERAGE_DEBT without DEFT_RELEASE_PREFLIGHT
     // (sanitizeTsLaneEnv strips preflight). Refs #2573 / #2618.
@@ -186,17 +190,17 @@ export function runTsLane(projectRoot: string, options: RunTsLaneOptions): numbe
     if (code === null) {
       if (result.error) {
         out(
-          `[ts:check-lane] \`pnpm ${command.join(" ")}\` failed to start: ${result.error.message}`,
+          `[ts:check-lane] \`pnpm ${resolved.join(" ")}\` failed to start: ${result.error.message}`,
         );
         return 1;
       }
       out(
-        `[ts:check-lane] \`pnpm ${command.join(" ")}\` was killed by ${result.signal ?? "a signal"} before exit -- treating as failure.`,
+        `[ts:check-lane] \`pnpm ${resolved.join(" ")}\` was killed by ${result.signal ?? "a signal"} before exit -- treating as failure.`,
       );
       return 1;
     }
     if (code !== 0) {
-      out(`[ts:check-lane] \`pnpm ${command.join(" ")}\` failed (exit ${code}).`);
+      out(`[ts:check-lane] \`pnpm ${resolved.join(" ")}\` failed (exit ${code}).`);
       return code;
     }
   }

--- a/packages/core/src/ts-check-lane/run-lane.ts
+++ b/packages/core/src/ts-check-lane/run-lane.ts
@@ -22,6 +22,7 @@ import { existsSync } from "node:fs";
 import { posix, win32 } from "node:path";
 import { BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV } from "../release/constants.js";
 import { resolveCoverageDebtIssue } from "../vitest-runner/coverage-debt.js";
+import { buildTestLaneCommand } from "./progress.js";
 
 /** Release Step-5 vars that must not leak into vitest via inherited pnpm env (#2434). */
 const TS_LANE_POISON_ENV_KEYS = [BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV] as const;
@@ -30,10 +31,10 @@ const TS_LANE_POISON_ENV_KEYS = [BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV] 
  * Run order is deliberate: lint (cheapest, catches the biome class first),
  * then build, then the test suite.
  */
-export const LANE_COMMANDS: ReadonlyArray<readonly [string, string]> = [
+export const LANE_COMMANDS: ReadonlyArray<readonly string[]> = [
   ["run", "lint"],
   ["run", "build"],
-  ["run", "test"],
+  buildTestLaneCommand(),
 ];
 
 export const SKIP_NOTICE =


### PR DESCRIPTION
## Summary

ts:check-lane now prints coarse flushed percent/count ticks during the vitest suite (every 20% of collected files). A mid-run log snapshot can tell the suite is moving. Pass/fail is unchanged.

## Related Issues

Closes #3470

## Checklist

- [x] /deft:change -- N/A (ts-check-lane + CHANGELOG; not cross-cutting)
- [x] CHANGELOG.md -- added entry under [Unreleased]
- [x] ROADMAP.md -- N/A
- [x] Tests pass locally

## Test plan

- pnpm exec vitest run packages/core/src/ts-check-lane (34 passed)
- task check (1004 test files passed, 6 skipped; ticks 20/40/60/80/100% on 1010 files)
