### PR TITLE
fix(test,windows): stop per-test timeout overrides shadowing the win32 global (#3616)

### DIFF
--- a/packages/core/src/content-contracts/standards/taskfile_caching.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_caching.test.ts
@@ -890,7 +890,7 @@ describe("test_taskfile_caching.py", () => {
   });
   it.skipIf(!taskAvailable)(
     "test_prd_render_force_overwrites_hand_authored_prd",
-    { timeout: 60_000 },
+    { timeout: process.platform === "win32" ? 120_000 : 60_000 },
     () => {
       const fixture = mkdtempSync(join(tmpdir(), "deft-prd-render-574-"));
       try {

--- a/packages/core/src/render/framework-commands-branches.test.ts
+++ b/packages/core/src/render/framework-commands-branches.test.ts
@@ -22,7 +22,11 @@ describe("framework-commands branch coverage", () => {
     expect(cmdCoreValidate(["--extra"])).toBe(2);
   });
 
-  it("cmdCoreValidate succeeds with capture", { timeout: 5_000 }, () => {
+  // win32 keeps the global cap (#3616). A bare number here would LOWER win32
+  // below the 120s global rather than raising the tight non-win32 default.
+  it("cmdCoreValidate succeeds with capture", {
+    timeout: process.platform === "win32" ? 120_000 : 5_000,
+  }, () => {
     const root = mkdtempSync(join(tmpdir(), "fw-core-val-"));
     writeFileSync(join(root, "sample.md"), "# sample\n", "utf8");
     try {

--- a/packages/core/src/session/branches.test.ts
+++ b/packages/core/src/session/branches.test.ts
@@ -301,7 +301,9 @@ describe("session branches", () => {
   });
 
   // Linux CI full-suite can exceed the 5s default under load (merge-gate flake on #3287).
-  it("runSessionStart triage exception path", { timeout: 15_000 }, () => {
+  it("runSessionStart triage exception path", {
+    timeout: process.platform === "win32" ? 120_000 : 15_000,
+  }, () => {
     const { root, head } = initRepo();
     const result = runSessionStart(root, {
       now: new Date("2026-06-09T01:00:00Z"),

--- a/packages/core/src/session/occupancy-stress.test.ts
+++ b/packages/core/src/session/occupancy-stress.test.ts
@@ -38,7 +38,9 @@ function markersNeverInterleave(markers: string[]): boolean {
 }
 
 describe("occupancy concurrency stress (#3433)", () => {
-  it("child workers never interleave live leases", { timeout: 30_000 }, async () => {
+  it("child workers never interleave live leases", {
+    timeout: process.platform === "win32" ? 120_000 : 30_000,
+  }, async () => {
     const root = mkdtempSync(join(tmpdir(), "occupancy-stress-"));
     temps.push(root);
     const logPath = join(root, "markers.log");


### PR DESCRIPTION
Follow-up to #3623. Raising the win32 global to 120s did not reach four tests that carry their own `{ timeout: N }` — a per-test value overrides the global **in both directions**.

Every one of the four was written to **raise** the tight non-win32 default of 5s. Post-#3623 they instead **lower** win32 from 120s:

| Test | Override | Effect on win32 |
| --- | --- | --- |
| `session/branches.test.ts` | 15s | **was failing** at 15.1s |
| `render/framework-commands-branches.test.ts` | 5s | 24x below the global |
| `session/occupancy-stress.test.ts` | 30s | 4x below |
| `content-contracts/standards/taskfile_caching.test.ts` | 60s | 2x below |

`session/branches.test.ts > runSessionStart triage exception path` was **one of the two survivors** of the #3623 validation run (154 failures → 2). Its own comment attributes the override to "Linux CI full-suite under load (merge-gate flake on #3287)" — so the intent was always a floor, never a ceiling.

Each becomes `process.platform === "win32" ? 120_000 : <original>`, preserving the non-win32 intent exactly while letting win32 keep the global cap.

## Verification

- `session/branches.test.ts`: **8/8** (previously 1 failed at 15,110ms)
- The three fast suites together: **17/17**
- `tsc --noEmit` clean, biome clean

## Note for future overrides

A bare `{ timeout: N }` is a **ceiling on every platform**. If the intent is "at least N on slow CI", it must be written platform-aware or it silently caps whichever platform has the larger global. That is the trap this PR is cleaning up, and it will recur otherwise.

Refs #3616, #3623, #3287.