### PR TITLE
chore(xbrief): land leftover completed-tracked artifact for #3637

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Land leftover completed-tracked artifact for #3637 (#3264 / #1358).** The #3637 xBRIEF stayed untracked after squash of PR 3644. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for leftover #3596 probe (#3264 / #1358).** The leftover probe xBRIEF stayed untracked after squash of PR 3639. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #3627 (#3264 / #1358).** The #3627 xBRIEF stayed untracked after squash of PR 3635. Moved to `xbrief/completed/` via `swarm:finalize-cohort`. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #3628 (#3264 / #1358).** The #3628 xBRIEF stayed untracked after squash of PR 3634. Moved to `xbrief/completed/` via `swarm:finalize-cohort`. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-08-23-3637-doctor-header-drift-bare-vbrief-slash.xbrief.json
+++ b/xbrief/completed/2026-08-23-3637-doctor-header-drift-bare-vbrief-slash.xbrief.json
@@ -1,0 +1,240 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Doctor AGENTS.md header-drift over-fires on bare vbrief/ in prose; recut detector and rewriter per #3637 successor lean.",
+    "updated": "2026-08-23T15:45:48Z"
+  },
+  "plan": {
+    "id": "issue-3637-doctor-header-drift-bare-vbrief",
+    "title": "doctor header drift: left-bound vbrief/ and stop lying migrate:xbrief on already-xbrief",
+    "status": "completed",
+    "narratives": {
+      "Description": "detectStaleUnmanagedHeader uses includes on vbrief/, so a directory-name mention in unmanaged prose is the same hit as a layout pointer. Recut detector and rewriter together. Do not implement the original write-back 5386611610.",
+      "Origin": "GitHub issue #3637. Bind successor lean 5386676555 plus verified-claims table 5386676545. Synthesis accepted 5386676545. Supersedes triage write-back 5386611610. Critic 5386657693. Consumer-filed via feedback:file (#1709).",
+      "Overview": "Keep .vbrief.json and vbrief:preflight as hard hits. Left-bound vbrief/ so x-vbrief leftover prefix  is not a hit. Hard rewrite and hard doctor hits are those two plus left-bounded vbrief/ with a child segment. Bare vbrief/ with no child, including the #2154 backtick exemplar, is one class: detector may mention it; rewriter must not replaceAll it. Doctor line on already-xbrief trees must not say Run deft migrate:xbrief. Do not wire header patch onto already-xbrief until the rewriter is split. Reject issue-body path-that-resolves and exempt-all-backticks.",
+      "UserStory": "As an already-xbrief operator, I want doctor not to call a directory-name mention in the unmanaged header a layout pointer, and not to tell me to run migrate:xbrief when that command will not patch.",
+      "When": "When an unmanaged header names vbrief/ with no child segment, the rewriter leaves it; child-path / .vbrief.json / vbrief:preflight still rewrite; x-vbrief leftover prefix  is not a hit; already-xbrief doctor copy does not point at migrate:xbrief; tests lock those four; CHANGELOG has an Unreleased line.",
+      "LockedDecisions": "Bind 5386676555 + 5386676545, not 5386611610. Left-bound vbrief/. Hard rewrite+doctor: .vbrief.json, vbrief:preflight, left-bounded vbrief/ plus child. Bare vbrief/ including live-in backtick exemplar: one class; detector may mention; rewriter must not replaceAll. Backticks are not a discriminator. Issue-body exempt-backticks and path-that-resolves stay rejected. Already-xbrief doctor line: hand-edit, not Run deft migrate:xbrief (that CLI patches only after kind migrated). Do not wire already-xbrief header patch until rewriter is split. Do not add a second drift subsystem. Out: platform:windows, mint/authz #3596/#3638, auto-dispatch, new matcher language.",
+      "ImplementationPlan": "1. Split matcher/rewriter in packages/core/src/xbrief-migrate/agents-header.ts. 2. Change renderStaleHeaderLine for already-xbrief. 3. Tests in agents-header.test.ts and doctor.test.ts as named in the lean. 4. UPGRADING.md sentence that tells already-xbrief operators to re-run migrate:xbrief to patch the header. 5. CHANGELOG Unreleased. 6. Closes #3637.",
+      "OriginDivergence": "Issue body suggested path-that-resolves and exempt backticked tokens; both rejected (finding 8). Title overstates the word vbrief; matcher is vbrief/ with slash. Comments 5386676555/5386676545 are the next-build contract."
+    },
+    "items": [
+      {
+        "title": "Left-bound vbrief/ so x-vbrief leftover prefix  is not a hit",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When unmanaged text contains x-vbrief leftover prefix  or x-vbrief leftover plan prefix, detect and rewrite do not treat that as a vbrief/ layout pointer and do not emit x-xbrief/.",
+          "Acceptance": "When unmanaged text contains x-vbrief leftover prefix  or x-vbrief leftover plan prefix, detect and rewrite do not treat that as a vbrief/ layout pointer and do not emit x-xbrief/."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/xbrief-migrate/agents-header.test.ts#x-vbrief-non-hit",
+          "recorded_at": "2026-08-23T15:45:43Z",
+          "recorded_by": "leaf-implementation/3637"
+        }
+      },
+      {
+        "title": "Hard rewrite and hard doctor hits are .vbrief.json, vbrief:preflight, and left-bounded vbrief/ plus a child segment",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When unmanaged text has .vbrief.json, vbrief:preflight, or left-bounded vbrief/active/..., detect flags them and rewrite maps them to the xbrief forms.",
+          "Acceptance": "When unmanaged text has .vbrief.json, vbrief:preflight, or left-bounded vbrief/active/..., detect flags them and rewrite maps them to the xbrief forms."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/xbrief-migrate/agents-header.test.ts#child-path-rewrite",
+          "recorded_at": "2026-08-23T15:45:43Z",
+          "recorded_by": "leaf-implementation/3637"
+        }
+      },
+      {
+        "title": "Bare vbrief/ is not rewritten, including the #2154 backtick exemplar",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When unmanaged text has bare vbrief/ with no child segment, including Scoped work items live in backtick-vbrief-slash, the rewriter leaves that substring; backticks are not a discriminator.",
+          "Acceptance": "When unmanaged text has bare vbrief/ with no child segment, including Scoped work items live in backtick-vbrief-slash, the rewriter leaves that substring; backticks are not a discriminator."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/xbrief-migrate/agents-header.test.ts#bare-vbrief-prose",
+          "recorded_at": "2026-08-23T15:45:43Z",
+          "recorded_by": "leaf-implementation/3637"
+        }
+      },
+      {
+        "title": "Already-xbrief doctor line does not say Run deft migrate:xbrief",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When detectStaleUnmanagedHeader can fire (xbrief/ tree present), renderStaleHeaderLine does not tell the operator to run deft migrate:xbrief, because that CLI path does not call patchAgentsMdHeader except after kind migrated.",
+          "Acceptance": "When detectStaleUnmanagedHeader can fire (xbrief/ tree present), renderStaleHeaderLine does not tell the operator to run deft migrate:xbrief, because that CLI path does not call patchAgentsMdHeader except after kind migrated."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/cli/src/doctor.test.ts#already-xbrief-hand-edit",
+          "recorded_at": "2026-08-23T15:45:43Z",
+          "recorded_by": "leaf-implementation/3637"
+        }
+      },
+      {
+        "title": "Do not wire already-xbrief header patch until rewriter is split",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When migrate:xbrief runs on an already-xbrief tree, it still does not call patchAgentsMdHeader. Accidental safety stays until this PR's rewriter split is in place; this story does not add a new already-xbrief patch path.",
+          "Acceptance": "When migrate:xbrief runs on an already-xbrief tree, it still does not call patchAgentsMdHeader. Accidental safety stays until this PR's rewriter split is in place; this story does not add a new already-xbrief patch path."
+        },
+        "x-directive/evidence": {
+          "kind": "review",
+          "pointer": "packages/core/src/xbrief-migrate/migrate-project.ts#header-patch-after-migrated-only",
+          "recorded_at": "2026-08-23T15:45:43Z",
+          "recorded_by": "leaf-implementation/3637"
+        }
+      },
+      {
+        "title": "Tests and CHANGELOG lock the recut",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When the named tests pass, STALE_HEADER no longer requires live-in backtick-vbrief-slash to become xbrief/; unmanaged prose backtick-vbrief-slash is allowed; child-path / .vbrief.json / vbrief:preflight still rewrite; x-vbrief leftover prefix  is a non-hit; CHANGELOG Unreleased names the leftover doctor false signpost.",
+          "Acceptance": "When the named tests pass, STALE_HEADER no longer requires live-in backtick-vbrief-slash to become xbrief/; unmanaged prose backtick-vbrief-slash is allowed; child-path / .vbrief.json / vbrief:preflight still rewrite; x-vbrief leftover prefix  is a non-hit; CHANGELOG Unreleased names the leftover doctor false signpost."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/xbrief-migrate/agents-header.test.ts#3637-and-CHANGELOG",
+          "recorded_at": "2026-08-23T15:45:43Z",
+          "recorded_by": "leaf-implementation/3637"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "doctor"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3637",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3637"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3637#issuecomment-5386676555",
+        "type": "x-xbrief/github-comment",
+        "title": "Successor lean 5386676555"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3637#issuecomment-5386676545",
+        "type": "x-xbrief/github-comment",
+        "title": "Verified-claims and synthesis 5386676545"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2154",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2154 (closed; this is over-fire of that detector)"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/xbrief-migrate/agents-header.ts",
+          "packages/core/src/xbrief-migrate/agents-header.test.ts",
+          "packages/cli/src/doctor.test.ts",
+          "content/UPGRADING.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/xbrief-migrate/agents-header.test.ts packages/cli/src/doctor.test.ts"
+        ],
+        "expected_outputs": [
+          "left-bound vbrief/; bare directory mention not rewritten; already-xbrief doctor line not migrate:xbrief"
+        ],
+        "depends_on": [],
+        "conflict_group": "xbrief-header-drift-3637",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": [
+          "Bind 5386676555. Stay out of #3596/#3638 mint. Do not auto-dispatch critique."
+        ]
+      },
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [
+          "packages/core/src/xbrief-migrate/agents-header.ts",
+          "packages/core/src/xbrief-migrate/agents-header.test.ts",
+          "packages/cli/src/doctor.test.ts",
+          "content/UPGRADING.md",
+          "CHANGELOG.md"
+        ],
+        "module_boundary": "packages/core/src/xbrief-migrate",
+        "cohesion_exemption": "CHANGELOG.md and UPGRADING.md may already exceed FILE_SIZE_REVIEW_TRIGGER_LINES; this slice adds one Unreleased line and one already-xbrief doctor-copy correction."
+      },
+      "capacityBucket": "bugfix",
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3644,
+        "prBase": null,
+        "mergeCommit": "188f3b2390c758e5a349434687f8e92fe2e00d38",
+        "deliveryBranch": "master",
+        "deliveryCommit": "188f3b2390c758e5a349434687f8e92fe2e00d38",
+        "verifiedAt": "2026-08-23T15:45:48Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "e7664872-3917-4870-88b2-2e570cf2191d"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-23T15:45:48Z",
+      "completedSessionId": "e7664872-3917-4870-88b2-2e570cf2191d"
+    },
+    "updated": "2026-08-23T15:45:48Z",
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 1 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Split matcher/rewriter in packages/core/src/xbrief-migrate/agents-header.ts. 2. Change renderStaleHeaderLine for already-xbrief. 3. Tests in agents-header.test.ts and doctor.test.ts as named in the lean. 4. UPGRADING.md sentence that tells already-xbrief operators to re-run migrate:xbrief to patch the header. 5. CHANGELOG Unreleased. 6. Closes #3637.",
+          "artifact_path": "packages/core/src/xbrief-migrate/agents-header.ts",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "Split matcher/rewriter in packages/core/src/xbrief-migrate/agents-header.ts. 2. Change renderStaleHeaderLine for already-xbrief. 3. Tests in agents-header.test.ts and doctor.test.ts as named in the lean. 4. UPGRADING.md sentence that tells already-xbrief operators to re-run migrate:xbrief to patch the header. 5. CHANGELOG Unreleased. 6. Closes #3637. [reading: packages/core/src/xbrief-migrate/agents-header.ts]",
+              "artifact_path": "packages/core/src/xbrief-migrate/agents-header.ts"
+            },
+            {
+              "text": "Split matcher/rewriter in packages/core/src/xbrief-migrate/agents-header.ts. 2. Change renderStaleHeaderLine for already-xbrief. 3. Tests in agents-header.test.ts and doctor.test.ts as named in the lean. 4. UPGRADING.md sentence that tells already-xbrief operators to re-run migrate:xbrief to patch the header. 5. CHANGELOG Unreleased. 6. Closes #3637. [reading: agents-header.test.ts]",
+              "artifact_path": "agents-header.test.ts"
+            },
+            {
+              "text": "Split matcher/rewriter in packages/core/src/xbrief-migrate/agents-header.ts. 2. Change renderStaleHeaderLine for already-xbrief. 3. Tests in agents-header.test.ts and doctor.test.ts as named in the lean. 4. UPGRADING.md sentence that tells already-xbrief operators to re-run migrate:xbrief to patch the header. 5. CHANGELOG Unreleased. 6. Closes #3637. [reading: doctor.test.ts]",
+              "artifact_path": "doctor.test.ts"
+            },
+            {
+              "text": "Split matcher/rewriter in packages/core/src/xbrief-migrate/agents-header.ts. 2. Change renderStaleHeaderLine for already-xbrief. 3. Tests in agents-header.test.ts and doctor.test.ts as named in the lean. 4. UPGRADING.md sentence that tells already-xbrief operators to re-run migrate:xbrief to patch the header. 5. CHANGELOG Unreleased. 6. Closes #3637. [reading: UPGRADING.md]",
+              "artifact_path": "UPGRADING.md"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        }
+      ]
+    }
+  },
+  "vBRIEFInfo": {
+    "version": "0.8",
+    "updated": "2026-08-23T15:45:48Z"
+  }
+}


### PR DESCRIPTION
## Summary

Land leftover completed-tracked artifact for #3637 after squash of PR 3644. The xBRIEF stayed untracked because lifecycle folders are gitignored. Force-add to xbrief/completed/. Does not reopen or recut that issue.

## Related Issues

Refs #3637
Refs #2321
Refs #3476
Refs #3264
Refs #1358

## Checklist

- [x] `/deft:change <name>` — N/A: leftover completed-tracked land after merge
- [x] `CHANGELOG.md` — leftover Unreleased Added line
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally — N/A (no product code)

## Post-Merge

- [x] Issue #3637 already closed by PR 3644
