### PR TITLE
fix(authz): win32 mint probe uses device-namespace CONIN$ (#3596 leftover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Win32 operator mint opens `\\.\CONIN$` with r+ (#3596 leftover).** Bare `CONIN$` ENOENT on a real console. Probe errors still refuse mint. Refs #3596, #3110.
 - **Shell dest-form wrappers still see the verb after a post-flag env assignment (#3438 leftover).** `sudo -u root GIT_WORK_TREE=pkg git checkout -- file` stays recognized (fail-closed on work-tree). `sudo grep rm file` stays unclassifiable. Refs #3438.
 - **Shell dest-form wrappers do not treat a later `rm` data token as the verb (#3438 leftover).** `sudo grep rm file` stays unclassifiable. Value-taking wrapper flags (`sudo -u`, `env -u`) still find the real verb. Refs #3438.
 - **Shell dest-form treats escaped `$` / backtick as literal dest characters (#3438 leftover).** Double-quoted `\$` / `` \` `` and single-quoted `$` no longer fail closed as unresolved substitution under `shellDestForms: enforce`. Unescaped `"$TARGET"` and `` `cmd` `` still deny. Refs #3438, #3594.

--- a/content/docs/scope-provenance.md
+++ b/content/docs/scope-provenance.md
@@ -70,7 +70,7 @@ task scope:record-approved-scope -- xbrief/active/story.xbrief.json --actor scot
 
 Mint uses the shared #3110 human-presence gate (same module as `authz`):
 
-- Interactive TTY (stdin + stdout) and a controlling terminal (`/dev/tty` or `CONIN$`)
+- Interactive TTY (stdin + stdout) and a controlling terminal (`/dev/tty` or `\\.\CONIN$`)
 - Explicit `--confirm`
 - Typed phrase `mint` on the controlling TTY
 - Agent/CI env markers (`AUTHZ_AGENT_SHELL_ENV_MARKERS`) refuse fail-closed

--- a/packages/cli/src/authz.ts
+++ b/packages/cli/src/authz.ts
@@ -284,7 +284,7 @@ function helpText(): string {
     "  (grant / uat-start / uat-suspend / revoke) — no TTY, --confirm, or phrase path.",
     "  Self-approval under UAT is impossible by construction. Mint grants BEFORE uat-start.",
     "Outside UAT, mutating verbs require multi-factor human presence (#3110):",
-    "  - Interactive TTY (stdin+stdout) + controlling terminal (/dev/tty|CONIN$)",
+    "  - Interactive TTY (stdin+stdout) + controlling terminal (/dev/tty|\\\\.\\CONIN$)",
     "  - Explicit --confirm (argv flag alone never enough)",
     "  - Typed phrase 'mint' on the controlling TTY (PTY+--confirm alone never enough)",
     "  - Known agent/CI env markers always refuse (fail-closed).",

--- a/packages/cli/src/human-presence-mint.open-flag.test.ts
+++ b/packages/cli/src/human-presence-mint.open-flag.test.ts
@@ -28,7 +28,7 @@ describe("controlling-terminal open flag (#3596)", () => {
   });
 
   it("default probe and phrase read open the platform device with the platform flag", () => {
-    const expectedPath = process.platform === "win32" ? "CONIN$" : "/dev/tty";
+    const expectedPath = process.platform === "win32" ? "\\\\.\\CONIN$" : "/dev/tty";
     const expectedFlag = process.platform === "win32" ? "r+" : "r";
     const seams = resolveHumanPresenceMintSeams();
     expect(seams.hasControllingTerminal()).toBe(true);
@@ -36,5 +36,14 @@ describe("controlling-terminal open flag (#3596)", () => {
     hoisted.openSyncMock.mockClear();
     expect(seams.readInteractiveConfirm()).toBe("mint");
     expect(hoisted.openSyncMock).toHaveBeenCalledWith(expectedPath, expectedFlag);
+  });
+
+  it("probe catch returns false when the controlling terminal open throws", () => {
+    hoisted.openSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const seams = resolveHumanPresenceMintSeams();
+    expect(seams.hasControllingTerminal()).toBe(false);
+    expect(seams.readInteractiveConfirm()).toBeNull();
   });
 });

--- a/packages/cli/src/human-presence-mint.test.ts
+++ b/packages/cli/src/human-presence-mint.test.ts
@@ -140,8 +140,8 @@ describe("shared #3110 human-presence mint (#3384)", () => {
     expect(resolved.environ).toBe(process.env);
   });
 
-  it("opens CONIN$ with r+ on win32 and /dev/tty with r elsewhere (#3596)", () => {
-    expect(controllingTerminalPath("win32")).toBe("CONIN$");
+  it("opens the win32 device-namespace CONIN$ path with r+ and /dev/tty with r elsewhere (#3596 leftover)", () => {
+    expect(controllingTerminalPath("win32")).toBe("\\\\.\\CONIN$");
     expect(controllingTerminalOpenFlag("win32")).toBe("r+");
     expect(controllingTerminalPath("linux")).toBe("/dev/tty");
     expect(controllingTerminalOpenFlag("linux")).toBe("r");

--- a/packages/cli/src/human-presence-mint.ts
+++ b/packages/cli/src/human-presence-mint.ts
@@ -69,7 +69,7 @@ export interface HumanPresenceMintSeams {
   /** Environ for agent-shell marker detection (default: process.env). */
   readonly environ?: NodeJS.ProcessEnv;
   /**
-   * True when a controlling terminal device is available (`/dev/tty` or `CONIN$`).
+   * True when a controlling terminal device is available (`/dev/tty` or `\\.\CONIN$`).
    * Default: open/close the platform controlling terminal (fail-closed on error).
    */
   readonly hasControllingTerminal?: () => boolean;
@@ -92,16 +92,17 @@ function defaultIsTty(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
 
-/** Platform controlling-terminal path (`CONIN$` on win32, `/dev/tty` elsewhere). */
+/** Platform controlling-terminal path (`\\.\CONIN$` on win32, `/dev/tty` elsewhere). */
 export function controllingTerminalPath(platform: NodeJS.Platform = process.platform): string {
-  return platform === "win32" ? "CONIN$" : "/dev/tty";
+  // Real-console diagnostic on #3596: bare CONIN$ and CON ENOENT; device-namespace path opens.
+  return platform === "win32" ? "\\\\.\\CONIN$" : "/dev/tty";
 }
 
 /**
- * Open flag for the platform controlling-terminal device (#3596).
+ * Open flag for the platform controlling-terminal device (#3596 leftover).
  *
- * Windows `CONIN$` generally requires read/write (`r+`); `r` (O_RDONLY) fails
- * in a real interactive console and made operator mint unreachable on win32.
+ * Win32 stays `r+` so the probe and phrase-read share one flag. The leftover
+ * path is the Windows device-namespace CONIN$ string, not bare CONIN$.
  */
 export function controllingTerminalOpenFlag(
   platform: NodeJS.Platform = process.platform,
@@ -184,7 +185,7 @@ export function refuseMintWhileUatActive(verb: string, projectRoot: string): num
  * Multi-factor human-presence gate (applies only when UAT lease is inactive):
  * 1. No known agent/CI env markers
  * 2. Interactive TTY (stdin + stdout isTTY)
- * 3. Controlling terminal device present (`/dev/tty` / `CONIN$`)
+ * 3. Controlling terminal device present (`/dev/tty` / `\\.\CONIN$`)
  * 4. Explicit argv `--confirm` (flag alone never enough)
  * 5. Interactive typed phrase `mint` (argv --confirm alone never enough even on PTY)
  *


### PR DESCRIPTION
## Summary

Win32 operator mint still opened bare CONIN$ with r+ (PR 3605). A real-console diagnostic on #3596 showed bare CONIN$ and CON ENOENT for both r and r+; the Windows device-namespace path opened for both flags.

This leftover probe uses that device-namespace path and keeps r+ so the probe and phrase-read share one flag. Open errors still refuse mint. A successful open is device present only. The #3110 env-marker, TTY, --confirm, and typed-phrase gates are unchanged.

Mint E2E on a real Windows console remains a human issue-close gate. This PR must not close GitHub #3596.

## Related Issues

Refs #3596
Refs #3110

## Checklist

- [x] /deft:change <name> — N/A (4 files, leftover probe on the existing mint module; not cross-cutting)
- [x] CHANGELOG.md — Unreleased line
- [x] ROADMAP.md — N/A (issue stays open until mint E2E)
- [x] Tests pass locally

## Test plan

- pnpm exec vitest run packages/cli/src/human-presence-mint.test.ts packages/cli/src/human-presence-mint.open-flag.test.ts
- task check: 1023 files passed, 14446 tests passed, 149 skipped; coverage statements 88.07 / branches 81.29 / functions 93.45 / lines 88.99

## Post-Merge

- After squash, confirm GitHub #3596 stays OPEN. Human mint E2E on a real console is the close gate.
