### PR TITLE
fix(test,windows): raise win32 testTimeout to 120s (#3616)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -205,7 +205,23 @@ export default defineConfig({
     include: ["packages/*/src/**/*.test.ts"],
     // Windows git fixture suites (session:start) exceed the 5s default under
     // full-suite parallelism; Linux CI stays on the default. Refs #2467.
-    testTimeout: isWin32 ? 20_000 : 5_000,
+    //
+    // 120s, not 20s (#3616). Windows process creation drains through a
+    // fixed-rate chokepoint (AV filter drivers scan on execute), measured at
+    // ~2.4-3.5 spawns/s at ANY concurrency: a serial `git --version` costs
+    // ~400ms and 16 concurrent cost ~4.6s each, while throughput stays flat.
+    // A git-fixture test issuing 10-30 sequential spawns therefore takes
+    // 25-80s, and the whole suite grazes the old cap -- a full run produced
+    // 164 failures, every one a timeout (min 20.04s, max 81.5s), zero
+    // assertion failures. The 20s value was calibrated when #3480 still ran
+    // files serially and was never revisited after it parallelised.
+    //
+    // ⊗ Do not "fix" this by lowering maxWorkers or re-serialising files.
+    // Spawn throughput is concurrency-independent, so capping parallelism buys
+    // nothing but wall-clock and regresses #3480. If timeouts return, the next
+    // step is partitioning spawn-heavy suites into their own vitest project
+    // (71 of 1028 files hold 79% of the failures) -- not trading cores away.
+    testTimeout: isWin32 ? 120_000 : 5_000,
     ...(coverageEnabled
       ? {
           teardownTimeout: 120_000,


### PR DESCRIPTION
One-line config change with a measured justification.

## Why

Windows process creation drains through a **fixed-rate chokepoint** — AV filter drivers scanning on execute — measured at ~2.4–3.5 spawns/s **at any concurrency**:

| Command | conc 1 | conc 8 | conc 16 |
| --- | --- | --- | --- |
| `git --version` | ~409ms | 2300ms | 4604ms |

Throughput stays flat; only latency multiplies. A git-fixture test issuing 10–30 sequential spawns therefore runs 25–80s.

A full suite run on such a machine produced **164 failures across 38 of 1028 files, every one timeout-class** — min 20.04s, p50 25.6s, p90 50.4s, max 81.5s, **zero assertion failures**. A *passing* test was clocked at 16.9s, so the suite was grazing the old 20s cap rather than sitting inside it.

The 20s value was calibrated when #3480 still ran files serially, and was never revisited after that change parallelised them. 120s clears the measured worst case with margin.

## Deliberately not doing

**Lowering `maxWorkers` or re-serialising files.** Spawn throughput is concurrency-independent, so capping parallelism costs wall-clock and buys no headroom. That is why the "cap workers locally, run the task, revert" workaround kept getting rediscovered without ever fixing anything — it never reduced throughput, it only stopped tests straddling the timeout. It also regresses #3480, whose directive ("do not serialize files or coverage processing") is still in the config.

If timeouts return, the next step is partitioning spawn-heavy suites into their own vitest project — **71 of 1028 files carry 64.6% of aggregate test time and 79% of the failures** — keeping the unit lane at full parallelism. Details and a smoke-tested config sketch are on #3616.

## Scope

- `packages/core/src/vitest-runner/vitest-config-contract.test.ts` does not pin `testTimeout`; it needs no change and still passes (16 tests).
- Linux/CI stays on the 5s default — this is win32-only, and CI was never affected (its runners lack the AV, which is why the merge gate has been green while local `task check` failed).

## Complementary, out of repo

AV exclusions for the repo, `%TEMP%`, and `git.exe`/`node.exe` roughly halved the serial spawn cost on the reporting machine (409ms → ~200ms). That makes the suite *faster*; this change makes it *pass*. Both are wanted.

Refs #3616, #3480, #2546, #2467.