### PR TITLE
fix(swarm): default finalize-cohort sweep base to delivery branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **spec:render accepts v0.8 xBRIEFInfo specification envelopes (#3555).** `render/spec-validate` shares the info-key resolver and `VALID_VBRIEF_VERSIONS` with `vbrief-validate`. Remediation names `task migrate:xbrief`. `project:export-spec` full-spec uses the same validator. Closes #3555. Refs #3547, #2107.
+- **finalize-cohort fetches the resolved delivery branch and rejects unknown flags (#3554).** On a `main` default-branch repo the command no longer fetches `origin/master`. `--base-branch` (space and equals) stays the override; `--help` / `-h` print usage and exit 0 before any git mutation; unknown flags fail closed. Closes #3554. Refs #3547, #3041.
 - **Policy ledger no-ops no longer dirty the tree (#3528).** Typed-policy writers and the welcome path now share one convention: real transitions append `changed=true`; a no-op `product-signal:enable` (and sibling policy verbs) leave `meta/policy-changes.log` unmodified. Existing rows stay. Refs #1250, #746.
 
 ### Removed

--- a/packages/core/src/swarm/finalize-cohort-cli.ts
+++ b/packages/core/src/swarm/finalize-cohort-cli.ts
@@ -1,26 +1,61 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
-import { finalizeCohort } from "./finalize-cohort.js";
+import { EXIT_CONFIG_ERROR, EXIT_OK } from "./constants.js";
+import { type FinalizeCohortArgs, finalizeCohort } from "./finalize-cohort.js";
 
-export function parseFinalizeCohortArgv(
-  argv: readonly string[],
-): Parameters<typeof finalizeCohort>[0] {
+export interface ParsedFinalizeCohortArgv extends FinalizeCohortArgs {
+  readonly help: boolean;
+  readonly error: string | null;
+}
+
+export const FINALIZE_COHORT_USAGE = `Usage: task swarm:finalize-cohort -- [--pr <n>[,<n>...]] [--stories <ids|paths>] [options]
+
+After cohort PRs merge, sweep story briefs active/ -> completed/ and open the lifecycle PR.
+
+Options:
+  --pr <n>[,<n>...]            Merged PR numbers (closing issues map to active stories)
+  --stories <ids|paths>        Explicit story tokens (repeatable)
+  --repo OWNER/REPO            GitHub repo (or $GH_REPO)
+  --project-root <path>        Project root (default: cwd)
+  --base-branch <name>         Sweep/PR base (default: resolved delivery branch)
+  --delivery-branch <name>     Delivery-branch override when policy is untyped
+  --label <name>               Feature-branch label
+  --dry-run                    Print plan; no git mutation
+  --no-commit                  Sweep without committing / opening a PR
+  --no-open-pr                 Commit without opening a PR
+  --json                       Machine-readable result
+  -h, --help                   Show this help
+`;
+
+function equalsValue(arg: string, flag: string): string {
+  return arg.slice(flag.length + 1);
+}
+
+export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalizeCohortArgv {
   const prNumbers: number[] = [];
   const storyTokens: string[] = [];
   let repo: string | null = null;
   let projectRoot = ".";
-  let baseBranch = "master";
+  let baseBranch: string | undefined;
   let deliveryBranch: string | null = null;
   let label: string | null = null;
   let dryRun = false;
   let noCommit = false;
   let noOpenPr = false;
   let emitJson = false;
+  let help = false;
+  let error: string | null = null;
+
+  const reject = (arg: string): void => {
+    error ??= `unrecognized argument: ${arg}`;
+  };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     const next = argv[i + 1];
-    if (arg === "--pr" && next !== undefined) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--pr" && next !== undefined) {
       for (const piece of next.split(",")) {
         const trimmed = piece.trim();
         if (/^\d+$/.test(trimmed)) {
@@ -38,6 +73,13 @@ export function parseFinalizeCohortArgv(
     } else if (arg === "--stories" && next !== undefined) {
       storyTokens.push(next);
       i += 1;
+    } else if (arg?.startsWith("--stories=")) {
+      const value = equalsValue(arg, "--stories");
+      if (value.length === 0) {
+        reject(arg);
+      } else {
+        storyTokens.push(value);
+      }
     } else if (arg === "--repo" && next !== undefined) {
       repo = next;
       i += 1;
@@ -46,9 +88,23 @@ export function parseFinalizeCohortArgv(
     } else if (arg === "--project-root" && next !== undefined) {
       projectRoot = next;
       i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      const value = equalsValue(arg, "--project-root");
+      if (value.length === 0) {
+        reject(arg);
+      } else {
+        projectRoot = value;
+      }
     } else if (arg === "--base-branch" && next !== undefined) {
       baseBranch = next;
       i += 1;
+    } else if (arg?.startsWith("--base-branch=")) {
+      const value = equalsValue(arg, "--base-branch");
+      if (value.length === 0) {
+        reject(arg);
+      } else {
+        baseBranch = value;
+      }
     } else if (arg === "--delivery-branch" && next !== undefined) {
       deliveryBranch = next;
       i += 1;
@@ -57,6 +113,13 @@ export function parseFinalizeCohortArgv(
     } else if (arg === "--label" && next !== undefined) {
       label = next;
       i += 1;
+    } else if (arg?.startsWith("--label=")) {
+      const value = equalsValue(arg, "--label");
+      if (value.length === 0) {
+        reject(arg);
+      } else {
+        label = value;
+      }
     } else if (arg === "--dry-run") {
       dryRun = true;
     } else if (arg === "--no-commit") {
@@ -67,6 +130,8 @@ export function parseFinalizeCohortArgv(
       emitJson = true;
     } else if (arg !== undefined && !arg.startsWith("-")) {
       storyTokens.push(arg);
+    } else if (arg !== undefined) {
+      reject(arg);
     }
   }
 
@@ -75,18 +140,29 @@ export function parseFinalizeCohortArgv(
     storyTokens,
     repo,
     projectRoot,
-    baseBranch,
+    ...(baseBranch !== undefined ? { baseBranch } : {}),
     deliveryBranch,
     label,
     dryRun,
     noCommit,
     noOpenPr,
     emitJson,
+    help,
+    error,
   };
 }
 
 export function finalizeCohortMain(argv: string[] = process.argv.slice(2)): number {
-  const result = finalizeCohort(parseFinalizeCohortArgv(argv));
+  const parsed = parseFinalizeCohortArgv(argv);
+  if (parsed.help) {
+    process.stdout.write(FINALIZE_COHORT_USAGE);
+    return EXIT_OK;
+  }
+  if (parsed.error !== null) {
+    process.stderr.write(`${parsed.error}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+  const result = finalizeCohort(parsed);
   if (result.stdout.length > 0) {
     process.stdout.write(result.stdout);
   }
@@ -96,6 +172,8 @@ export function finalizeCohortMain(argv: string[] = process.argv.slice(2)): numb
   return result.exitCode;
 }
 
+/* v8 ignore start -- entry guard */
 if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
   process.exit(finalizeCohortMain());
 }
+/* v8 ignore stop */

--- a/packages/core/src/swarm/finalize-cohort-cli.ts
+++ b/packages/core/src/swarm/finalize-cohort-cli.ts
@@ -31,6 +31,30 @@ function equalsValue(arg: string, flag: string): string {
   return arg.slice(flag.length + 1);
 }
 
+function parsePrList(
+  raw: string,
+  flag: string,
+  prNumbers: number[],
+  reject: (arg: string) => void,
+): void {
+  if (raw.trim().length === 0) {
+    reject(flag);
+    return;
+  }
+  for (const piece of raw.split(",")) {
+    const trimmed = piece.trim();
+    if (trimmed.length === 0) {
+      reject(flag);
+      return;
+    }
+    if (!/^\d+$/.test(trimmed)) {
+      reject(flag);
+      return;
+    }
+    prNumbers.push(Number.parseInt(trimmed, 10));
+  }
+}
+
 export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalizeCohortArgv {
   const prNumbers: number[] = [];
   const storyTokens: string[] = [];
@@ -65,26 +89,11 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
     } else if (arg === "--pr") {
       const value = takeValue(arg, next);
       if (value !== null) {
-        for (const piece of value.split(",")) {
-          const trimmed = piece.trim();
-          if (/^\d+$/.test(trimmed)) {
-            prNumbers.push(Number.parseInt(trimmed, 10));
-          }
-        }
+        parsePrList(value, arg, prNumbers, reject);
         i += 1;
       }
     } else if (arg?.startsWith("--pr=")) {
-      const value = equalsValue(arg, "--pr");
-      if (value.trim().length === 0) {
-        reject(arg);
-      } else {
-        for (const piece of value.split(",")) {
-          const trimmed = piece.trim();
-          if (/^\d+$/.test(trimmed)) {
-            prNumbers.push(Number.parseInt(trimmed, 10));
-          }
-        }
-      }
+      parsePrList(equalsValue(arg, "--pr"), arg, prNumbers, reject);
     } else if (arg === "--stories") {
       const value = takeValue(arg, next);
       if (value !== null) {

--- a/packages/core/src/swarm/finalize-cohort-cli.ts
+++ b/packages/core/src/swarm/finalize-cohort-cli.ts
@@ -74,10 +74,15 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
         i += 1;
       }
     } else if (arg?.startsWith("--pr=")) {
-      for (const piece of arg.slice("--pr=".length).split(",")) {
-        const trimmed = piece.trim();
-        if (/^\d+$/.test(trimmed)) {
-          prNumbers.push(Number.parseInt(trimmed, 10));
+      const value = equalsValue(arg, "--pr");
+      if (value.trim().length === 0) {
+        reject(arg);
+      } else {
+        for (const piece of value.split(",")) {
+          const trimmed = piece.trim();
+          if (/^\d+$/.test(trimmed)) {
+            prNumbers.push(Number.parseInt(trimmed, 10));
+          }
         }
       }
     } else if (arg === "--stories") {
@@ -100,7 +105,12 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
         i += 1;
       }
     } else if (arg?.startsWith("--repo=")) {
-      repo = arg.slice("--repo=".length);
+      const value = equalsValue(arg, "--repo");
+      if (value.length === 0) {
+        reject(arg);
+      } else {
+        repo = value;
+      }
     } else if (arg === "--project-root") {
       const value = takeValue(arg, next);
       if (value !== null) {
@@ -134,7 +144,12 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
         i += 1;
       }
     } else if (arg?.startsWith("--delivery-branch=")) {
-      deliveryBranch = arg.slice("--delivery-branch=".length);
+      const value = equalsValue(arg, "--delivery-branch");
+      if (value.length === 0) {
+        reject(arg);
+      } else {
+        deliveryBranch = value;
+      }
     } else if (arg === "--label") {
       const value = takeValue(arg, next);
       if (value !== null) {

--- a/packages/core/src/swarm/finalize-cohort-cli.ts
+++ b/packages/core/src/swarm/finalize-cohort-cli.ts
@@ -49,20 +49,30 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
   const reject = (arg: string): void => {
     error ??= `unrecognized argument: ${arg}`;
   };
+  const takeValue = (flag: string, nextValue: string | undefined): string | null => {
+    if (nextValue === undefined || nextValue.startsWith("-")) {
+      reject(flag);
+      return null;
+    }
+    return nextValue;
+  };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     const next = argv[i + 1];
     if (arg === "--help" || arg === "-h") {
       help = true;
-    } else if (arg === "--pr" && next !== undefined) {
-      for (const piece of next.split(",")) {
-        const trimmed = piece.trim();
-        if (/^\d+$/.test(trimmed)) {
-          prNumbers.push(Number.parseInt(trimmed, 10));
+    } else if (arg === "--pr") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        for (const piece of value.split(",")) {
+          const trimmed = piece.trim();
+          if (/^\d+$/.test(trimmed)) {
+            prNumbers.push(Number.parseInt(trimmed, 10));
+          }
         }
+        i += 1;
       }
-      i += 1;
     } else if (arg?.startsWith("--pr=")) {
       for (const piece of arg.slice("--pr=".length).split(",")) {
         const trimmed = piece.trim();
@@ -70,9 +80,12 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
           prNumbers.push(Number.parseInt(trimmed, 10));
         }
       }
-    } else if (arg === "--stories" && next !== undefined) {
-      storyTokens.push(next);
-      i += 1;
+    } else if (arg === "--stories") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        storyTokens.push(value);
+        i += 1;
+      }
     } else if (arg?.startsWith("--stories=")) {
       const value = equalsValue(arg, "--stories");
       if (value.length === 0) {
@@ -80,14 +93,20 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
       } else {
         storyTokens.push(value);
       }
-    } else if (arg === "--repo" && next !== undefined) {
-      repo = next;
-      i += 1;
+    } else if (arg === "--repo") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        repo = value;
+        i += 1;
+      }
     } else if (arg?.startsWith("--repo=")) {
       repo = arg.slice("--repo=".length);
-    } else if (arg === "--project-root" && next !== undefined) {
-      projectRoot = next;
-      i += 1;
+    } else if (arg === "--project-root") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        projectRoot = value;
+        i += 1;
+      }
     } else if (arg?.startsWith("--project-root=")) {
       const value = equalsValue(arg, "--project-root");
       if (value.length === 0) {
@@ -95,9 +114,12 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
       } else {
         projectRoot = value;
       }
-    } else if (arg === "--base-branch" && next !== undefined) {
-      baseBranch = next;
-      i += 1;
+    } else if (arg === "--base-branch") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        baseBranch = value;
+        i += 1;
+      }
     } else if (arg?.startsWith("--base-branch=")) {
       const value = equalsValue(arg, "--base-branch");
       if (value.length === 0) {
@@ -105,14 +127,20 @@ export function parseFinalizeCohortArgv(argv: readonly string[]): ParsedFinalize
       } else {
         baseBranch = value;
       }
-    } else if (arg === "--delivery-branch" && next !== undefined) {
-      deliveryBranch = next;
-      i += 1;
+    } else if (arg === "--delivery-branch") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        deliveryBranch = value;
+        i += 1;
+      }
     } else if (arg?.startsWith("--delivery-branch=")) {
       deliveryBranch = arg.slice("--delivery-branch=".length);
-    } else if (arg === "--label" && next !== undefined) {
-      label = next;
-      i += 1;
+    } else if (arg === "--label") {
+      const value = takeValue(arg, next);
+      if (value !== null) {
+        label = value;
+        i += 1;
+      }
     } else if (arg?.startsWith("--label=")) {
       const value = equalsValue(arg, "--label");
       if (value.length === 0) {

--- a/packages/core/src/swarm/finalize-cohort.test.ts
+++ b/packages/core/src/swarm/finalize-cohort.test.ts
@@ -760,6 +760,16 @@ describe("finalize-cohort sweep base and argv (#3554)", () => {
     }
   });
 
+  it("fails closed on malformed nonempty --pr tokens", () => {
+    expect(parseFinalizeCohortArgv(["--pr=abc", "--stories", "story-a"]).error).toBe(
+      "unrecognized argument: --pr=abc",
+    );
+    expect(parseFinalizeCohortArgv(["--pr=12,abc", "--stories", "story-a"]).error).toBe(
+      "unrecognized argument: --pr=12,abc",
+    );
+    expect(parseFinalizeCohortArgv(["--pr", "12,abc"]).error).toBe("unrecognized argument: --pr");
+  });
+
   it("fails closed when a value flag is followed by another flag instead of a value", () => {
     const parsed = parseFinalizeCohortArgv(["--base-branch", "--dry-run", "--stories", "story-a"]);
     expect(parsed.error).toBe("unrecognized argument: --base-branch");

--- a/packages/core/src/swarm/finalize-cohort.test.ts
+++ b/packages/core/src/swarm/finalize-cohort.test.ts
@@ -746,8 +746,16 @@ describe("finalize-cohort sweep base and argv (#3554)", () => {
   });
 
   it("rejects empty equals-form values as unrecognized arguments", () => {
-    for (const flag of ["--base-branch=", "--stories=", "--project-root=", "--label="]) {
-      const parsed = parseFinalizeCohortArgv([flag]);
+    for (const flag of [
+      "--base-branch=",
+      "--stories=",
+      "--project-root=",
+      "--label=",
+      "--pr=",
+      "--repo=",
+      "--delivery-branch=",
+    ]) {
+      const parsed = parseFinalizeCohortArgv([flag, "--stories", "story-a"]);
       expect(parsed.error).toBe(`unrecognized argument: ${flag}`);
     }
   });

--- a/packages/core/src/swarm/finalize-cohort.test.ts
+++ b/packages/core/src/swarm/finalize-cohort.test.ts
@@ -10,11 +10,17 @@ vi.mock("../scope/transition.js", () => ({
 import { CLAUSE_STAMP_IMPLEMENTATION_ONLY_REMEDIATION } from "../intake/clause-derivation.js";
 import type { RunGhFn } from "../pr-protected-issues/types.js";
 import { runTransition } from "../scope/transition.js";
+import { EXIT_CONFIG_ERROR, EXIT_OK } from "./constants.js";
 import { finalizeCohort } from "./finalize-cohort.js";
-import { finalizeCohortMain } from "./finalize-cohort-cli.js";
+import { finalizeCohortMain, parseFinalizeCohortArgv } from "./finalize-cohort-cli.js";
 import type { TextCaptureResult } from "./subprocess.js";
 
-function writeActiveStory(project: string, storyId: string, issueNumber: number): string {
+function writeActiveStory(
+  project: string,
+  storyId: string,
+  issueNumber: number,
+  opts: { deliveryBranch?: string } = {},
+): string {
   const full = join(project, "xbrief", "active", `${storyId}.xbrief.json`);
   mkdirSync(join(project, "xbrief", "active"), { recursive: true });
   writeFileSync(
@@ -23,7 +29,11 @@ function writeActiveStory(project: string, storyId: string, issueNumber: number)
       plan: {
         title: "Project",
         status: "running",
-        policy: { allowDirectCommitsToMaster: false, wipCap: 10 },
+        policy: {
+          allowDirectCommitsToMaster: false,
+          wipCap: 10,
+          ...(opts.deliveryBranch !== undefined ? { deliveryBranch: opts.deliveryBranch } : {}),
+        },
       },
     }),
     "utf8",
@@ -605,5 +615,174 @@ describe("finalizeCohort", () => {
     expect(result.result.sweep?.parents.some((p) => p.action === "activate+complete")).toBe(true);
     expect(result.stdout).toContain(CLAUSE_STAMP_IMPLEMENTATION_ONLY_REMEDIATION);
     rmSync(project, { recursive: true, force: true });
+  });
+});
+
+describe("finalize-cohort sweep base and argv (#3554)", () => {
+  function capturingGit(): {
+    runGit: (command: readonly string[]) => TextCaptureResult;
+    commands: string[][];
+  } {
+    const commands: string[][] = [];
+    const inner = mockRunGit();
+    return {
+      commands,
+      runGit: (command) => {
+        commands.push([...command]);
+        return inner(command);
+      },
+    };
+  }
+
+  it("defaults sweep base to the resolved delivery branch and does not fetch origin/master", () => {
+    const project = mkdtempSync(join(tmpdir(), "sw-finalize-main-"));
+    const storyPath = writeActiveStory(project, "story-main", 3554, { deliveryBranch: "main" });
+    const { runGit, commands } = capturingGit();
+    const result = finalizeCohort({
+      projectRoot: project,
+      storyTokens: [storyPath],
+      label: "story-main",
+      repo: "deftai/directive",
+      runGit,
+      runGh: mockRunGh({}),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.result.sweep_base).toBe("main");
+    expect(result.result.delivery_branch).toBe("main");
+    expect(result.stdout).toContain("Delivery branch: main");
+    expect(result.stdout).toContain("Sweep base: main");
+    const fetches = commands.filter((c) => c.includes("fetch"));
+    expect(fetches.some((c) => c.includes("origin") && c.includes("master"))).toBe(false);
+    expect(fetches.some((c) => c.includes("origin") && c.includes("main"))).toBe(true);
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  it("prints both names and proceeds when an explicit --base-branch differs from delivery", () => {
+    const project = mkdtempSync(join(tmpdir(), "sw-finalize-override-"));
+    const storyPath = writeActiveStory(project, "story-over", 3554, { deliveryBranch: "main" });
+    const { runGit, commands } = capturingGit();
+    const result = finalizeCohort({
+      projectRoot: project,
+      storyTokens: [storyPath],
+      label: "story-over",
+      repo: "deftai/directive",
+      baseBranch: "develop",
+      runGit,
+      runGh: mockRunGh({}),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.result.ok).toBe(true);
+    expect(result.result.delivery_branch).toBe("main");
+    expect(result.result.sweep_base).toBe("develop");
+    expect(result.stdout).toContain("Delivery branch: main");
+    expect(result.stdout).toContain("Sweep base: develop");
+    const fetches = commands.filter((c) => c.includes("fetch"));
+    expect(fetches.some((c) => c.includes("origin") && c.includes("develop"))).toBe(true);
+    expect(fetches.some((c) => c.includes("origin") && c.includes("master"))).toBe(false);
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  it("omits baseBranch unless --base-branch is passed (space and equals form)", () => {
+    const omitted = parseFinalizeCohortArgv(["--stories", "story-a", "--no-commit"]);
+    expect(omitted.error).toBeNull();
+    expect(omitted.help).toBe(false);
+    expect(omitted.baseBranch).toBeUndefined();
+
+    const space = parseFinalizeCohortArgv(["--base-branch", "develop", "--stories", "story-a"]);
+    expect(space.error).toBeNull();
+    expect(space.baseBranch).toBe("develop");
+
+    const equals = parseFinalizeCohortArgv(["--base-branch=main", "--stories", "story-a"]);
+    expect(equals.error).toBeNull();
+    expect(equals.baseBranch).toBe("main");
+  });
+
+  it("parses remaining value flags in space and equals form", () => {
+    const space = parseFinalizeCohortArgv([
+      "--pr",
+      "9,10",
+      "--stories",
+      "story-b",
+      "--repo",
+      "acme/app",
+      "--project-root",
+      "/tmp/space",
+      "--delivery-branch",
+      "trunk",
+      "--label",
+      "wave2",
+      "--no-commit",
+    ]);
+    expect(space.error).toBeNull();
+    expect(space.prNumbers).toEqual([9, 10]);
+    expect(space.storyTokens).toEqual(["story-b"]);
+    expect(space.repo).toBe("acme/app");
+    expect(space.projectRoot).toBe("/tmp/space");
+    expect(space.deliveryBranch).toBe("trunk");
+    expect(space.label).toBe("wave2");
+    expect(space.noCommit).toBe(true);
+
+    const parsed = parseFinalizeCohortArgv([
+      "--pr=12",
+      "--stories=story-a",
+      "--repo=deftai/directive",
+      "--project-root=/tmp/proj",
+      "--delivery-branch=main",
+      "--label=wave1",
+      "--dry-run",
+      "--no-open-pr",
+      "--json",
+    ]);
+    expect(parsed.error).toBeNull();
+    expect(parsed.prNumbers).toEqual([12]);
+    expect(parsed.storyTokens).toEqual(["story-a"]);
+    expect(parsed.repo).toBe("deftai/directive");
+    expect(parsed.projectRoot).toBe("/tmp/proj");
+    expect(parsed.deliveryBranch).toBe("main");
+    expect(parsed.label).toBe("wave1");
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.noOpenPr).toBe(true);
+    expect(parsed.emitJson).toBe(true);
+  });
+
+  it("rejects empty equals-form values as unrecognized arguments", () => {
+    for (const flag of ["--base-branch=", "--stories=", "--project-root=", "--label="]) {
+      const parsed = parseFinalizeCohortArgv([flag]);
+      expect(parsed.error).toBe(`unrecognized argument: ${flag}`);
+    }
+  });
+
+  it("fails closed on unrecognized arguments including boolean equals forms", () => {
+    for (const flag of ["--dry-run=true", "--no-commit=1", "--wat"]) {
+      const parsed = parseFinalizeCohortArgv([flag, "--stories", "story-a"]);
+      expect(parsed.error).toBe(`unrecognized argument: ${flag}`);
+    }
+  });
+
+  it("prints usage and exits 0 on --help / -h before any git mutation", () => {
+    const chunks: string[] = [];
+    const errChunks: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      errChunks.push(String(chunk));
+      return true;
+    });
+    try {
+      for (const flag of ["--help", "-h"]) {
+        chunks.length = 0;
+        const code = finalizeCohortMain([flag, "--project-root", "/definitely-not-a-repo"]);
+        expect(code).toBe(EXIT_OK);
+        expect(chunks.join("")).toMatch(/Usage:/);
+        expect(chunks.join("")).toMatch(/--base-branch/);
+      }
+      expect(finalizeCohortMain(["--dry-run=true"])).toBe(EXIT_CONFIG_ERROR);
+      expect(errChunks.join("")).toContain("unrecognized argument: --dry-run=true");
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+    }
   });
 });

--- a/packages/core/src/swarm/finalize-cohort.test.ts
+++ b/packages/core/src/swarm/finalize-cohort.test.ts
@@ -752,6 +752,13 @@ describe("finalize-cohort sweep base and argv (#3554)", () => {
     }
   });
 
+  it("fails closed when a value flag is followed by another flag instead of a value", () => {
+    const parsed = parseFinalizeCohortArgv(["--base-branch", "--dry-run", "--stories", "story-a"]);
+    expect(parsed.error).toBe("unrecognized argument: --base-branch");
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.baseBranch).toBeUndefined();
+  });
+
   it("fails closed on unrecognized arguments including boolean equals forms", () => {
     for (const flag of ["--dry-run=true", "--no-commit=1", "--wat"]) {
       const parsed = parseFinalizeCohortArgv([flag, "--stories", "story-a"]);

--- a/packages/core/src/swarm/finalize-cohort.ts
+++ b/packages/core/src/swarm/finalize-cohort.ts
@@ -30,6 +30,7 @@ export interface FinalizeCohortResult {
   readonly branch: string | null;
   readonly pr_url: string | null;
   readonly delivery_branch: string | null;
+  readonly sweep_base: string;
   readonly delivery_errors: readonly string[];
   readonly errors: readonly string[];
   readonly warnings: readonly string[];
@@ -444,8 +445,6 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
   const prNumbers = [...(args.prNumbers ?? [])].sort((a, b) => a - b);
   const storyTokens = splitCsv(args.storyTokens ?? []);
   const repo = args.repo ?? process.env.GH_REPO ?? null;
-  // baseBranch is for the lifecycle sweep PR only — not delivery proof (#3041).
-  const baseBranch = args.baseBranch ?? "master";
   const dryRun = args.dryRun ?? false;
   const noCommit = args.noCommit ?? false;
   const noOpenPr = args.noOpenPr ?? false;
@@ -473,6 +472,13 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
     policyDelivery.source === "typed"
       ? policyDelivery.branch
       : (cliDelivery ?? policyDelivery.branch);
+  // Sweep/PR base is distinct from delivery proof (#3041). Default via the resolved
+  // delivery branch — never a hardcoded "master". --base-branch remains the override.
+  const explicitSweepBase =
+    args.baseBranch !== undefined && args.baseBranch !== null && args.baseBranch.trim().length > 0
+      ? args.baseBranch.trim()
+      : null;
+  const baseBranch = explicitSweepBase ?? deliveryBranch;
 
   if (!existsSync(projectRoot)) {
     return buildResponse({
@@ -487,6 +493,7 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
       branch: null,
       prUrl: null,
       deliveryBranch,
+      sweepBase: baseBranch,
       deliveryErrors: [],
       errors: [`project root does not exist: ${projectRoot}`],
       warnings: [],
@@ -509,6 +516,7 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
       branch: null,
       prUrl: null,
       deliveryBranch,
+      sweepBase: baseBranch,
       deliveryErrors: [],
       errors: [`no xbrief/ directory under project root: ${projectRoot}`],
       warnings: [],
@@ -691,6 +699,7 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
       branch: null,
       prUrl: null,
       deliveryBranch,
+      sweepBase: baseBranch,
       deliveryErrors,
       errors,
       warnings,
@@ -718,6 +727,7 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
       branch: null,
       prUrl: null,
       deliveryBranch,
+      sweepBase: baseBranch,
       deliveryErrors,
       errors,
       warnings,
@@ -822,6 +832,7 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
       branch: null,
       prUrl: null,
       deliveryBranch,
+      sweepBase: baseBranch,
       deliveryErrors,
       errors,
       warnings,
@@ -870,6 +881,7 @@ export function finalizeCohort(args: FinalizeCohortArgs): {
     branch,
     prUrl,
     deliveryBranch,
+    sweepBase: baseBranch,
     deliveryErrors,
     errors,
     warnings,
@@ -891,6 +903,7 @@ function buildResponse(input: {
   branch: string | null;
   prUrl: string | null;
   deliveryBranch: string | null;
+  sweepBase: string;
   deliveryErrors: readonly string[];
   errors: readonly string[];
   warnings: readonly string[];
@@ -910,6 +923,7 @@ function buildResponse(input: {
     branch: input.branch,
     pr_url: input.prUrl,
     delivery_branch: input.deliveryBranch,
+    sweep_base: input.sweepBase,
     delivery_errors: input.deliveryErrors,
     errors: input.errors,
     warnings: input.warnings,
@@ -933,6 +947,7 @@ function buildResponse(input: {
   if (input.deliveryBranch !== null) {
     lines.push(`  Delivery branch: ${input.deliveryBranch}`);
   }
+  lines.push(`  Sweep base: ${input.sweepBase}`);
   if (input.prNumbers.length > 0) {
     lines.push(`  PRs: ${input.prNumbers.map((n) => `#${n}`).join(", ")}`);
   }


### PR DESCRIPTION
## Summary

`task swarm:finalize-cohort` printed the resolved delivery branch then fetched `origin/master` for the lifecycle sweep. Sweep `baseBranch` defaulted to the literal `master` in both the CLI and the library, so a library-only fix could not help: the CLI always passed initialized `master`.

This PR defaults sweep base via `resolveDeliveryBranch(projectRoot)`, keeps `--base-branch` (space and equals) as the explicit override, fail-closes unknown flags with `unrecognized argument:`, prints `--help`/`-h` and exits 0 before git mutation, and prints sweep base alongside the delivery branch.

On a `main` delivery repo, a default run no longer fetches `origin/master`.

## Related Issues

Closes #3554
Refs #3547
Refs #3041

## Checklist

- [x] `/deft:change <name>` — N/A (4 files, scoped bugfix; not cross-cutting architecture)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (bugfix, not a tracked roadmap item)
- [x] Tests pass locally

## Test plan

- [x] `pnpm exec vitest run packages/core/src/swarm/finalize-cohort.test.ts`
- [x] `pnpm exec vitest run packages/core/src/swarm` (literal AC)
- [x] `task check`

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed.
