### PR TITLE
fix(authz): open Windows CONIN$ read/write for operator mint (#3596)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Operator mint works in a real Windows console (#3596).** The controlling-terminal probe no longer opens the Windows console input device read-only, which blocked mint after TTY checks passed. Remediation text for `scope:record-approved-scope` includes `--confirm`. The #3110 env-marker, TTY, `--confirm`, and typed-phrase gates are unchanged. Closes #3596. Refs #3110, #3145, #3205.
 - **Prescribed agent commands emit `deft <verb>` (#3439).** Skill MUST fences, routing/bootstrap remediations, commands.md work-selection, and the unknown-verb hint no longer print bare `task <verb>` that a consumer include-only Taskfile cannot run. `deft plan-sequence:current` is documented; `:status` is not a verb. `--` is accepted on triage and plan-sequence. `scope:promote --help` no longer dumps `scope_lifecycle.py` required action. Closes #3439.
 - **Agent-hook live probe timeout is not a broken hook (#3570).** One retry at 1.5s keeps the four-host ceiling at 24s under Cursor `tool.before` 30s. `timed-out` is not mapped as non-functional and does not recommend reinstall or hostHooks opt-out. Closes #3570. Refs #3571, #3246, #3100.
 - **Literal-AC prompt capture is dollar-sign only (#3572 leftover).** Markdown blockquote `>` is not a shell prompt, so ingested reviewer findings no longer land on the rejected ledger as `prompt@`. `$` prompts, labeled `verify:`/`command:`/`run:` lines, fences, and inline backticks stay. Narratives are still scanned. Closes #3572.

--- a/packages/cli/src/human-presence-mint.open-flag.test.ts
+++ b/packages/cli/src/human-presence-mint.open-flag.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  openSyncMock: vi.fn(() => 7),
+  closeSyncMock: vi.fn(),
+  readSyncMock: vi.fn((_fd: unknown, buf: unknown, offset: unknown) => {
+    const text = Buffer.from("mint\n");
+    text.copy(buf as Buffer, Number(offset) || 0);
+    return text.length;
+  }),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => hoisted.openSyncMock(...args),
+    closeSync: (...args: Parameters<typeof actual.closeSync>) => hoisted.closeSyncMock(...args),
+    readSync: (...args: Parameters<typeof actual.readSync>) => hoisted.readSyncMock(...args),
+  };
+});
+
+import { resolveHumanPresenceMintSeams } from "./human-presence-mint.js";
+
+describe("controlling-terminal open flag (#3596)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("default probe and phrase read open the platform device with the platform flag", () => {
+    const expectedPath = process.platform === "win32" ? "CONIN$" : "/dev/tty";
+    const expectedFlag = process.platform === "win32" ? "r+" : "r";
+    const seams = resolveHumanPresenceMintSeams();
+    expect(seams.hasControllingTerminal()).toBe(true);
+    expect(hoisted.openSyncMock).toHaveBeenCalledWith(expectedPath, expectedFlag);
+    hoisted.openSyncMock.mockClear();
+    expect(seams.readInteractiveConfirm()).toBe("mint");
+    expect(hoisted.openSyncMock).toHaveBeenCalledWith(expectedPath, expectedFlag);
+  });
+});

--- a/packages/cli/src/human-presence-mint.test.ts
+++ b/packages/cli/src/human-presence-mint.test.ts
@@ -7,6 +7,8 @@ import { AUTHZ_AGENT_SHELL_ENV_MARKERS as fromAuthz } from "./authz.js";
 import {
   AUTHZ_AGENT_SHELL_ENV_MARKERS,
   AUTHZ_INTERACTIVE_CONFIRM_PHRASE,
+  controllingTerminalOpenFlag,
+  controllingTerminalPath,
   looksLikeAgentShell,
   refuseMintWhileUatActive,
   refuseNonInteractiveMint,
@@ -136,5 +138,14 @@ describe("shared #3110 human-presence mint (#3384)", () => {
     expect(typeof resolved.hasControllingTerminal).toBe("function");
     expect(typeof resolved.readInteractiveConfirm).toBe("function");
     expect(resolved.environ).toBe(process.env);
+  });
+
+  it("opens CONIN$ with r+ on win32 and /dev/tty with r elsewhere (#3596)", () => {
+    expect(controllingTerminalPath("win32")).toBe("CONIN$");
+    expect(controllingTerminalOpenFlag("win32")).toBe("r+");
+    expect(controllingTerminalPath("linux")).toBe("/dev/tty");
+    expect(controllingTerminalOpenFlag("linux")).toBe("r");
+    expect(controllingTerminalPath("darwin")).toBe("/dev/tty");
+    expect(controllingTerminalOpenFlag("darwin")).toBe("r");
   });
 });

--- a/packages/cli/src/human-presence-mint.ts
+++ b/packages/cli/src/human-presence-mint.ts
@@ -92,10 +92,26 @@ function defaultIsTty(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
 
+/** Platform controlling-terminal path (`CONIN$` on win32, `/dev/tty` elsewhere). */
+export function controllingTerminalPath(platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? "CONIN$" : "/dev/tty";
+}
+
+/**
+ * Open flag for the platform controlling-terminal device (#3596).
+ *
+ * Windows `CONIN$` generally requires read/write (`r+`); `r` (O_RDONLY) fails
+ * in a real interactive console and made operator mint unreachable on win32.
+ */
+export function controllingTerminalOpenFlag(
+  platform: NodeJS.Platform = process.platform,
+): "r" | "r+" {
+  return platform === "win32" ? "r+" : "r";
+}
+
 function defaultHasControllingTerminal(): boolean {
   try {
-    const path = process.platform === "win32" ? "CONIN$" : "/dev/tty";
-    const fd = openSync(path, "r");
+    const fd = openSync(controllingTerminalPath(), controllingTerminalOpenFlag());
     closeSync(fd);
     return true;
   } catch {
@@ -108,8 +124,7 @@ function defaultReadInteractiveConfirm(): string | null {
   // so agent-controlled stdin alone cannot supply the confirm phrase (#3110).
   let fd: number | null = null;
   try {
-    const path = process.platform === "win32" ? "CONIN$" : "/dev/tty";
-    fd = openSync(path, "r");
+    fd = openSync(controllingTerminalPath(), controllingTerminalOpenFlag());
     const buf = Buffer.alloc(256);
     const n = readSync(fd, buf, 0, buf.length, null);
     if (n <= 0) return null;

--- a/packages/core/src/scope-provenance/evaluate.test.ts
+++ b/packages/core/src/scope-provenance/evaluate.test.ts
@@ -88,6 +88,43 @@ describe("evaluateOneScopeProvenance (#3145)", () => {
     expect(finding?.kind).toBe("self-authorizing-scope-expansion");
     expect(finding?.expandedPaths).toContain("infra/scripts/test_release.py");
     expect(finding?.remediation).toMatch(/human approval/i);
+    expect(finding?.remediation).toMatch(/--confirm/);
+  });
+
+  it("non-human stamp remediations include --confirm (#3596)", () => {
+    const current = xbrief("story-1", ["src/app.ts"]);
+    const agentStamp = {
+      kind: "agent",
+      actor: "agent:bot",
+      mintedAt: "2026-08-01T00:00:00Z",
+    };
+    const matching = evaluateOneScopeProvenance({
+      xbriefRelPath: "xbrief/active/story.xbrief.json",
+      currentPayload: current,
+      approved: buildApprovedScopeRecord({
+        xbriefRelPath: "xbrief/active/story.xbrief.json",
+        payload: current,
+        humanApproval: agentStamp,
+      }),
+      xbriefModifiedInChangeSet: true,
+      enforce: true,
+    });
+    expect(matching?.kind).toBe("active-xbrief-modified-without-digest");
+    expect(matching?.remediation).toMatch(/--confirm/);
+
+    const shrink = evaluateOneScopeProvenance({
+      xbriefRelPath: "xbrief/active/story.xbrief.json",
+      currentPayload: current,
+      approved: buildApprovedScopeRecord({
+        xbriefRelPath: "xbrief/active/story.xbrief.json",
+        payload: xbrief("story-1", ["src/app.ts", "src/extra.ts"]),
+        humanApproval: agentStamp,
+      }),
+      xbriefModifiedInChangeSet: true,
+      enforce: true,
+    });
+    expect(shrink?.kind).toBe("active-xbrief-modified-without-digest");
+    expect(shrink?.remediation).toMatch(/--confirm/);
   });
 
   it("does not treat the original activation stamp as renewal for expansion", () => {

--- a/packages/core/src/scope-provenance/evaluate.ts
+++ b/packages/core/src/scope-provenance/evaluate.ts
@@ -278,7 +278,7 @@ function listActiveXbriefPaths(projectRoot: string): string[] {
 function remediationForExpansion(): string {
   return (
     "Renew human approval: re-record the approved-scope digest after operator review " +
-    "(`task scope:record-approved-scope -- <xbrief-path> --actor <you>` writes " +
+    "(`task scope:record-approved-scope -- <xbrief-path> --actor <you> --confirm` writes " +
     "`.deft/approved-scope/<plan-id>.json` with a humanApproval stamp). Commit that " +
     "approval on the merge base (or a prior PR) before expanding or activating the " +
     "scoped xBRIEF in the implementation change set. Editing the active xBRIEF alone " +
@@ -435,7 +435,7 @@ export function evaluateOneScopeProvenance(input: {
           "only humanApproval stamps authorize non-empty file_scope",
         remediation:
           "Record a human-origin approval via `task scope:record-approved-scope -- " +
-          "<xbrief-path> --actor <you>` (#3145 / #3205).",
+          "<xbrief-path> --actor <you> --confirm` (#3145 / #3205).",
       };
     }
   }
@@ -455,7 +455,7 @@ export function evaluateOneScopeProvenance(input: {
           "only humanApproval stamps authorize non-empty file_scope",
         remediation:
           "Record a human-origin approval via `task scope:record-approved-scope -- " +
-          "<xbrief-path> --actor <you>` (#3145 / #3205).",
+          "<xbrief-path> --actor <you> --confirm` (#3145 / #3205).",
       };
     }
     return null;

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -161,8 +161,8 @@ tasks:
   # Mint a human-origin .deft/approved-scope/<plan-id>.json so
   # verify:scope-provenance can authorize pending→active and operator-approved
   # expansion without same-PR self-authorization.
-  #   task scope:record-approved-scope -- xbrief/pending/story.xbrief.json --actor scott
-  #   task scope:record-approved-scope -- xbrief/active/story.xbrief.json --actor scott --kind renewed-approval
+  #   task scope:record-approved-scope -- xbrief/pending/story.xbrief.json --actor scott --confirm
+  #   task scope:record-approved-scope -- xbrief/active/story.xbrief.json --actor scott --kind renewed-approval --confirm
   record-approved-scope:
     desc: "Record human-approved file_scope digest under .deft/approved-scope/<plan-id>.json (#3205). Requires --actor <human>. Refuses agent stamps. Path-binds pending→active. Commit on merge base before activation/expansion PR."
     dir: '{{.USER_WORKING_DIR}}'


### PR DESCRIPTION
## Summary

Windows operator mint failed after TTY checks because `CONIN$` was opened read-only. On win32 the controlling-terminal probe and phrase read now open that device with `r+`. A regression test covers the platform flag. Stale `scope:record-approved-scope` remediations include `--confirm`. The #3110 env-marker, TTY, `--confirm`, and typed-phrase gates are unchanged.

Agent-pipe diagnostic (this session): both `r` and `r+` fail `ENOENT`. That is not a real console. The reporter already reached the controlling-terminal message after TTY passed in a real console. Mint E2E is operator-owned and is not faked here.

## Related Issues

Closes #3596
Refs #3110, #3145, #3205

## Checklist

- [x] `/deft:change` — N/A (scoped bug fix, not a new change proposal)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Product tests pass locally (`human-presence-mint*` and `evaluate.test.ts`). Full `pnpm exec vitest run packages/cli/src` flakes on this Windows agent via 20s timeouts under load (pre-existing #2467 class). Linux CI is the merge chokepoint.

## Post-Merge

- [ ] Verify issue auto-close for #3596
- [ ] `task scope:complete` and leftover completed-tracked land if needed
