### PR TITLE
fix(agents-entry): name session:ready on the #1149 ritual line (#3506)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Same rules as the managed `## Session routing (#2176)` below: at session start, 
 
 ## Session-start ritual (#1149)
 
-Same as managed `## Session-start ritual` below; substitute `task` for `deft` (`task session:start`, `task verify:session-ritual -- --tier=gated`, `task verify:tools`, `task doctor`, `task verify:cache-fresh`, `task agents:refresh`, `npm i -g @deftai/directive@latest`).
+Same as managed `## Session-start ritual` below; substitute `task` for `deft` (`task session:start`, `task session:ready`, `task verify:session-ritual -- --tier=gated`, `task verify:tools`, `task doctor`, `task verify:cache-fresh`, `task agents:refresh`, `npm i -g @deftai/directive@latest`).
 
 ## Session routing (#2176)
 
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=1907fe769c3a refreshed=2026-08-18T22:26:57Z session=43595180dafd -->
+<!-- deft:managed-section v3 sha=d7c319d80b34 refreshed=2026-08-19T18:43:20Z session=db8e52419d40 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -178,7 +178,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session-start ritual (#1149)
 
-! On **mutation** session start, run `deft session:start`; before code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft verify:cache-fresh` / `deft agents:refresh` / `npm i -g @deftai/directive@latest`; #1149 / #1348) — `.deft/core/commands.md` § Session-start ritual. ! SCM mirror tip (#3124): restate existence + get-the-most user-visible when tip fires (depth `commands.md`). ⊗ Absorb tip without restating.
+! On **mutation** session start, run `deft session:start`; before code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft verify:cache-fresh` / `deft agents:refresh` / `npm i -g @deftai/directive@latest`; #1149 / #1348) — `.deft/core/commands.md` § Session-start ritual. Recovery: `deft session:ready` (one-shot: start + gated ritual + cache recovery; #2993). ! SCM mirror tip (#3124): restate existence + get-the-most user-visible when tip fires (depth `commands.md`). ⊗ Absorb tip without restating.
 
 ## WIP cap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Consumer AGENTS.md names `session:ready` on the #1149 ritual line (#3506).** The deposit pointer now includes the one-shot recovery verb (`session:start` + gated ritual + cache recovery). `agents_entry_contract` markers follow. Closes #3506. Refs #3500, #2993, #1149, #1309, PR 3509.
 - **CI merge-gate exempts `verify:branch` on a post-merge master checkout (#3499).** The documented `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` env is set on the two `task check:merge` steps only. Local `task check` and git hooks stay fail-closed. Closes #3499. Refs #1704, #747.
 - **Land leftover completed-tracked artifact for #3502 (#3264 / #1358).** The #3502 xBRIEF stayed in `xbrief/active/` after squash, so `verify:orphan-active` failed on later PRs. Moved to `xbrief/completed/`. Does not reopen or recut that issue. Refs #2321.
 - **Gated ritual CLI failure prints `session:ready` recovery (#3506).** Direct `verify:session-ritual --tier=gated` now appends the one-shot recovery line and the audited `session:start -- --defer cache_fresh=<reason>` soft path. `--json` includes `recovery_tier`. Tracking: #3506. Refs #3500, #2993, #1149, #3507.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -16,7 +16,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session-start ritual (#1149)
 
-! On **mutation** session start, run `deft session:start`; before code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft verify:cache-fresh` / `deft agents:refresh` / `npm i -g @deftai/directive@latest`; #1149 / #1348) — `.deft/core/commands.md` § Session-start ritual. ! SCM mirror tip (#3124): restate existence + get-the-most user-visible when tip fires (depth `commands.md`). ⊗ Absorb tip without restating.
+! On **mutation** session start, run `deft session:start`; before code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft verify:cache-fresh` / `deft agents:refresh` / `npm i -g @deftai/directive@latest`; #1149 / #1348) — `.deft/core/commands.md` § Session-start ritual. Recovery: `deft session:ready` (one-shot: start + gated ritual + cache recovery; #2993). ! SCM mirror tip (#3124): restate existence + get-the-most user-visible when tip fires (depth `commands.md`). ⊗ Absorb tip without restating.
 
 ## WIP cap
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -312,7 +312,12 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     shape: "doc",
     header: "Session-start ritual (#1149)",
     canonicalHome: "commands.md",
-    pointerHints: ["deft session:start", "deft verify:session-ritual", "deft session:ready", "#1149"],
+    pointerHints: [
+      "deft session:start",
+      "deft verify:session-ritual",
+      "deft session:ready",
+      "#1149",
+    ],
     canonicalBodyMarkers: [
       "sessionRitualStalenessHours",
       "DEFT_SESSION_RITUAL_SKIP",

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -23,6 +23,7 @@ const FIXTURES_DIR = join(
 
 const PROPAGATION_COMMAND_MARKERS: ReadonlyArray<readonly [string, string]> = [
   ["deft session:start", "task session:start"],
+  ["deft session:ready", "task session:ready"],
   ["deft verify:session-ritual", "task verify:session-ritual"],
   ["deft verify:tools", "task verify:tools"],
   ["deft triage:welcome --onboard", "task triage:welcome --onboard"],
@@ -58,6 +59,7 @@ const PROPAGATION_COMMAND_MARKERS: ReadonlyArray<readonly [string, string]> = [
 
 const CONSUMER_FORBIDDEN_BARE_TASK_MARKERS = [
   "task session:start",
+  "task session:ready",
   "task verify:session-ritual",
   "task verify:tools",
   "task doctor",
@@ -310,7 +312,7 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     shape: "doc",
     header: "Session-start ritual (#1149)",
     canonicalHome: "commands.md",
-    pointerHints: ["deft session:start", "deft verify:session-ritual", "#1149"],
+    pointerHints: ["deft session:start", "deft verify:session-ritual", "deft session:ready", "#1149"],
     canonicalBodyMarkers: [
       "sessionRitualStalenessHours",
       "DEFT_SESSION_RITUAL_SKIP",


### PR DESCRIPTION
## Summary

Clause 2 of #3506: the consumer deposit now names `deft session:ready` on the #1149 ritual line.

Clause 1 already printed the one-shot on the CLI (PR 3509). Consumers still could not discover it because `agents-entry.md` listed `session:start` and `verify:session-ritual` only.

## Changes

- Add the `deft session:ready` recovery pointer to `content/templates/agents-entry.md` (one-shot: start + gated ritual + cache recovery; #2993).
- Refresh `AGENTS.md` managed section via `agents:refresh`.
- Update `agents_entry_contract` `pointerHints` and the `deft`/`task` dual pair.
- CHANGELOG `[Unreleased]` Fixed entry. Clause 1 entry left as shipped.

## Verify

Local (host constraint: no full `task check`):

- `agents:refresh` (vendored CLI; no go-task wrapper)
- `pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts` -- 75/75
- `task verify:agents-md-budget` -- managed 161/162, 15685/15700
- `task verify:encoding`, `task verify:forward-coverage`, `task verify:branch`

CI is the full merge chokepoint.

Closes #3506.
Refs #3500, #2993, #1149, #1309, PR 3509.
