### PR TITLE
fix(policy): do not append no-op rows to policy-changes.log (Closes #3528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Policy ledger no-ops no longer dirty the tree (#3528).** Typed-policy writers and the welcome path now share one convention: real transitions append `changed=true`; a no-op `product-signal:enable` (and sibling policy verbs) leave `meta/policy-changes.log` unmodified. Existing rows stay. Refs #1250, #746.
+
 ### Removed
 
 ## [0.105.0] - 2026-08-19

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -874,7 +874,7 @@ Six phases, each detection-bound so a partial re-run resumes cleanly:
 
 ### Audit trail
 
-Every policy write (Phase 2 / Phase 4) appends an entry to `meta/policy-changes.log` with `actor=triage-welcome`, the field name, the new value, the previous value, and a `changed=true|false` token. This mirrors the existing `scripts/policy.py::set_policy` audit format so `git grep triage-welcome meta/policy-changes.log` surfaces every ritual run.
+Every **real** policy write (Phase 2 / Phase 4, and every other `meta/policy-changes.log` writer) appends an entry with the field name, the new value, the previous value, and a machine-readable `changed=true` token. Welcome rows still use `actor=triage-welcome`. Typed-policy verbs (`product-signal:enable`, `policy:enable-value-feedback`, `policy:set-ceremony-dial`, `policy:allow-direct-commits`, …) stamp the same `changed=` token. A no-op (value already matched) does **not** append, so `task check` cannot dirty the tracked ledger. Historical rows may omit the token or record `changed=false`; do not rewrite or prune them (#3528 / #746). `git grep 'changed=true' meta/policy-changes.log` is the transition history.
 
 ### References
 

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1159,6 +1159,23 @@ describe("native policy-set handler (#2022)", () => {
     expect(readFileSync(auditLogPath(), "utf8")).toBe(before);
   });
 
+  it("equal-value wip-cap still persists a legacy plan.policy key migration", async () => {
+    writeFileSync(
+      projectDefPath(),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: { title: "T", status: "running", items: [], policy: { wipCap: 5 } },
+      }),
+      "utf8",
+    );
+    const result = await runPolicy(["wip-cap", "--set", "5", "--confirm", "--project-root", root]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("audit:");
+    const plan = JSON.parse(readFileSync(projectDefPath(), "utf8")).plan as Record<string, unknown>;
+    expect(plan.policy).toBeUndefined();
+    expect((plan["x-directive/policy"] as Record<string, unknown>).wipCap).toBe(5);
+  });
+
   it("wip-cap honors --actor / --note in the audit row", async () => {
     const result = await runPolicy([
       "wip-cap",

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1141,12 +1141,22 @@ describe("native policy-set handler (#2022)", () => {
     expect(result.code).toBe(0);
     expect(result.out).toBe(
       "\u2713 plan.policy.wipCap=5.\n" +
-        "  audit: meta/policy-changes.log :: actor=deft policy set wip-cap wipCap=5 previous=None\n" +
+        "  audit: meta/policy-changes.log :: actor=deft policy set wip-cap wipCap=5 previous=None changed=true\n" +
         "[deft policy] plan.policy.wipCap=5 (source: typed).\n",
     );
     expect(readPolicyBlock().wipCap).toBe(5);
     expect(existsSync(auditLogPath())).toBe(true);
     expect(readFileSync(auditLogPath(), "utf8")).toContain("wipCap=5 previous=None");
+  });
+
+  it("wip-cap no-op does not append the audit log (#3528)", async () => {
+    await runPolicy(["wip-cap", "--set", "5", "--confirm", "--project-root", root]);
+    resetHandlerCacheForTests();
+    const before = readFileSync(auditLogPath(), "utf8");
+    const result = await runPolicy(["wip-cap", "--set", "5", "--confirm", "--project-root", root]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("ledger unchanged");
+    expect(readFileSync(auditLogPath(), "utf8")).toBe(before);
   });
 
   it("wip-cap honors --actor / --note in the audit row", async () => {
@@ -1210,7 +1220,7 @@ describe("native policy-set handler (#2022)", () => {
     expect(result.out).toBe(
       "\u2713 plan.policy.swarmSubagentBackend=composer.\n" +
         "  audit: meta/policy-changes.log :: actor=deft policy set subagent-backend " +
-        "swarmSubagentBackend=composer previous=None\n" +
+        "swarmSubagentBackend=composer previous=None changed=true\n" +
         "[deft policy] plan.policy.swarmSubagentBackend='composer' (source: typed).\n",
     );
     expect(readPolicyBlock().swarmSubagentBackend).toBe("composer");

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -2437,6 +2437,7 @@ interface PdWriteContext {
   path: string;
   data: Record<string, unknown>;
   policyBlock: Record<string, unknown>;
+  legacyMigrated: boolean;
 }
 
 /** Load PROJECT-DEFINITION for an in-place typed-field write (mirrors the .setdefault chain). */
@@ -2469,7 +2470,7 @@ function loadProjectDefinitionForWrite(projectRoot: string): PdWriteContext {
     throw new PolicySetError("PROJECT-DEFINITION 'plan' is not an object", "config");
   }
   const planObj = plan as Record<string, unknown>;
-  migrateLegacyPolicyKey(planObj);
+  const legacyMigrated = migrateLegacyPolicyKey(planObj);
   let policy = planObj[PLAN_POLICY_KEY];
   if (policy === undefined) {
     policy = {};
@@ -2478,7 +2479,7 @@ function loadProjectDefinitionForWrite(projectRoot: string): PdWriteContext {
   if (typeof policy !== "object" || policy === null || Array.isArray(policy)) {
     throw new PolicySetError("plan.policy is not an object", "config");
   }
-  return { path, data, policyBlock: policy as Record<string, unknown> };
+  return { path, data, policyBlock: policy as Record<string, unknown>, legacyMigrated };
 }
 
 /** Write plan.policy.wipCap in place + append the audit row (mirrors set_wip_cap). */
@@ -2488,10 +2489,10 @@ function writeWipCap(
   actor: string,
   note: string,
 ): { changed: boolean; auditEntry: string } {
-  const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
+  const { path, data, policyBlock, legacyMigrated } = loadProjectDefinitionForWrite(projectRoot);
   const previous = policyBlock.wipCap;
   policyBlock.wipCap = cap;
-  const changed = previous !== cap;
+  const changed = previous !== cap || legacyMigrated;
   const parts = [`actor=${actor}`, `wipCap=${cap}`, `previous=${pyRepr(previous)}`];
   if (note) parts.push(`note=${sanitizeNote(note)}`);
   const auditEntry = stampChangedToken(parts.join(" "), changed);
@@ -2510,10 +2511,10 @@ function writeSubagentBackend(
   actor: string,
   note: string,
 ): { changed: boolean; auditEntry: string } {
-  const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
+  const { path, data, policyBlock, legacyMigrated } = loadProjectDefinitionForWrite(projectRoot);
   const previous = policyBlock.swarmSubagentBackend;
   policyBlock.swarmSubagentBackend = backendId;
-  const changed = previous !== backendId;
+  const changed = previous !== backendId || legacyMigrated;
   const parts = [
     `actor=${actor}`,
     `swarmSubagentBackend=${backendId}`,

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -26,12 +26,14 @@ import {
   disclosureLine,
   migrateLegacyPolicyKey,
   PLAN_POLICY_KEY,
+  POLICY_AUDIT_NOOP_STDOUT,
   policyColonInvocation,
   policySetInvocation,
   projectDefinitionPath,
   resolvePolicy,
   resolveWipCap,
   setPolicy,
+  stampChangedToken,
 } from "@deftai/directive-core/policy";
 import { defaultWhich, type WhichFn } from "@deftai/directive-core/scm";
 import {
@@ -2489,13 +2491,15 @@ function writeWipCap(
   const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
   const previous = policyBlock.wipCap;
   policyBlock.wipCap = cap;
-  assertWriteTargetSafe(projectRoot, path);
-  atomicWriteProjectDefinition(path, data);
   const changed = previous !== cap;
   const parts = [`actor=${actor}`, `wipCap=${cap}`, `previous=${pyRepr(previous)}`];
   if (note) parts.push(`note=${sanitizeNote(note)}`);
-  const auditEntry = parts.join(" ");
-  appendAuditLog(projectRoot, auditEntry);
+  const auditEntry = stampChangedToken(parts.join(" "), changed);
+  if (changed) {
+    assertWriteTargetSafe(projectRoot, path);
+    atomicWriteProjectDefinition(path, data);
+  }
+  appendAuditLog(projectRoot, auditEntry, changed);
   return { changed, auditEntry };
 }
 
@@ -2509,8 +2513,6 @@ function writeSubagentBackend(
   const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
   const previous = policyBlock.swarmSubagentBackend;
   policyBlock.swarmSubagentBackend = backendId;
-  assertWriteTargetSafe(projectRoot, path);
-  atomicWriteProjectDefinition(path, data);
   const changed = previous !== backendId;
   const parts = [
     `actor=${actor}`,
@@ -2518,8 +2520,12 @@ function writeSubagentBackend(
     `previous=${pyRepr(previous)}`,
   ];
   if (note) parts.push(`note=${sanitizeNote(note)}`);
-  const auditEntry = parts.join(" ");
-  appendAuditLog(projectRoot, auditEntry);
+  const auditEntry = stampChangedToken(parts.join(" "), changed);
+  if (changed) {
+    assertWriteTargetSafe(projectRoot, path);
+    atomicWriteProjectDefinition(path, data);
+  }
+  appendAuditLog(projectRoot, auditEntry, changed);
   return { changed, auditEntry };
 }
 
@@ -2594,7 +2600,7 @@ function applyBranchPolicy(args: PolicySetArgs, io: DispatchIo): number {
   if (result.changed) {
     io.writeOut(`  audit: meta/policy-changes.log :: ${result.auditEntry}\n`);
   } else {
-    io.writeOut("  no-op: value already matched (audit entry still appended for trail).\n");
+    io.writeOut(`${POLICY_AUDIT_NOOP_STDOUT}\n`);
   }
   io.writeOut(`${disclosureLine(resolvePolicy(args.projectRoot))}\n`);
   return 0;
@@ -2624,7 +2630,7 @@ function applyWipCap(args: PolicySetArgs, io: DispatchIo): number {
   if (res.changed) {
     io.writeOut(`  audit: meta/policy-changes.log :: ${res.auditEntry}\n`);
   } else {
-    io.writeOut("  no-op: value already matched (audit entry still appended for trail).\n");
+    io.writeOut(`${POLICY_AUDIT_NOOP_STDOUT}\n`);
   }
   const result = resolveWipCap(args.projectRoot);
   io.writeOut(`[deft policy] plan.policy.wipCap=${result.cap} (source: ${result.source}).\n`);
@@ -2643,7 +2649,7 @@ function applySubagentBackend(args: PolicySetArgs, io: DispatchIo): number {
   if (res.changed) {
     io.writeOut(`  audit: meta/policy-changes.log :: ${res.auditEntry}\n`);
   } else {
-    io.writeOut("  no-op: value already matched (audit entry still appended for trail).\n");
+    io.writeOut(`${POLICY_AUDIT_NOOP_STDOUT}\n`);
   }
   const result = resolveSwarmSubagentBackend(args.projectRoot);
   io.writeOut(

--- a/packages/cli/src/policy.test.ts
+++ b/packages/cli/src/policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -348,6 +348,8 @@ describe("run show + set integration", () => {
     const { code, out } = captureRun(["enforce-branches", "--project-root", r]);
     expect(code).toBe(0);
     expect(out).toContain("no-op");
+    expect(out).toContain("ledger unchanged");
+    expect(existsSync(join(r, "meta", "policy-changes.log"))).toBe(false);
   });
 
   it("returns config error for malformed project definition on set", () => {

--- a/packages/cli/src/policy.test.ts
+++ b/packages/cli/src/policy.test.ts
@@ -340,7 +340,7 @@ describe("run show + set integration", () => {
           title: "T",
           status: "running",
           items: [],
-          policy: { allowDirectCommitsToMaster: false, wipCap: 5 },
+          "x-directive/policy": { allowDirectCommitsToMaster: false, wipCap: 5 },
         },
       }),
       { encoding: "utf8" },

--- a/packages/cli/src/policy.ts
+++ b/packages/cli/src/policy.ts
@@ -27,6 +27,7 @@ import {
   NO_DEFT_DIRECTIVE_DISABLED_MESSAGE,
   NO_DEFT_DIRECTIVE_FLAG_NAME,
   NO_DEFT_DIRECTIVE_INCONSISTENT_MESSAGE,
+  POLICY_AUDIT_NOOP_STDOUT,
   policyColonInvocation,
   projectDefinitionPath,
   pythonListRepr,
@@ -452,9 +453,7 @@ function runSet(args: SetArgs): number {
     if (changed) {
       process.stdout.write(`  audit: meta/policy-changes.log :: ${auditEntry}\n`);
     } else {
-      process.stdout.write(
-        "  no-op: value already matched (audit entry still appended for trail).\n",
-      );
+      process.stdout.write(`${POLICY_AUDIT_NOOP_STDOUT}\n`);
     }
     process.stdout.write(`${disclosureLine(resolvePolicy(projectRoot))}\n`);
     return 0;
@@ -542,9 +541,7 @@ function runAllowBotMerge(args: SetArgs): number {
     if (changed) {
       process.stdout.write(`  audit: meta/policy-changes.log :: ${auditEntry}\n`);
     } else {
-      process.stdout.write(
-        "  no-op: value already matched (audit entry still appended for trail).\n",
-      );
+      process.stdout.write(`${POLICY_AUDIT_NOOP_STDOUT}\n`);
     }
     const line = humanMergeDisclosureLine(resolveHumanMergePolicy(projectRoot));
     if (line !== null) {

--- a/packages/core/src/policy/ceremony-dial.test.ts
+++ b/packages/core/src/policy/ceremony-dial.test.ts
@@ -380,6 +380,18 @@ describe("resolveCeremonyDial + policy surface", () => {
 
     const audit = readFileSync(join(root, "meta", "policy-changes.log"), "utf8");
     expect(audit).toContain("ceremonyDial.override=rapid");
+    expect(audit).toContain("changed=true");
+
+    const before = audit;
+    const noop = setCeremonyDial(root, {
+      override: "rapid",
+      enabled: true,
+      confirm: true,
+      actor: "test",
+    });
+    expect(noop.changed).toBe(false);
+    expect(noop.stdout).toContain("ledger unchanged");
+    expect(readFileSync(join(root, "meta", "policy-changes.log"), "utf8")).toBe(before);
   });
 
   it("mergeCeremonyDialDeferrals does not clobber operator reasons", () => {

--- a/packages/core/src/policy/ceremony-dial.ts
+++ b/packages/core/src/policy/ceremony-dial.ts
@@ -27,7 +27,12 @@ import {
 } from "../vbrief-build/project-definition-io.js";
 import { migrateLegacyPolicyKey, PLAN_POLICY_KEY, readPlanPolicy } from "./plan-extensions.js";
 import { policyColonInvocation } from "./policy-invocation.js";
-import { appendAuditLog, loadProjectDefinition, projectDefinitionPath } from "./resolve.js";
+import {
+  appendAuditLog,
+  loadProjectDefinition,
+  POLICY_AUDIT_NOOP_STDOUT,
+  projectDefinitionPath,
+} from "./resolve.js";
 
 /** Canonical dotted policy field name. */
 export const FIELD_CEREMONY_DIAL = "plan.policy.ceremonyDial";
@@ -753,16 +758,14 @@ export function setCeremonyDial(
       if (note) {
         parts.push(`note=${note.replace(/\n/g, " ").replace(/\r/g, " ")}`);
       }
-      appendAuditLog(projectRoot, parts.join(" "));
+      appendAuditLog(projectRoot, parts.join(" "), changedFlag);
       return { changed: changedFlag };
     });
 
     const resolved = resolveCeremonyDial(projectRoot);
     const lines = [
       `\u2713 ${FIELD_CEREMONY_DIAL} updated.`,
-      changed
-        ? "  audit: meta/policy-changes.log updated."
-        : "  no-op: value already matched (audit entry still appended for trail).",
+      changed ? "  audit: meta/policy-changes.log updated." : POLICY_AUDIT_NOOP_STDOUT,
       formatCeremonyDialStatusLine(resolved),
     ];
     return { exitCode: 0, stdout: `${lines.join("\n")}\n`, changed };

--- a/packages/core/src/policy/ceremony-dial.ts
+++ b/packages/core/src/policy/ceremony-dial.ts
@@ -699,7 +699,7 @@ export function setCeremonyDial(
         }
       }
       const plan = data.plan as Record<string, unknown>;
-      migrateLegacyPolicyKey(plan);
+      const legacyKeyMigrated = migrateLegacyPolicyKey(plan);
       const existingPolicy = plan[PLAN_POLICY_KEY];
       if (
         typeof existingPolicy !== "object" ||
@@ -740,7 +740,9 @@ export function setCeremonyDial(
       };
       const prevParsed = parseConfig(previous).config;
       const changedFlag =
-        prevParsed.enabled !== nextBlock.enabled || prevParsed.override !== nextBlock.override;
+        prevParsed.enabled !== nextBlock.enabled ||
+        prevParsed.override !== nextBlock.override ||
+        legacyKeyMigrated;
 
       policyBlock.ceremonyDial = nextBlock;
       if (changedFlag) {

--- a/packages/core/src/policy/org-force-on-migration.ts
+++ b/packages/core/src/policy/org-force-on-migration.ts
@@ -562,6 +562,7 @@ function applyForceOn(
         : ORG_FORCE_ON_NO_BASELINE;
 
     const actor = options.actor ?? "directive-update";
+    const changed = valueFeedbackChanged || productSignalChanged;
     appendAuditLog(
       projectRoot,
       [
@@ -572,6 +573,7 @@ function applyForceOn(
         `previousValueFeedback=${JSON.stringify(normalizePolicySnapshot(markerPreviousVf))}`,
         `previousProductSignal=${JSON.stringify(normalizePolicySnapshot(markerPreviousPs))}`,
       ].join(" "),
+      changed,
     );
 
     writeMarker(projectRoot, options, {

--- a/packages/core/src/policy/plan-extensions.ts
+++ b/packages/core/src/policy/plan-extensions.ts
@@ -75,11 +75,13 @@ export function readPlanOnboarding(plan: unknown): unknown {
  * policy key is present. Used by writers so a mutation never strands a legacy
  * bare block alongside the namespaced one.
  */
-export function migrateLegacyPolicyKey(plan: Record<string, unknown>): void {
+export function migrateLegacyPolicyKey(plan: Record<string, unknown>): boolean {
   if (plan[PLAN_POLICY_KEY] === undefined && plan[LEGACY_PLAN_POLICY_KEY] !== undefined) {
     plan[PLAN_POLICY_KEY] = plan[LEGACY_PLAN_POLICY_KEY];
     delete plan[LEGACY_PLAN_POLICY_KEY];
+    return true;
   }
+  return false;
 }
 
 /** The namespaced/legacy key pairs a bare block can silently shadow (#2301). */

--- a/packages/core/src/policy/product-signal.test.ts
+++ b/packages/core/src/policy/product-signal.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -29,6 +29,9 @@ describe("product-signal policy module", () => {
     );
     enableProductSignal(root, { confirm: true });
     expect(resolveProductSignal(root).enabled).toBe(true);
+    const audit = readFileSync(join(root, "meta", "policy-changes.log"), "utf8");
+    expect(audit).toContain("changed=true");
+    expect(audit).not.toMatch(/\schanged=false(?:\s|$)/);
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -75,7 +78,7 @@ describe("product-signal policy module", () => {
     expect(line).toContain("productSignal");
   });
 
-  it("enableProductSignal no-op when already enabled", () => {
+  it("enableProductSignal no-op leaves the audit log unmodified (#3528)", () => {
     const root = mkdtempSync(join(tmpdir(), "deft-ps-pol-noop-"));
     const xbrief = join(root, "xbrief");
     mkdirSync(xbrief, { recursive: true });
@@ -86,9 +89,18 @@ describe("product-signal policy module", () => {
       }),
       "utf8",
     );
+    mkdirSync(join(root, "meta"), { recursive: true });
+    const logPath = join(root, "meta", "policy-changes.log");
+    const historical =
+      "# meta/policy-changes.log -- historical\n" +
+      "2026-07-23T20:23:26Z actor=task product-signal:enable productSignal.enabled=true previous=null\n";
+    writeFileSync(logPath, historical, "utf8");
     const result = enableProductSignal(root, { confirm: true, note: "trail" });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("no-op");
+    expect(result.changed).toBe(false);
+    expect(result.stdout).toContain("ledger unchanged");
+    expect(readFileSync(logPath, "utf8")).toBe(historical);
+    expect(existsSync(logPath)).toBe(true);
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/core/src/policy/product-signal.ts
+++ b/packages/core/src/policy/product-signal.ts
@@ -232,7 +232,7 @@ export function enableProductSignal(
         }
       }
       const plan = data.plan as Record<string, unknown>;
-      migrateLegacyPolicyKey(plan);
+      const legacyKeyMigrated = migrateLegacyPolicyKey(plan);
       const existingPolicy = plan[PLAN_POLICY_KEY];
       if (
         typeof existingPolicy !== "object" ||
@@ -260,7 +260,8 @@ export function enableProductSignal(
       const previousNormalized = resolveProductSignalFromTypedBlock(previous);
       const changedFlag =
         previousNormalized.enabled !== nextBlock.enabled ||
-        previousNormalized.sinkRepo !== nextBlock.sinkRepo;
+        previousNormalized.sinkRepo !== nextBlock.sinkRepo ||
+        legacyKeyMigrated;
       policyBlock.productSignal = nextBlock;
       if (changedFlag) {
         atomicWriteProjectDefinition(path, data);

--- a/packages/core/src/policy/product-signal.ts
+++ b/packages/core/src/policy/product-signal.ts
@@ -6,7 +6,12 @@ import {
 import { productSignalInstallForceOnSource } from "./org-force-on-migration.js";
 import { migrateLegacyPolicyKey, PLAN_POLICY_KEY, readPlanPolicy } from "./plan-extensions.js";
 import { policyColonInvocation } from "./policy-invocation.js";
-import { appendAuditLog, loadProjectDefinition, projectDefinitionPath } from "./resolve.js";
+import {
+  appendAuditLog,
+  loadProjectDefinition,
+  POLICY_AUDIT_NOOP_STDOUT,
+  projectDefinitionPath,
+} from "./resolve.js";
 
 /** Canonical registered policy field name (#2693). */
 export const FIELD_PRODUCT_SIGNAL = "plan.policy.productSignal";
@@ -272,16 +277,14 @@ export function enableProductSignal(
       if (note) {
         parts.push(`note=${note.replace(/\n/g, " ").replace(/\r/g, " ")}`);
       }
-      appendAuditLog(projectRoot, parts.join(" "));
+      appendAuditLog(projectRoot, parts.join(" "), changedFlag);
       return { changed: changedFlag };
     });
 
     const resolved = resolveProductSignal(projectRoot);
     const lines = [
       `\u2713 ${FIELD_PRODUCT_SIGNAL}.enabled=true (product-signal ON).`,
-      changed
-        ? "  audit: meta/policy-changes.log updated."
-        : "  no-op: value already matched (audit entry still appended for trail).",
+      changed ? "  audit: meta/policy-changes.log updated." : POLICY_AUDIT_NOOP_STDOUT,
       formatProductSignalStatusLine(resolved),
     ];
     return { exitCode: 0, stdout: `${lines.join("\n")}\n`, changed };

--- a/packages/core/src/policy/require-human-merge.test.ts
+++ b/packages/core/src/policy/require-human-merge.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -137,5 +137,14 @@ describe("setRequireHumanMerge", () => {
     const p = resolveHumanMergePolicy(r, {});
     expect(p.requireHumanMerge).toBe(false);
     expect(p.source).toBe("typed");
+    expect(readFileSync(join(r, "meta", "policy-changes.log"), "utf8")).toContain("changed=true");
+  });
+
+  it("no-op does not append the audit log (#3528)", () => {
+    const r = tempRoot();
+    writePd(r, { requireHumanMerge: false });
+    const { changed } = setRequireHumanMerge(r, { requireHumanMerge: false, actor: "test" });
+    expect(changed).toBe(false);
+    expect(existsSync(join(r, "meta", "policy-changes.log"))).toBe(false);
   });
 });

--- a/packages/core/src/policy/require-human-merge.test.ts
+++ b/packages/core/src/policy/require-human-merge.test.ts
@@ -147,4 +147,28 @@ describe("setRequireHumanMerge", () => {
     expect(changed).toBe(false);
     expect(existsSync(join(r, "meta", "policy-changes.log"))).toBe(false);
   });
+
+  it("equal-value set still persists a legacy plan.policy key migration", () => {
+    const r = tempRoot();
+    mkdirSync(join(r, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(r, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: { title: "t", status: "running", policy: { requireHumanMerge: false } },
+      }),
+      "utf8",
+    );
+    const { changed, auditEntry } = setRequireHumanMerge(r, {
+      requireHumanMerge: false,
+      actor: "test",
+    });
+    expect(changed).toBe(true);
+    expect(auditEntry).toContain("changed=true");
+    const plan = JSON.parse(
+      readFileSync(join(r, "xbrief", "PROJECT-DEFINITION.xbrief.json"), "utf8"),
+    ).plan as Record<string, unknown>;
+    expect(plan.policy).toBeUndefined();
+    expect((plan["x-directive/policy"] as Record<string, unknown>).requireHumanMerge).toBe(false);
+  });
 });

--- a/packages/core/src/policy/require-human-merge.ts
+++ b/packages/core/src/policy/require-human-merge.ts
@@ -382,7 +382,7 @@ export function setRequireHumanMerge(
       }
     }
     const plan = data.plan as Record<string, unknown>;
-    migrateLegacyPolicyKey(plan);
+    const legacyKeyMigrated = migrateLegacyPolicyKey(plan);
     const existingPolicy = plan[PLAN_POLICY_KEY];
     if (
       typeof existingPolicy !== "object" ||
@@ -411,7 +411,7 @@ export function setRequireHumanMerge(
       legacyDropped = true;
     }
 
-    const changed = previous !== Boolean(requireHumanMerge) || legacyDropped;
+    const changed = previous !== Boolean(requireHumanMerge) || legacyDropped || legacyKeyMigrated;
     const parts = [
       `actor=${actor}`,
       `requireHumanMerge=${requireHumanMerge ? "true" : "false"}`,

--- a/packages/core/src/policy/require-human-merge.ts
+++ b/packages/core/src/policy/require-human-merge.ts
@@ -22,7 +22,12 @@ import {
 } from "../vbrief-build/project-definition-io.js";
 import { migrateLegacyPolicyKey, PLAN_POLICY_KEY, readPlanPolicy } from "./plan-extensions.js";
 import { policyColonInvocation } from "./policy-invocation.js";
-import { appendAuditLog, loadProjectDefinition, projectDefinitionPath } from "./resolve.js";
+import {
+  appendAuditLog,
+  loadProjectDefinition,
+  projectDefinitionPath,
+  stampChangedToken,
+} from "./resolve.js";
 
 export const FIELD_REQUIRE_HUMAN_MERGE = "plan.policy.requireHumanMerge";
 export const FIELD_REQUIRE_HUMAN_MERGE_CLI_ALIAS = "requireHumanMerge";
@@ -406,8 +411,6 @@ export function setRequireHumanMerge(
       legacyDropped = true;
     }
 
-    atomicWriteProjectDefinition(path, data);
-
     const changed = previous !== Boolean(requireHumanMerge) || legacyDropped;
     const parts = [
       `actor=${actor}`,
@@ -418,8 +421,11 @@ export function setRequireHumanMerge(
     if (note) {
       parts.push(`note=${note.replace(/\n/g, " ").replace(/\r/g, " ")}`);
     }
-    const auditEntry = parts.join(" ");
-    appendAuditLog(projectRoot, auditEntry);
+    const auditEntry = stampChangedToken(parts.join(" "), changed);
+    if (changed) {
+      atomicWriteProjectDefinition(path, data);
+    }
+    appendAuditLog(projectRoot, auditEntry, changed);
     return { changed, auditEntry };
   });
 }

--- a/packages/core/src/policy/resolve.test.ts
+++ b/packages/core/src/policy/resolve.test.ts
@@ -293,6 +293,24 @@ describe("setPolicy", () => {
     expect(second.auditEntry).toContain("changed=false");
     expect(readFileSync(logPath, "utf8")).toBe(before);
   });
+
+  it("equal-value setPolicy still persists a legacy plan.policy key migration", () => {
+    const r = mkdtempSync(join(tmpdir(), "deft-policy-legacy-key-"));
+    roots.push(r);
+    writeProjectDef(r, { policy: { allowDirectCommitsToMaster: true } });
+    const result = setPolicy(r, { allowDirectCommits: true, actor: "test" });
+    expect(result.changed).toBe(true);
+    expect(result.auditEntry).toContain("changed=true");
+    const plan = (
+      JSON.parse(readFileSync(join(r, "xbrief", "PROJECT-DEFINITION.xbrief.json"), "utf8")) as {
+        plan: Record<string, unknown>;
+      }
+    ).plan;
+    expect(plan.policy).toBeUndefined();
+    expect((plan["x-directive/policy"] as Record<string, unknown>).allowDirectCommitsToMaster).toBe(
+      true,
+    );
+  });
 });
 
 describe("appendAuditLog (#3528)", () => {

--- a/packages/core/src/policy/resolve.test.ts
+++ b/packages/core/src/policy/resolve.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -18,11 +18,13 @@ import {
   renderText,
 } from "./index.js";
 import {
+  appendAuditLog,
   coerceLegacyNarrative,
   ENV_BYPASS,
   type PolicyResult,
   resolvePolicy,
   setPolicy,
+  stampChangedToken,
 } from "./resolve.js";
 import { countVbriefWip, DEFAULT_WIP_CAP, resolveWipCap } from "./wip.js";
 
@@ -275,6 +277,41 @@ describe("setPolicy", () => {
     });
     setPolicy(r, { allowDirectCommits: false, actor: "t" });
     expect(resolvePolicy(r).source).toBe("typed");
+  });
+
+  it("setPolicy no-op does not append the audit log (#3528)", () => {
+    const r = mkdtempSync(join(tmpdir(), "deft-policy-noop-"));
+    roots.push(r);
+    writeProjectDef(r, {});
+    const first = setPolicy(r, { allowDirectCommits: true, actor: "test" });
+    expect(first.changed).toBe(true);
+    expect(first.auditEntry).toContain("changed=true");
+    const logPath = join(r, "meta", "policy-changes.log");
+    const before = readFileSync(logPath, "utf8");
+    const second = setPolicy(r, { allowDirectCommits: true, actor: "test" });
+    expect(second.changed).toBe(false);
+    expect(second.auditEntry).toContain("changed=false");
+    expect(readFileSync(logPath, "utf8")).toBe(before);
+  });
+});
+
+describe("appendAuditLog (#3528)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+  });
+
+  it("stampChangedToken is idempotent and encodes both sides", () => {
+    expect(stampChangedToken("actor=t field=x", true)).toBe("actor=t field=x changed=true");
+    expect(stampChangedToken("actor=t field=x", false)).toBe("actor=t field=x changed=false");
+    expect(stampChangedToken("actor=t changed=true", false)).toBe("actor=t changed=true");
+  });
+
+  it("does not create the log on changed=false", () => {
+    const r = mkdtempSync(join(tmpdir(), "deft-audit-skip-"));
+    roots.push(r);
+    appendAuditLog(r, "actor=test field=x", false);
+    expect(existsSync(join(r, "meta", "policy-changes.log"))).toBe(false);
   });
 });
 

--- a/packages/core/src/policy/resolve.ts
+++ b/packages/core/src/policy/resolve.ts
@@ -279,7 +279,7 @@ export function setPolicy(
       }
     }
     const plan = data.plan as Record<string, unknown>;
-    migrateLegacyPolicyKey(plan);
+    const legacyKeyMigrated = migrateLegacyPolicyKey(plan);
     const existingPolicy = plan[PLAN_POLICY_KEY];
     if (
       typeof existingPolicy !== "object" ||
@@ -309,7 +309,7 @@ export function setPolicy(
       legacyDropped = true;
     }
 
-    const changed = previous !== Boolean(allowDirectCommits) || legacyDropped;
+    const changed = previous !== Boolean(allowDirectCommits) || legacyDropped || legacyKeyMigrated;
     const parts = [
       `actor=${actor}`,
       `allowDirectCommitsToMaster=${allowDirectCommits ? "true" : "false"}`,

--- a/packages/core/src/policy/resolve.ts
+++ b/packages/core/src/policy/resolve.ts
@@ -21,6 +21,19 @@ export const LEGACY_NARRATIVE_KEY = "Allow direct commits to master";
 /** Audit log relative path (#746). */
 export const AUDIT_LOG_REL_PATH = "meta/policy-changes.log";
 
+/** Operator line when a policy writer matches current state and does not append (#3528). */
+export const POLICY_AUDIT_NOOP_STDOUT = "  no-op: value already matched (ledger unchanged).";
+
+const CHANGED_TOKEN_RE = /(?:^|\s)changed=(?:true|false)(?:\s|$)/;
+
+/** Stamp a machine-readable `changed=true|false` token (#3528 / UPGRADING.md). */
+export function stampChangedToken(entry: string, changed: boolean): string {
+  if (CHANGED_TOKEN_RE.test(entry)) {
+    return entry;
+  }
+  return `${entry} changed=${changed ? "true" : "false"}`;
+}
+
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 
 export type PolicySource = "typed" | "legacy-narrative" | "env-bypass" | "default-fail-closed";
@@ -204,10 +217,15 @@ function nowIso(): string {
   return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
-/** Append a one-line audit entry to meta/policy-changes.log (#746). */
-export function appendAuditLog(projectRoot: string, entry: string): string {
+/** Append a one-line audit entry to meta/policy-changes.log (#746).
+ * No-op (`changed=false`) does not create or modify the tracked file (#3528). */
+export function appendAuditLog(projectRoot: string, entry: string, changed = true): string {
   const root = pathResolve(projectRoot);
   const logPath = join(root, AUDIT_LOG_REL_PATH);
+  const stamped = stampChangedToken(entry, changed);
+  if (!changed) {
+    return logPath;
+  }
   // #2980 wave D: product write sink routes through containedWrite.
   if (!existsSync(logPath)) {
     const header =
@@ -223,7 +241,7 @@ export function appendAuditLog(projectRoot: string, entry: string): string {
   containedWrite({
     root,
     target: AUDIT_LOG_REL_PATH,
-    data: `${nowIso()} ${entry}\n`,
+    data: `${nowIso()} ${stamped}\n`,
     mode: "append",
   });
   return logPath;
@@ -291,8 +309,6 @@ export function setPolicy(
       legacyDropped = true;
     }
 
-    atomicWriteProjectDefinition(path, data);
-
     const changed = previous !== Boolean(allowDirectCommits) || legacyDropped;
     const parts = [
       `actor=${actor}`,
@@ -305,8 +321,11 @@ export function setPolicy(
     if (note) {
       parts.push(`note=${note.replace(/\n/g, " ").replace(/\r/g, " ")}`);
     }
-    const auditEntry = parts.join(" ");
-    appendAuditLog(projectRoot, auditEntry);
+    const auditEntry = stampChangedToken(parts.join(" "), changed);
+    if (changed) {
+      atomicWriteProjectDefinition(path, data);
+    }
+    appendAuditLog(projectRoot, auditEntry, changed);
     return { changed, auditEntry };
   });
 }

--- a/packages/core/src/policy/value-feedback.test.ts
+++ b/packages/core/src/policy/value-feedback.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
@@ -224,6 +224,8 @@ describe("enableValueFeedback disclosure gate", () => {
     const result = enableValueFeedback(root, { confirm: true, actor: "test" });
     expect(result.exitCode).toBe(0);
     expect(result.changed).toBe(false);
+    expect(result.stdout).toContain("ledger unchanged");
+    expect(existsSync(join(root, "meta", "policy-changes.log"))).toBe(false);
     expect(resolveValueFeedback(root)).toMatchObject({
       enabled: true,
       emitEvents: false,

--- a/packages/core/src/policy/value-feedback.test.ts
+++ b/packages/core/src/policy/value-feedback.test.ts
@@ -212,7 +212,7 @@ describe("enableValueFeedback disclosure gate", () => {
 
   it("preserves existing sub-flags on idempotent re-enable", () => {
     const root = makeRepo({
-      policy: {
+      "x-directive/policy": {
         valueFeedback: {
           enabled: true,
           emitEvents: false,

--- a/packages/core/src/policy/value-feedback.ts
+++ b/packages/core/src/policy/value-feedback.ts
@@ -6,7 +6,12 @@ import {
 import { valueFeedbackInstallForceOnSource } from "./org-force-on-migration.js";
 import { migrateLegacyPolicyKey, PLAN_POLICY_KEY, readPlanPolicy } from "./plan-extensions.js";
 import { policyColonInvocation } from "./policy-invocation.js";
-import { appendAuditLog, loadProjectDefinition, projectDefinitionPath } from "./resolve.js";
+import {
+  appendAuditLog,
+  loadProjectDefinition,
+  POLICY_AUDIT_NOOP_STDOUT,
+  projectDefinitionPath,
+} from "./resolve.js";
 import { isTrustedOrgAutoEnable, type OrgAutoEnableOptions } from "./value-feedback-autoenable.js";
 
 /** Canonical registered policy field name (matches other FIELD_* dotted paths). */
@@ -402,16 +407,14 @@ export function enableValueFeedback(
       if (note) {
         parts.push(`note=${note.replace(/\n/g, " ").replace(/\r/g, " ")}`);
       }
-      appendAuditLog(projectRoot, parts.join(" "));
+      appendAuditLog(projectRoot, parts.join(" "), changedFlag);
       return { changed: changedFlag };
     });
 
     const resolved = resolveValueFeedback(projectRoot);
     const lines = [
       `\u2713 ${FIELD_VALUE_FEEDBACK}.enabled=true (value-feedback ON).`,
-      changed
-        ? "  audit: meta/policy-changes.log updated."
-        : "  no-op: value already matched (audit entry still appended for trail).",
+      changed ? "  audit: meta/policy-changes.log updated." : POLICY_AUDIT_NOOP_STDOUT,
       formatValueFeedbackStatusLine(resolved),
     ];
     return { exitCode: 0, stdout: `${lines.join("\n")}\n`, changed };
@@ -483,7 +486,7 @@ export function clearValueFeedback(
       if (note) {
         parts.push(`note=${note.replace(/\n/g, " ").replace(/\r/g, " ")}`);
       }
-      appendAuditLog(projectRoot, parts.join(" "));
+      appendAuditLog(projectRoot, parts.join(" "), true);
       return { changed: true };
     });
 

--- a/packages/core/src/policy/value-feedback.ts
+++ b/packages/core/src/policy/value-feedback.ts
@@ -348,7 +348,7 @@ export function enableValueFeedback(
         }
       }
       const plan = data.plan as Record<string, unknown>;
-      migrateLegacyPolicyKey(plan);
+      const legacyKeyMigrated = migrateLegacyPolicyKey(plan);
       const existingPolicy = plan[PLAN_POLICY_KEY];
       if (
         typeof existingPolicy !== "object" ||
@@ -388,7 +388,8 @@ export function enableValueFeedback(
         previousNormalized.enabled !== nextBlock.enabled ||
         previousNormalized.emitEvents !== nextBlock.emitEvents ||
         previousNormalized.sessionLine !== nextBlock.sessionLine ||
-        previousNormalized.upstreamPrompt !== nextBlock.upstreamPrompt;
+        previousNormalized.upstreamPrompt !== nextBlock.upstreamPrompt ||
+        legacyKeyMigrated;
       policyBlock.valueFeedback = nextBlock;
       if (changedFlag) {
         atomicWriteProjectDefinition(path, data);

--- a/packages/core/src/triage/welcome/writers-branches.test.ts
+++ b/packages/core/src/triage/welcome/writers-branches.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -67,6 +68,10 @@ describe("writers error and edge branches", () => {
     expect(readFileSync(join(root, "meta", "policy-changes.log"), "utf8")).toContain(
       "actor=tester",
     );
+    const before = readFileSync(join(root, "meta", "policy-changes.log"), "utf8");
+    const [unchanged] = writeTriageScope(root, rules, { presetLabel: "small", actor: "tester" });
+    expect(unchanged).toBe(false);
+    expect(readFileSync(join(root, "meta", "policy-changes.log"), "utf8")).toBe(before);
   });
 
   it("writeWipCap fails for invalid values and missing project definition", () => {
@@ -80,6 +85,7 @@ describe("writers error and edge branches", () => {
     seedPd(root, { plan: { policy: { wipCap: 8 } } });
     const [changed] = writeWipCap(root, 8, { actor: "tester" });
     expect(changed).toBe(false);
+    expect(existsSync(join(root, "meta", "policy-changes.log"))).toBe(false);
   });
 
   it("writeWipCapDecision fails when PROJECT-DEFINITION is missing or plan is malformed", () => {
@@ -108,12 +114,14 @@ describe("writers error and edge branches", () => {
       actor: "tester",
     });
     // Idempotent re-write with same acceptance flag.
+    const before = readFileSync(join(root, "meta", "policy-changes.log"), "utf8");
     const [changedAgain] = writeWipCapDecision(root, {
       acceptedDefault: false,
       value: 7,
       actor: "tester",
     });
     expect(changedAgain).toBe(false);
+    expect(readFileSync(join(root, "meta", "policy-changes.log"), "utf8")).toBe(before);
   });
 
   it("writeWipCapDecision dropping acceptedDefault clears a prior override value", () => {

--- a/packages/core/src/triage/welcome/writers.ts
+++ b/packages/core/src/triage/welcome/writers.ts
@@ -20,6 +20,7 @@ import {
   PLAN_ONBOARDING_KEY,
   PLAN_POLICY_KEY,
 } from "../../policy/plan-extensions.js";
+import { stampChangedToken } from "../../policy/resolve.js";
 import { projectDefinitionMutationLock } from "../../vbrief-build/project-definition-io.js";
 import {
   AUDIT_LOG_REL_PATH,
@@ -37,9 +38,13 @@ function utcIso(): string {
   return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
-export function appendAuditEntry(projectRoot: string, entry: string): string {
+export function appendAuditEntry(projectRoot: string, entry: string, changed = true): string {
   const root = resolve(projectRoot);
   const logPath = join(root, AUDIT_LOG_REL_PATH);
+  const stamped = stampChangedToken(entry, changed);
+  if (!changed) {
+    return logPath;
+  }
   // #2980 wave D: product write sink routes through containedWrite.
   mkdirSync(root, { recursive: true });
   if (!existsSync(logPath)) {
@@ -53,7 +58,7 @@ export function appendAuditEntry(projectRoot: string, entry: string): string {
   containedWrite({
     root,
     target: AUDIT_LOG_REL_PATH,
-    data: `${utcIso()} ${entry}\n`,
+    data: `${utcIso()} ${stamped}\n`,
     mode: "append",
   });
   return logPath;
@@ -130,7 +135,7 @@ export function writeTriageScope(
       `rule_count=${rules.length}`,
       `changed=${changed ? "true" : "false"}`,
     ].join(" ");
-    appendAuditEntry(projectRoot, auditEntry);
+    appendAuditEntry(projectRoot, auditEntry, changed);
     return [changed, auditEntry];
   });
 }
@@ -189,7 +194,7 @@ export function writeWipCapDecision(
       `acceptedDefault=${acceptedDefault ? "true" : "false"}`,
       `changed=${changed ? "true" : "false"}`,
     ].join(" ");
-    appendAuditEntry(projectRoot, auditEntry);
+    appendAuditEntry(projectRoot, auditEntry, changed);
     return [changed, auditEntry];
   });
 }
@@ -265,7 +270,7 @@ export function writeWipCap(
     const auditEntry =
       `actor=${actor} field=plan.policy.wipCap value=${wipCap} previous=${JSON.stringify(previous)} ` +
       `changed=${changed ? "true" : "false"}`;
-    appendAuditEntry(projectRoot, auditEntry);
+    appendAuditEntry(projectRoot, auditEntry, changed);
     return [changed, auditEntry];
   });
 }

--- a/xbrief/active/2026-08-20-3528-policy-changeslog-holds-two-contradictory-no-op-conventions.xbrief.json
+++ b/xbrief/active/2026-08-20-3528-policy-changeslog-holds-two-contradictory-no-op-conventions.xbrief.json
@@ -1,0 +1,177 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3528",
+    "updated": "2026-08-20T03:17:35Z"
+  },
+  "plan": {
+    "title": "policy-changes.log holds two contradictory no-op conventions; 63 of 236 rows record nothing (#1250 vs typed-policy writers)",
+    "status": "running",
+    "narratives": {
+      "Description": "Typed-policy writers append meta/policy-changes.log even on no-op while the #1250 welcome path suppresses those rows. That contradiction dirties the tree during task check and dilutes a security ledger. Pick one convention, record it, and stop no-op appends from leaving a tracked dirty file.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3528",
+      "Overview": "## Summary\n\n`meta/policy-changes.log` carries two contradictory no-op conventions. The typed-policy verbs append an audit row even when nothing changed; the #1250 welcome path suppresses it. Neither is recorded as a decision. The \"always append\" side dominates, and 63 of the ledger's 236 rows now record that nothing happened.\n\nThe operational cost is that a read-only-in-effect verb dirties a tracked file, which trips release Step 1 pre-flight.\n\n## Observed\n\nDuring the v0.105.0 cut, `task check` ran a `product-signal:enable` and left the tree dirty with:\n\n```\n2026-08-20T00:28:20Z actor=task product-signal:enable productSignal.enabled=true\n  sinkRepo=deftai/product-signal previous={\"enabled\":true,\"sinkRepo\":\"deftai/product-signal\"}\n```\n\nNew value equals previous value.\n\nLedger composition (236 rows):\n\n| Rows | Verb | Real transitions |\n|---|---|---|\n| 64 | `product-signal:enable` | **1** (the initial `previous=null` on 2026-07-23) |\n| 45 | `policy:enforce-branches` | 45 — genuine |\n| 45 | `policy:allow-direct-commits` | 45 — genuine |\n| 82 | assorted `actor=deft` one-offs | genuine |\n\nThe 90 enforce/allow rows are repetitive but legitimate — they are the release ritual flipping branch protection off and back on, and each is a real state change. The no-op population is the 63 `product-signal:enable` rows.\n\n## This is deliberate, which is the actual problem\n\n`packages/core/src/policy/product-signal.ts:256-276` computes `changedFlag`, guards the PROJECT-DEFINITION write on it, then appends unconditionally:\n\n```ts\nconst changedFlag =\n  previousNormalized.enabled !== nextBlock.enabled ||\n  previousNormalized.sinkRepo !== nextBlock.sinkRepo;\npolicyBlock.productSignal = nextBlock;\nif (changedFlag) {\n  atomicWriteProjectDefinition(path, data);   // write is guarded\n}\n...\nappendAuditLog(projectRoot, parts.join(\" \"));  // append is not\n```\n\nand says so to the operator:\n\n```\nno-op: value already matched (audit entry still appended for trail).\n```\n\nThe same shape and the same string appear in `ceremony-dial.ts:756`, `value-feedback.ts:405`, and `require-human-merge.ts:422`. So the typed-policy family consistently chose \"record the attempt.\"\n\n#1250 chose the opposite for the wipCap welcome path (`packages/core/src/triage/welcome/onboard.ts:115`), where accepting the default deliberately does **not** materialize the field or write a row.\n\nBoth positions are defensible. Recording attempts has real value for a security-relevant ledger — \"who tried to flip this and when\" is not nothing. Suppressing no-ops keeps the trail readable. What is not defensible is holding both in the same file with no decision explaining which applies where.\n\n## Why it matters beyond tidiness\n\n1. **Tree dirtying before a release.** The append happens during `task check`, so a verb that changed no state leaves a tracked file modified. Release Step 1 is `git status --porcelain`, so this must be reverted or committed before every cut. It surfaced exactly that way on v0.105.0.\n2. **Signal dilution in a security artifact.** This ledger is the audit trail for `allowDirectCommitsToMaster` transitions (#746/#747) and was hardened against symlink redirection in #2470. It is meant to be read during incident review. A quarter of it saying \"nothing changed\" is the failure mode audit logs die of.\n3. **The `previous=` field already carries the information.** A reader can distinguish a real transition from a no-op by comparing new against `previous` — but only by parsing every row, which is what suppression or an explicit token would avoid.\n\n## Proposed change\n\nPick one convention and record it. Either direction closes this:\n\n**Option A — suppress no-ops.** Guard `appendAuditLog` on `changedFlag` in the four typed-policy writers, matching #1250. Simplest, and makes the ledger all-signal.\n\n**Option B — keep recording attempts, mark them.** Add an explicit `changed=true|false` token to the row and keep appending. `content/UPGRADING.md:868` documents exactly this token for the `actor=triage-welcome` rows, so the format precedent already exists in-tree. A reader greps `changed=true` for the transition history. This preserves the \"who tried\" value that the current copy is reaching for.\n\n**Either way**, the no-op append must stop dirtying the tree during `task check`, or `product-signal:enable` should not run there at all.\n\nOption B is the better fit if the \"for trail\" intent is genuine, because it keeps the evidence and makes it filterable. Option A is right if that intent was never load-bearing.\n\n⊗ Rewriting or pruning existing rows. The ledger is append-only by design (#746) and hardened (#2470); historical no-op rows stay.\n\n## Acceptance\n\n- One convention applies to every writer of `meta/policy-changes.log`, recorded as a decision (`task decision:write`) naming which and why.\n- `#1250`'s welcome path and the typed-policy verbs agree.\n- A `product-signal:enable` that changes nothing does not leave a tracked file modified after `task check`.\n- If Option B: rows carry a machine-readable changed token, and `content/UPGRADING.md:868`'s existing `changed=` documentation is generalized to cover them.\n- Existing rows are untouched.\n\n## Affected writers\n\n- `packages/core/src/policy/product-signal.ts:275`\n- `packages/core/src/policy/ceremony-dial.ts:756`\n- `packages/core/src/policy/value-feedback.ts:405`\n- `packages/core/src/policy/require-human-merge.ts:422`\n- `packages/core/src/policy/org-force-on-migration.ts:565`\n- shared sink: `packages/core/src/policy/resolve.ts:208` (`appendAuditLog`)\n\nRefs #746, #747, #1250, #1186, #2470, #2980\n\n",
+      "Labels": "bug, process, source-of-truth",
+      "UserStory": "As a maintainer, I want one recorded no-op convention for policy-changes.log, so that task check cannot dirty a security ledger when nothing changed.",
+      "ImplementationPlan": "1. Guard appendAuditLog in packages/core/src/policy/product-signal.ts and sibling writers on changedFlag or stamp changed=true|false, matching the #1250 welcome module.\n2. Add tests that assert a no-op product-signal:enable leaves meta/policy-changes.log unmodified and existing rows stay intact.",
+      "Decisions": "- xbrief/decisions/2026-08-20-policy-changes-log-records-real-transitions-only-written-rows-st.decision.json — Policy-changes.log records real transitions only. Written rows stamp changed=true. No-op verbs do not append."
+    },
+    "items": [
+      {
+        "title": "Record one ledger convention",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the story lands, task decision:write records which no-op convention applies to every writer of meta/policy-changes.log and why."
+        }
+      },
+      {
+        "title": "Writers and welcome path agree",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When a typed-policy verb and the #1250 welcome path run, both follow the same recorded convention instead of contradictory append versus suppress behavior."
+        }
+      },
+      {
+        "title": "No-op enable does not dirty the tree",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When product-signal:enable matches the current value during task check, git status returns a clean tree for meta/policy-changes.log."
+        }
+      },
+      {
+        "title": "Historical rows stay",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the convention ships, existing ledger rows remain byte-identical and are not rewritten or pruned."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "process",
+      "source-of-truth"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3528",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3528: policy-changes.log holds two contradictory no-op conventions; 63 of 236 rows record nothing (#1250 vs typed-policy writers)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/746",
+        "type": "x-xbrief/refs",
+        "title": "Issue #746"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [
+        {
+          "command": "task check",
+          "source": "task_statement",
+          "sourceSpan": "inline@L73"
+        }
+      ],
+      "literal_acceptance_rejected": [
+        {
+          "command": "2026-08-20T00:28:20Z actor=task product-signal:enable productSignal.enabled=true",
+          "reason": "path-like first token is not allowlisted",
+          "sourceSpan": "fence@L13"
+        },
+        {
+          "command": "sinkRepo=deftai/product-signal previous={\"enabled\":true,\"sinkRepo\":\"deftai/product-signal\"}",
+          "reason": "shell metacharacter \"{\" is not allowed in literal AC commands",
+          "sourceSpan": "fence@L13"
+        },
+        {
+          "command": "no-op: value already matched (audit entry still appended for trail)",
+          "reason": "shell metacharacter \"(\" is not allowed in literal AC commands",
+          "sourceSpan": "fence@L49"
+        }
+      ],
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/policy"
+        ],
+        "expected_outputs": [
+          "policy writer tests pass and no-op enable leaves the ledger clean or marked"
+        ],
+        "depends_on": [],
+        "conflict_group": "policy-audit-3528",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": [
+          "Issue-ingested story; FR traces live in GitHub #3528 acceptance."
+        ]
+      },
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      },
+      "kind": "story"
+    },
+    "acceptance": {
+      "commands": [
+        {
+          "command": "pnpm exec vitest run packages/core/src/policy"
+        }
+      ],
+      "none_stated": false,
+      "source_rung": "stated",
+      "derived_reason": "Re-derived the executable command away from recursive `task check` (that string is the merge-chokepoint, not a product oracle; invoking it from verify:ac deadlocks). Independent oracle: the story verify_commands for the policy writers. Clauses unchanged (#3322 / #3323).",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "One convention applies to every writer of `meta/policy-changes.log`, recorded as a decision (`task decision:write`) naming which and why.",
+          "artifact_path": "meta/policy-changes.log",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "`#1250`'s welcome path and the typed-policy verbs agree.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "A `product-signal:enable` that changes nothing does not leave a tracked file modified after `task check`.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "Real policy-change rows stamp the machine-readable token \"changed=true\" in content/UPGRADING.md.",
+          "artifact_path": "content/UPGRADING.md",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "If Option B: rows carry a machine-readable changed token, and `content/UPGRADING.md:868`'s existing `changed=` documentation is generalized to cover them. [reading: content/UPGRADING.md:868]",
+              "artifact_path": "content/UPGRADING.md:868"
+            },
+            {
+              "text": "If Option B: rows carry a machine-readable changed token, and `content/UPGRADING.md:868`'s existing `changed=` documentation is generalized to cover them (shipped token \"changed=true\"). [reading: content/UPGRADING.md]",
+              "artifact_path": "content/UPGRADING.md"
+            }
+          ],
+          "chosen_reading": 1,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "Existing rows are untouched.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ]
+    },
+    "updated": "2026-08-20T03:17:35Z",
+    "id": "2026-08-20-3528-policy-changeslog-holds-two-contradictory-no-op-conventions"
+  }
+}

--- a/xbrief/decisions/2026-08-20-policy-changes-log-records-real-transitions-only-written-rows-st.decision.json
+++ b/xbrief/decisions/2026-08-20-policy-changes-log-records-real-transitions-only-written-rows-st.decision.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "policy-changes-log-records-real-transitions-only-written-rows-st",
+  "decision": "Policy-changes.log records real transitions only. Written rows stamp changed=true. No-op verbs do not append.",
+  "governingRule": {
+    "description": "One convention for every writer of meta/policy-changes.log; a no-op must not dirty the tracked ledger",
+    "path": "content/UPGRADING.md",
+    "rfc2119": "MUST"
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Option B: keep appending no-ops with changed=true|false",
+      "whyNot": "A product-signal:enable during task check would still dirty the tracked file. 63 of 64 product-signal rows were check-loop noise, not security attempts."
+    },
+    {
+      "option": "Option A: suppress no-ops with no changed= token",
+      "whyNot": "UPGRADING.md already documents changed= for welcome rows; omitting the token would leave two formats."
+    }
+  ],
+  "whyWinner": "The typed-policy copy said always append for trail, but that trail was not load-bearing for no-ops: the previous= field already distinguishes them, and the operational cost is a dirty tree at release Step 1. Stamping changed=true on real writes matches the welcome format. Skipping the write on changed=false satisfies the dirty-tree acceptance criterion without rewriting historical rows.",
+  "confidence": "high",
+  "activeScopeRefs": [
+    "xbrief/active/2026-08-20-3528-policy-changeslog-holds-two-contradictory-no-op-conventions.xbrief.json"
+  ],
+  "timestamp": "2026-08-20T03:42:54Z",
+  "revisitTrigger": "If a security review needs no-op attempt evidence (who tried a flip that did not take), add a gitignored sidecar rather than dirtying the tracked ledger.",
+  "tags": [
+    "process",
+    "source-of-truth"
+  ],
+  "relatedIssues": [
+    3528,
+    1250,
+    746
+  ]
+}


### PR DESCRIPTION
## Summary

One convention for meta/policy-changes.log: record real transitions only. Typed-policy writers and the welcome path skip the append on no-op, stamp changed=true on real writes, and leave historical rows byte-identical. A no-op product-signal:enable no longer dirties the tree during 	ask check.

Decision: xbrief/decisions/2026-08-20-policy-changes-log-records-real-transitions-only-written-rows-st.decision.json.

## Related Issues

Closes #3528

Refs #1250, #746

## Checklist

- [x] /deft:change <name> — N/A (single-issue bugfix; not a /deft:change proposal)
- [x] CHANGELOG.md — added entry under [Unreleased]
- [x] ROADMAP.md — N/A (issue not listed)
- [x] Tests pass locally (	ask check exit 0)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed.
- [x] Enable branch protection on master requiring CI status check (one-time setup, see #57) — N/A this PR
