### PR TITLE
chore(scope): remint #3438 approved-scope for the opt-in default

### DIFF
--- a/.deft/approved-scope/issue-3438-shell-dest-form-scope-gate.intent.json
+++ b/.deft/approved-scope/issue-3438-shell-dest-form-scope-gate.intent.json
@@ -12,7 +12,7 @@
       "When": "When Edit/Write is denied for empty active, the copy names direct-write and spawn only. When Bash runs git checkout -- paths, git restore, or rm/rmdir of in-repo paths with empty active, inspectMutationGates denies with the same exemptions as Edit/Write. python -c, cmd /c copy, and obfuscated bash stay known-open. git status stays fail-open. Commit-time active-scope is not in this story.",
       "LockedDecisions": "Verified synthesis 5364744368 is the lock. Accept the diagnosis; do not accept reuse UAT dest-writer classification as the v1 mechanism. V1 dest-form list: git checkout -- <paths>, git restore, rm/rmdir of in-repo paths. These need a NEW product-mutation classifier; classifyShellAuthzOps and listShellOps return empty for the filed repro. Route those through inspectMutationGates with Edit/Write parity exemptions (assist/scratch #1802, proposed lifecycle #2625; decide file_scope for Shell). Honesty copy lands even if the classifier slips. Residual known-open: python -c, cmd /c copy, obfuscated bash. Keep #2711 fail-open for non-dest unclassifiable shell. Keep #2885 closed. Commit-time active-scope is a separate story. Do not weaken Edit to match Shell.",
       "ImplementationPlan": "Change Edit/Write scope-not-ready deny copy to name direct-write and spawn, not Shell dest-forms. Add a new product dest-form classifier for the named list; do not wire classifyShellAuthzOps or listShellOps as-is. Route matching Shell ops through inspectMutationGates with assist/scratch and proposed-lifecycle exemptions; decide file_scope. Tests: reporter git checkout -- / rm with empty active denies; git status still allows; python -c documented residual. CHANGELOG Unreleased. Do not add a commit-time active-scope check.",
-      "OriginDivergence": "Ingest 2026-08-21. Body expected Bash same-check OR honesty copy OR later commit-time. Synthesis locks honesty plus a NEW dest-form classifier, not reuse UAT classify, and parks commit-time. D12: synthesis newer than body."
+      "OriginDivergence": "Ingest 2026-08-21. Body expected Bash same-check OR honesty copy OR later commit-time. Synthesis locks honesty plus a NEW dest-form classifier, not reuse UAT classify, and parks commit-time. D12: synthesis newer than body. D13 operator directive 2026-08-21 (post-synthesis, recorded per #3383): ship the gate OPT-IN, not enforcing. New field plan.policy.runtimeAuthority.shellDestForms: off|enforce, default off, folding the separately-filed knob #3594 into this story. Rationale: before #3438 Bash mutations were not gated at all, so default enforcement would land new denials on every consumer with no opt-out, on a release carrying a large open-bug count; shipping inert removes the need to stage a breaking change at all. enforce moves BOTH halves together (resolved dests through inspectMutationGates, and fail-closed targets) because splitting them would allow `cd x && rm y` while denying `rm x/y`. No warn state: its only purpose was staging, and renderHostDecision emits no text on the allow path for tool.before, so a warned denial is byte-identical to `git status` in the decision record. Tracked policy may only ENABLE this gate -- a tracked switch that disabled it would contradict policy/deft-directive-disable.ts (repository-controlled content must not disable hooks for downstream clones). Independent of runtimeAuthority.enabled in both directions. Deferred, not dropped: #3620 allow-path measurement, #3595 recognizer breadth, and the eventual default flip, which needs #3620 data first. LockedDecisions above still describes the enforcing behaviour and remains accurate for shellDestForms=enforce; it is inert at the default. Shape informed by the #3434 design-critique motion on #3594."
     },
     "items": [
       {
@@ -78,11 +78,14 @@
           "content/commands.md",
           "content/contracts/path-write-fence.md",
           "content/contracts/runtime-authority.md",
-          "packages/core/src/hooks/dest-form.ts",
           "packages/core/src/hooks/dest-form.test.ts",
-          "packages/core/src/hooks/dispatcher.ts",
+          "packages/core/src/hooks/dest-form.ts",
           "packages/core/src/hooks/dispatcher.test.ts",
-          "packages/core/src/hooks/index.ts"
+          "packages/core/src/hooks/dispatcher.ts",
+          "packages/core/src/hooks/index.ts",
+          "packages/core/src/policy/runtime-authority.test.ts",
+          "packages/core/src/policy/runtime-authority.ts",
+          "packages/core/src/policy/write-fence.ts"
         ],
         "missing_traces_justification": [
           "Issue-ingested #3438; FR traces from verified synthesis 5364744368."

--- a/.deft/approved-scope/issue-3438-shell-dest-form-scope-gate.json
+++ b/.deft/approved-scope/issue-3438-shell-dest-form-scope-gate.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "xbriefRelPath": "xbrief/active/2026-08-21-3438-scope-gate-file-mutations-via-bash-bypass-the-active-xbrief.xbrief.json",
   "planId": "issue-3438-shell-dest-form-scope-gate",
-  "approvedAt": "2026-08-21T20:06:16Z",
+  "approvedAt": "2026-08-21T21:01:17Z",
   "fileScope": [
     "CHANGELOG.md",
     "content/commands.md",
@@ -12,15 +12,18 @@
     "packages/core/src/hooks/dest-form.ts",
     "packages/core/src/hooks/dispatcher.test.ts",
     "packages/core/src/hooks/dispatcher.ts",
-    "packages/core/src/hooks/index.ts"
+    "packages/core/src/hooks/index.ts",
+    "packages/core/src/policy/runtime-authority.test.ts",
+    "packages/core/src/policy/runtime-authority.ts",
+    "packages/core/src/policy/write-fence.ts"
   ],
-  "fileScopeDigest": "8a0b23302637e38ba8de0e2499ba2b9109b60da9982f73fa5bcc6219221570c4",
+  "fileScopeDigest": "f35f58ca993dfce49ff169e13c65a2210d032a710baec12b56a5ac350623421a",
   "humanApproval": {
     "kind": "operator",
     "actor": "msadams",
-    "mintedAt": "2026-08-21T20:06:16Z",
+    "mintedAt": "2026-08-21T21:01:17Z",
     "mintedVia": "scope:record-approved-scope"
   },
-  "intentDigest": "a707dbed744f3304aa9640f7115dc6b2f1e968b0d55c13bee0717c1a21c829ed",
+  "intentDigest": "0e0be2f1f4b4e9c6cde846212117f88f6a247133713c334fa81f78f245c8db31",
   "digestAlgo": "intent-extract-v1"
 }


### PR DESCRIPTION
Supersedes the record landed in #3621. Operator-minted by msadams at 2026-08-21T21:01:17Z.

## Why a remint

Two artifact corrections the previous digests could not have covered:

1. **`file_scope` grew by three policy modules** (`policy/runtime-authority.ts`, its test, `policy/write-fence.ts`) when the operator directed the gate ship **opt-in** rather than enforcing — folding the separately-filed knob #3594 into this story.
2. **The approved intent did not record that directive.** The preimage described an *enforcing* gate for a change that deliberately enforces nothing. Same class of defect as the stale `file_scope` corrected in #3621 — an approval attesting to work that was not done — in the other direction.

## What changed in the artifact

The xBRIEF now carries the directive as `OriginDivergence` **D13**, recorded per #3383 (live operator intent contradicting a recorded xBRIEF gets written down rather than proceeding silently). D13 states:

- the directive and its rationale (no new consumer denials on a release with a large open-bug count; shipping inert removes the need to stage a breaking change)
- why `enforce` moves **both** halves together — splitting them would allow `cd x && rm y` while denying `rm x/y`
- why there is **no `warn`** state — `renderHostDecision` emits no text on the allow path for `tool.before`, so a warned denial is byte-identical to `git status` in the decision record
- that tracked policy may only **enable** the gate, per `policy/deft-directive-disable.ts` (repository-controlled content must not disable hooks for downstream clones)
- that `LockedDecisions` still describes `enforce` accurately and is simply **inert at the default** — the verified synthesis is conditioned, not overridden
- deferred, not dropped: #3620 measurement, #3595 breadth, and the eventual default flip

## Verification

Preimage read before commit per #3385: D13 present, 12-path `fileScope` matching the branch exactly, `intentDigest` `0e0be2f1`.

No product code. Force-added because `.deft/` is gitignored, consistent with the existing tracked digests.

Unblocks #3588. Refs #3438, #3594, #3145, #3205, #3385, #3383.