### PR TITLE
perf(ci): skip optional jobs on leftover-completion diffs

### DIFF
--- a/.github/scripts/artifact-only-lifecycle.mjs
+++ b/.github/scripts/artifact-only-lifecycle.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Artifact-only lifecycle predicate (#3678).
+ *
+ * Allowlist is exactly {xbrief/completed/**, CHANGELOG.md}. Widening it is a
+ * gate change, not maintenance. Evaluated on the complete merge-base diff
+ * (caller supplies the path list); any other path takes the full CI stack.
+ *
+ * Empty input fails closed to the full stack.
+ *
+ * CLI: node artifact-only-lifecycle.mjs [--stdin | path...]
+ * stdout: artifact_only=true|false
+ */
+
+import { readFileSync } from "node:fs";
+
+/** @param {string} path */
+export function normalizeRepoPath(path) {
+  return String(path ?? "")
+    .trim()
+    .replaceAll("\\", "/");
+}
+
+/** @param {string} path */
+export function isAllowlistedLifecyclePath(path) {
+  const n = normalizeRepoPath(path);
+  if (!n) return false;
+  if (n === "CHANGELOG.md") return true;
+  return n.startsWith("xbrief/completed/");
+}
+
+/**
+ * @param {string[]} paths
+ * @returns {boolean}
+ */
+export function isArtifactOnlyLifecycle(paths) {
+  const cleaned = (Array.isArray(paths) ? paths : []).map(normalizeRepoPath).filter(Boolean);
+  if (cleaned.length === 0) return false;
+  return cleaned.every(isAllowlistedLifecyclePath);
+}
+
+/**
+ * @param {string[]} argv
+ * @param {{ stdin?: string }} [io]
+ * @returns {{ artifact_only: boolean, paths: string[] }}
+ */
+export function evaluateArgv(argv, io = {}) {
+  let paths;
+  if (argv[0] === "--stdin") {
+    const raw = io.stdin ?? readFileSync(0, { encoding: "utf8" });
+    paths = raw.split(/\r?\n/);
+  } else {
+    paths = argv;
+  }
+  const artifact_only = isArtifactOnlyLifecycle(paths);
+  return { artifact_only, paths: paths.map(normalizeRepoPath).filter(Boolean) };
+}
+
+function main(argv) {
+  const { artifact_only } = evaluateArgv(argv);
+  console.log(`artifact_only=${artifact_only ? "true" : "false"}`);
+}
+
+const invokedDirectly =
+  Boolean(process.argv[1]) &&
+  process.argv[1].replaceAll("\\", "/").endsWith("artifact-only-lifecycle.mjs");
+
+if (invokedDirectly) {
+  main(process.argv.slice(2));
+}

--- a/.github/scripts/compute-artifact-only.sh
+++ b/.github/scripts/compute-artifact-only.sh
@@ -34,9 +34,16 @@ if [ -z "${BASE:-}" ] || [ "$BASE" = "$ZERO" ] || [ "$BASE" = "origin/" ] || [ -
   exit 0
 fi
 
+# Caller MUST pass ARTIFACT_ONLY_SCRIPT from a merge-base `git show`.
+# Unset means the workspace (PR HEAD) copy would be used — fail closed.
+if [ -z "${ARTIFACT_ONLY_SCRIPT:-}" ]; then
+  echo "ARTIFACT_ONLY_SCRIPT unset; refusing HEAD predicate; routing to full stack"
+  echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
 files="$(git diff --name-only --no-renames --diff-filter=ACDMRT "${BASE}...${TIP}" || true)"
 printf '%s\n' "$files"
-result="$(printf '%s\n' "$files" | node .github/scripts/artifact-only-lifecycle.mjs --stdin || true)"
+result="$(printf '%s\n' "$files" | node "$ARTIFACT_ONLY_SCRIPT" --stdin || true)"
 echo "$result"
 case "$result" in
   artifact_only=true) artifact_only=true ;;

--- a/.github/scripts/compute-artifact-only.sh
+++ b/.github/scripts/compute-artifact-only.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Merge-base artifact-only predicate (#3678).
+# Writes artifact_only=true|false to $GITHUB_OUTPUT. Fail closed: unknown
+# event, unusable base, or script error -> false (full stack).
+#
+# --no-renames: git name-only would otherwise emit only the destination of a
+# rename into the allowlist and skip optional jobs.
+set -eu
+
+artifact_only=false
+ZERO="0000000000000000000000000000000000000000"
+EVENT_NAME="${EVENT_NAME:-}"
+BASE_REF="${BASE_REF:-}"
+PR_HEAD_SHA="${PR_HEAD_SHA:-}"
+PUSH_BEFORE="${PUSH_BEFORE:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+
+if [ "$EVENT_NAME" = "pull_request" ]; then
+  git fetch --no-tags origin "$BASE_REF" || true
+  BASE="origin/${BASE_REF}"
+  TIP="$PR_HEAD_SHA"
+elif [ "$EVENT_NAME" = "push" ]; then
+  BASE="$PUSH_BEFORE"
+  TIP="$HEAD_SHA"
+else
+  echo "Unknown event ${EVENT_NAME}; routing to full stack"
+  echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+if [ -z "${BASE:-}" ] || [ "$BASE" = "$ZERO" ] || [ "$BASE" = "origin/" ] || [ -z "${TIP:-}" ]; then
+  echo "Unusable merge-base (base=${BASE:-empty} tip=${TIP:-empty}); routing to full stack"
+  echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+files="$(git diff --name-only --no-renames --diff-filter=ACDMRT "${BASE}...${TIP}" || true)"
+printf '%s\n' "$files"
+result="$(printf '%s\n' "$files" | node .github/scripts/artifact-only-lifecycle.mjs --stdin || true)"
+echo "$result"
+case "$result" in
+  artifact_only=true) artifact_only=true ;;
+  *) artifact_only=false ;;
+esac
+echo "artifact_only=${artifact_only}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/branch-gate.yml
+++ b/.github/workflows/branch-gate.yml
@@ -3,6 +3,9 @@ name: branch-gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+    paths-ignore:
+      - "xbrief/completed/**"
+      - "CHANGELOG.md"
 
 permissions:
   contents: read

--- a/.github/workflows/branch-gate.yml
+++ b/.github/workflows/branch-gate.yml
@@ -3,9 +3,6 @@ name: branch-gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    paths-ignore:
-      - "xbrief/completed/**"
-      - "CHANGELOG.md"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,37 +92,7 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          artifact_only=false
-          ZERO="0000000000000000000000000000000000000000"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            git fetch --no-tags origin "$BASE_REF" || true
-            BASE="origin/${BASE_REF}"
-            TIP="$PR_HEAD_SHA"
-          elif [ "$EVENT_NAME" = "push" ]; then
-            BASE="$PUSH_BEFORE"
-            TIP="$HEAD_SHA"
-          else
-            echo "Unknown event ${EVENT_NAME}; routing to full stack"
-            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ -z "${BASE:-}" ] || [ "$BASE" = "$ZERO" ] || [ "$BASE" = "origin/" ] || [ -z "${TIP:-}" ]; then
-            echo "Unusable merge-base (base=${BASE:-empty} tip=${TIP:-empty}); routing to full stack"
-            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # --no-renames: name-only otherwise emits only the destination of a
-          # rename into the allowlist and would skip optional jobs (#3678 P2).
-          files="$(git diff --name-only --no-renames --diff-filter=ACDMRT "${BASE}...${TIP}" || true)"
-          printf '%s\n' "$files"
-          result="$(printf '%s\n' "$files" | node .github/scripts/artifact-only-lifecycle.mjs --stdin || true)"
-          echo "$result"
-          case "$result" in
-            artifact_only=true) artifact_only=true ;;
-            *) artifact_only=false ;;
-          esac
-          echo "artifact_only=${artifact_only}" >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/compute-artifact-only.sh
 
   ts-primary:
     name: TypeScript (Blacksmith primary)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   #
   # | Role        | Workflow job id      | Display / check name                    | Required? |
   # |-------------|----------------------|-----------------------------------------|-----------|
+  # | Predicate   | changes              | Changes (artifact-only predicate)       | no        |
   # | Primary TS  | ts-primary           | TypeScript (Blacksmith primary)         | no        |
   # | Primary Go  | go-primary           | Go (Blacksmith primary)                 | no        |
   # | Primary MG  | merge-gate-primary   | Merge gate (Blacksmith primary)         | no        |
@@ -55,9 +56,12 @@ jobs:
   # | Failover Go | go-failover          | Go (GH-hosted failover)                 | no        |
   # | Failover MG | merge-gate-failover  | Merge gate (GH-hosted failover)         | no        |
   # | Aggregator  | ts                   | TypeScript (build + lint + test)        | YES       |
-  # | Aggregator  | go                   | Go (test + build)                       | YES       |
-  # | Aggregator  | merge-gate           | Merge gate (task check)                 | YES       |
+  # | Aggregator  | go                   | Go (test + build)                       | no        |
+  # | Aggregator  | merge-gate           | Merge gate (task check)                 | no        |
   #
+  # Live branch protection requires ONLY the TypeScript aggregator.
+  # Go and merge-gate aggregators are not required; they skip on diffs
+  # confined to {xbrief/completed/**, CHANGELOG.md} (#3678).
   # Primary/failover lane names must never be branch-protection required checks.
   # -------------------------------------------------------------------------
 
@@ -66,6 +70,58 @@ jobs:
   # required checks — those live only on the aggregators below.
   # No concurrency group on these caller jobs (invalidates workflow_call graphs).
   # -------------------------------------------------------------------------
+  # Merge-base predicate for leftover-completion diffs (#3678). Fail closed:
+  # any error or empty/unusable base routes to the full stack (artifact_only=false).
+  # Do NOT copy this as workflow-level paths: — the required TS aggregator
+  # must still report. Allowlist widening is a gate change, not maintenance.
+  changes:
+    name: Changes (artifact-only predicate)
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_only: ${{ steps.predicate.outputs.artifact_only }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Compute artifact-only predicate against merge base
+        id: predicate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          artifact_only=false
+          ZERO="0000000000000000000000000000000000000000"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "$BASE_REF" || true
+            BASE="origin/${BASE_REF}"
+            TIP="$PR_HEAD_SHA"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            BASE="$PUSH_BEFORE"
+            TIP="$HEAD_SHA"
+          else
+            echo "Unknown event ${EVENT_NAME}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ "$BASE" = "$ZERO" ] || [ "$BASE" = "origin/" ] || [ -z "${TIP:-}" ]; then
+            echo "Unusable merge-base (base=${BASE:-empty} tip=${TIP:-empty}); routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files="$(git diff --name-only --diff-filter=ACDMRT "${BASE}...${TIP}" || true)"
+          printf '%s\n' "$files"
+          result="$(printf '%s\n' "$files" | node .github/scripts/artifact-only-lifecycle.mjs --stdin || true)"
+          echo "$result"
+          case "$result" in
+            artifact_only=true) artifact_only=true ;;
+            *) artifact_only=false ;;
+          esac
+          echo "artifact_only=${artifact_only}" >> "$GITHUB_OUTPUT"
+
   ts-primary:
     name: TypeScript (Blacksmith primary)
     uses: ./.github/workflows/ci-lane.yml
@@ -75,6 +131,8 @@ jobs:
 
   go-primary:
     name: Go (Blacksmith primary)
+    needs: [changes]
+    if: always() && needs.changes.outputs.artifact_only != 'true'
     uses: ./.github/workflows/ci-lane.yml
     with:
       suite: go
@@ -82,6 +140,8 @@ jobs:
 
   merge-gate-primary:
     name: Merge gate (Blacksmith primary)
+    needs: [changes]
+    if: always() && needs.changes.outputs.artifact_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -133,9 +193,13 @@ jobs:
   # -------------------------------------------------------------------------
   capacity-watchdog:
     name: Capacity watchdog
+    needs: [changes]
+    if: always()
     runs-on: ubuntu-latest
     # Isolate from primary-lane cancel thrash: this job never needs: primaries
     # and is not selected by cancel-queued-ci-primary.mjs needles.
+    # Artifact-only diffs still start the TS primary, so this job still runs;
+    # it must not treat skipped Go/merge-gate jobs as capacity death (#3678).
     outputs:
       ts_failover: ${{ steps.poll.outputs.ts_failover }}
       go_failover: ${{ steps.poll.outputs.go_failover }}
@@ -150,28 +214,33 @@ jobs:
           POLL_SECONDS: ${{ env.CI_CAPACITY_POLL_SECONDS }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
+          ARTIFACT_ONLY: ${{ needs.changes.outputs.artifact_only }}
         run: |
           set -euo pipefail
           ts_failover=false
           go_failover=false
           merge_failover=false
-          echo "Stall budget=${STALL_BUDGET_SECONDS}s poll=${POLL_SECONDS}s run=${RUN_ID}"
+          echo "Stall budget=${STALL_BUDGET_SECONDS}s poll=${POLL_SECONDS}s run=${RUN_ID} artifact_only=${ARTIFACT_ONLY}"
 
           while true; do
             jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")"
             ts_state="$(node .github/scripts/classify-ci-job-state.mjs "typescript (blacksmith primary)" "$jobs_json")"
-            go_state="$(node .github/scripts/classify-ci-job-state.mjs "go (blacksmith primary)" "$jobs_json")"
-            merge_state="$(node .github/scripts/classify-ci-job-state.mjs "merge gate (blacksmith primary)" "$jobs_json")"
-            echo "state ts=${ts_state} go=${go_state} merge=${merge_state} elapsed=${SECONDS}s"
+            go_state="done"
+            merge_state="done"
+            if [[ "$ARTIFACT_ONLY" != "true" ]]; then
+              go_state="$(node .github/scripts/classify-ci-job-state.mjs "go (blacksmith primary)" "$jobs_json")"
+              merge_state="$(node .github/scripts/classify-ci-job-state.mjs "merge gate (blacksmith primary)" "$jobs_json")"
+            fi
+            echo "state ts=${ts_state} go=${go_state} merge=${merge_state} elapsed=${SECONDS}s artifact_only=${ARTIFACT_ONLY}"
 
             # #3168: cancelled/skipped without a runner claim = capacity death → arm now.
             if [[ "$ts_state" == "cancelled_unclaimed" ]]; then
               ts_failover=true
             fi
-            if [[ "$go_state" == "cancelled_unclaimed" ]]; then
+            if [[ "$ARTIFACT_ONLY" != "true" && "$go_state" == "cancelled_unclaimed" ]]; then
               go_failover=true
             fi
-            if [[ "$merge_state" == "cancelled_unclaimed" ]]; then
+            if [[ "$ARTIFACT_ONLY" != "true" && "$merge_state" == "cancelled_unclaimed" ]]; then
               merge_failover=true
             fi
 
@@ -239,7 +308,7 @@ jobs:
   # -------------------------------------------------------------------------
   capacity-arm:
     name: Capacity arm (failover decision)
-    needs: [capacity-watchdog]
+    needs: [changes, capacity-watchdog]
     if: always()
     runs-on: ubuntu-latest
     outputs:
@@ -258,6 +327,7 @@ jobs:
           TS_FROM_WD: ${{ needs.capacity-watchdog.outputs.ts_failover }}
           GO_FROM_WD: ${{ needs.capacity-watchdog.outputs.go_failover }}
           MERGE_FROM_WD: ${{ needs.capacity-watchdog.outputs.merge_failover }}
+          ARTIFACT_ONLY: ${{ needs.changes.outputs.artifact_only }}
         run: |
           set -euo pipefail
           ts_failover=false
@@ -277,27 +347,31 @@ jobs:
           # TS, Go, or merge-gate is still unclaimed (same-run rerun included).
           jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")"
           ts_state="$(node .github/scripts/classify-ci-job-state.mjs "typescript (blacksmith primary)" "$jobs_json")"
-          go_state="$(node .github/scripts/classify-ci-job-state.mjs "go (blacksmith primary)" "$jobs_json")"
-          merge_state="$(node .github/scripts/classify-ci-job-state.mjs "merge gate (blacksmith primary)" "$jobs_json")"
-          echo "re-eval state ts=${ts_state} go=${go_state} merge=${merge_state}"
+          go_state="done"
+          merge_state="done"
+          if [[ "$ARTIFACT_ONLY" != "true" ]]; then
+            go_state="$(node .github/scripts/classify-ci-job-state.mjs "go (blacksmith primary)" "$jobs_json")"
+            merge_state="$(node .github/scripts/classify-ci-job-state.mjs "merge gate (blacksmith primary)" "$jobs_json")"
+          fi
+          echo "re-eval state ts=${ts_state} go=${go_state} merge=${merge_state} artifact_only=${ARTIFACT_ONLY}"
 
           if [[ "$ts_state" == "queued" || "$ts_state" == "missing" || "$ts_state" == "cancelled_unclaimed" ]]; then
             ts_failover=true
           fi
-          if [[ "$go_state" == "queued" || "$go_state" == "missing" || "$go_state" == "cancelled_unclaimed" ]]; then
+          if [[ "$ARTIFACT_ONLY" != "true" && ( "$go_state" == "queued" || "$go_state" == "missing" || "$go_state" == "cancelled_unclaimed" ) ]]; then
             go_failover=true
           fi
-          if [[ "$merge_state" == "queued" || "$merge_state" == "missing" || "$merge_state" == "cancelled_unclaimed" ]]; then
+          if [[ "$ARTIFACT_ONLY" != "true" && ( "$merge_state" == "queued" || "$merge_state" == "missing" || "$merge_state" == "cancelled_unclaimed" ) ]]; then
             merge_failover=true
           fi
 
           if [[ "$ts_failover" == "true" ]]; then
             node .github/scripts/cancel-queued-ci-primary.mjs "typescript (blacksmith primary)" "$jobs_json"
           fi
-          if [[ "$go_failover" == "true" ]]; then
+          if [[ "$ARTIFACT_ONLY" != "true" && "$go_failover" == "true" ]]; then
             node .github/scripts/cancel-queued-ci-primary.mjs "go (blacksmith primary)" "$jobs_json"
           fi
-          if [[ "$merge_failover" == "true" ]]; then
+          if [[ "$ARTIFACT_ONLY" != "true" && "$merge_failover" == "true" ]]; then
             node .github/scripts/cancel-queued-ci-primary.mjs "merge gate (blacksmith primary)" "$jobs_json"
           fi
 
@@ -309,6 +383,10 @@ jobs:
             go_failover=false
           fi
           if [[ -z "$merge_failover" || "$merge_failover" == "null" ]]; then
+            merge_failover=false
+          fi
+          if [[ "$ARTIFACT_ONLY" == "true" ]]; then
+            go_failover=false
             merge_failover=false
           fi
 
@@ -419,8 +497,8 @@ jobs:
 
   go:
     name: Go (test + build)
-    needs: [capacity-arm, go-failover]
-    if: always()
+    needs: [changes, capacity-arm, go-failover]
+    if: always() && needs.changes.outputs.artifact_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -437,8 +515,8 @@ jobs:
 
   merge-gate:
     name: Merge gate (task check)
-    needs: [capacity-arm, merge-gate-failover]
-    if: always()
+    needs: [changes, capacity-arm, merge-gate-failover]
+    if: always() && needs.changes.outputs.artifact_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -460,6 +538,8 @@ jobs:
     # invokes scripts/migrate_vbrief.py directly — the task surface no longer
     # ships `migrate:vbrief` on current npm deposits.
     name: Windows (task dispatch regression)
+    needs: [changes]
+    if: always() && needs.changes.outputs.artifact_only != 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,9 @@ jobs:
             echo "artifact_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files="$(git diff --name-only --diff-filter=ACDMRT "${BASE}...${TIP}" || true)"
+          # --no-renames: name-only otherwise emits only the destination of a
+          # rename into the allowlist and would skip optional jobs (#3678 P2).
+          files="$(git diff --name-only --no-renames --diff-filter=ACDMRT "${BASE}...${TIP}" || true)"
           printf '%s\n' "$files"
           result="$(printf '%s\n' "$files" | node .github/scripts/artifact-only-lifecycle.mjs --stdin || true)"
           echo "$result"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,38 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: bash .github/scripts/compute-artifact-only.sh
+        run: |
+          ZERO="0000000000000000000000000000000000000000"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "$BASE_REF" || true
+            BASE="origin/${BASE_REF}"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            BASE="$PUSH_BEFORE"
+          else
+            echo "Unknown event ${EVENT_NAME}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ "$BASE" = "$ZERO" ] || [ "$BASE" = "origin/" ]; then
+            echo "Unusable merge-base ${BASE:-empty}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Execute predicate code from BASE, not HEAD. A PR that changes
+          # product files and lies in HEAD's script must not skip optional
+          # jobs. Absent on base (first landing) fail-closes to full stack.
+          MJS=".github/scripts/artifact-only-lifecycle.mjs"
+          SH=".github/scripts/compute-artifact-only.sh"
+          if ! git cat-file -e "${BASE}:${MJS}" || ! git cat-file -e "${BASE}:${SH}"; then
+            echo "Trusted predicate absent on ${BASE}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TRUST="$(mktemp -d)"
+          git show "${BASE}:${MJS}" > "$TRUST/artifact-only-lifecycle.mjs"
+          git show "${BASE}:${SH}" > "$TRUST/compute-artifact-only.sh"
+          export ARTIFACT_ONLY_SCRIPT="$TRUST/artifact-only-lifecycle.mjs"
+          bash "$TRUST/compute-artifact-only.sh"
 
   ts-primary:
     name: TypeScript (Blacksmith primary)

--- a/.github/workflows/greenfield-python-free-smoke.yml
+++ b/.github/workflows/greenfield-python-free-smoke.yml
@@ -2,20 +2,41 @@ name: greenfield-python-free-smoke
 
 on:
   pull_request:
-    paths-ignore:
-      - "xbrief/completed/**"
-      - "CHANGELOG.md"
   push:
     branches: [master, main]
-    paths-ignore:
-      - "xbrief/completed/**"
-      - "CHANGELOG.md"
 
 permissions:
   contents: read
 
+# Do not use workflow-level paths-ignore here: GitHub path filters see only
+# the destination of a rename, so a non-allowlisted source renamed into the
+# leftover allowlist would skip this workflow (#3678). Gate the expensive
+# smoke job on the merge-base predicate instead (same --no-renames script as
+# ci.yml). This workflow hosts no required check.
 jobs:
+  changes:
+    name: Changes (artifact-only predicate)
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_only: ${{ steps.predicate.outputs.artifact_only }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Compute artifact-only predicate against merge base
+        id: predicate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: bash .github/scripts/compute-artifact-only.sh
+
   smoke:
+    needs: [changes]
+    if: always() && needs.changes.outputs.artifact_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/greenfield-python-free-smoke.yml
+++ b/.github/workflows/greenfield-python-free-smoke.yml
@@ -2,8 +2,14 @@ name: greenfield-python-free-smoke
 
 on:
   pull_request:
+    paths-ignore:
+      - "xbrief/completed/**"
+      - "CHANGELOG.md"
   push:
     branches: [master, main]
+    paths-ignore:
+      - "xbrief/completed/**"
+      - "CHANGELOG.md"
 
 permissions:
   contents: read

--- a/.github/workflows/greenfield-python-free-smoke.yml
+++ b/.github/workflows/greenfield-python-free-smoke.yml
@@ -32,7 +32,38 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: bash .github/scripts/compute-artifact-only.sh
+        run: |
+          ZERO="0000000000000000000000000000000000000000"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "$BASE_REF" || true
+            BASE="origin/${BASE_REF}"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            BASE="$PUSH_BEFORE"
+          else
+            echo "Unknown event ${EVENT_NAME}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ "$BASE" = "$ZERO" ] || [ "$BASE" = "origin/" ]; then
+            echo "Unusable merge-base ${BASE:-empty}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Execute predicate code from BASE, not HEAD. A PR that changes
+          # product files and lies in HEAD's script must not skip optional
+          # jobs. Absent on base (first landing) fail-closes to full stack.
+          MJS=".github/scripts/artifact-only-lifecycle.mjs"
+          SH=".github/scripts/compute-artifact-only.sh"
+          if ! git cat-file -e "${BASE}:${MJS}" || ! git cat-file -e "${BASE}:${SH}"; then
+            echo "Trusted predicate absent on ${BASE}; routing to full stack"
+            echo "artifact_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TRUST="$(mktemp -d)"
+          git show "${BASE}:${MJS}" > "$TRUST/artifact-only-lifecycle.mjs"
+          git show "${BASE}:${SH}" > "$TRUST/compute-artifact-only.sh"
+          export ARTIFACT_ONLY_SCRIPT="$TRUST/artifact-only-lifecycle.mjs"
+          bash "$TRUST/compute-artifact-only.sh"
 
   smoke:
     needs: [changes]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Leftover-completion PRs skip optional CI jobs (#3678).** When the diff against the merge base is only a completed xBRIEF and CHANGELOG, Windows, Go, merge-gate, smoke, and branch-gate do not run. The required TypeScript check still runs over a real lane. Closes #3678.
+
 - **Design-critique panels share one input ceiling (#3660).** Same-round critics read comments only up to one id, fixed before any sibling posts. An N=3 panel gets three first-round posts and no default retry. The parent records the ceiling before dispatch. Closes #3660.
 
 - **Design-critique walk is parent-disagreement only; empty all-accept map auto-stamps (#3640).** **walk** iterates disagree headings. **walk all** is the census (`walk findings one at a time` stays a one-release alias). A non-empty all-accept successor lean auto-posts the verified-claims table then `design-critique: synthesis accepted, because agents agreed (empty disagreement set)` and remaining-set-replaces to `triage-ready`. Stub critics and dispatch-fail do not stamp. Looks-good still does not bind. Thin skill pointer. Closes #3640.

--- a/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
+++ b/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
@@ -76,6 +76,13 @@ describe("artifact-only lifecycle CI lane (#3678)", () => {
     expect(artifactOnly(["xbrief/pending/foo.xbrief.json"])).toBe(false);
   });
 
+  it("rename source plus allowlisted dest fails closed (workflow lists both via --no-renames)", () => {
+    expect(
+      artifactOnly(["packages/core/src/foo.ts", "xbrief/completed/2026-08-24-renamed.xbrief.json"]),
+    ).toBe(false);
+    expect(artifactOnly(["packages/core/src/foo.ts", "CHANGELOG.md"])).toBe(false);
+  });
+
   it("a diff touching packages/** takes the full stack", () => {
     expect(artifactOnly([...TWO_FILE_SHAPE, "packages/core/src/index.ts"])).toBe(false);
   });
@@ -106,7 +113,7 @@ describe("artifact-only lifecycle CI lane (#3678)", () => {
     expect(ci).toContain("  changes:");
     expect(ci).toMatch(/name:\s*Changes \(artifact-only predicate\)/);
     expect(ci).toContain("artifact_only:");
-    expect(ci).toContain("git diff --name-only");
+    expect(ci).toContain("git diff --name-only --no-renames");
     expect(ci).toContain("artifact-only-lifecycle.mjs");
     expect(ci).toMatch(/\$\{BASE\}\.\.\.\$\{TIP\}/);
   });

--- a/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
+++ b/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
@@ -110,12 +110,14 @@ describe("artifact-only lifecycle CI lane (#3678)", () => {
 
   it("ci.yml changes job diffs against the merge base and exposes artifact_only", () => {
     const ci = readText(".github/workflows/ci.yml");
+    const script = readText(".github/scripts/compute-artifact-only.sh");
     expect(ci).toContain("  changes:");
     expect(ci).toMatch(/name:\s*Changes \(artifact-only predicate\)/);
     expect(ci).toContain("artifact_only:");
-    expect(ci).toContain("git diff --name-only --no-renames");
-    expect(ci).toContain("artifact-only-lifecycle.mjs");
-    expect(ci).toMatch(/\$\{BASE\}\.\.\.\$\{TIP\}/);
+    expect(ci).toContain("compute-artifact-only.sh");
+    expect(script).toContain("git diff --name-only --no-renames");
+    expect(script).toContain("artifact-only-lifecycle.mjs");
+    expect(script).toMatch(/\$\{BASE\}\.\.\.\$\{TIP\}/);
   });
 
   it("ci.yml does not use workflow-level paths filters (required aggregator must report)", () => {
@@ -186,17 +188,19 @@ describe("artifact-only lifecycle CI lane (#3678)", () => {
     expect(resolver).toContain("isCapacityDeath");
   });
 
-  it("smoke and branch-gate ignore only the measured two-file allowlist", () => {
+  it("smoke gates on the merge-base predicate; branch-gate always runs", () => {
     const smoke = readText(".github/workflows/greenfield-python-free-smoke.yml");
     const branchGate = readText(".github/workflows/branch-gate.yml");
-    for (const text of [smoke, branchGate]) {
-      expect(text).toContain("paths-ignore:");
-      expect(text).toContain('"xbrief/completed/**"');
-      expect(text).toContain('"CHANGELOG.md"');
-    }
+    const skipIf = "if: always() && needs.changes.outputs.artifact_only != 'true'";
+    expect(smoke).toContain("compute-artifact-only.sh");
+    expect(smoke).toContain(skipIf);
+    expect(jobBlock(smoke, "smoke")).toMatch(/needs:\s*\[changes/);
     const smokeOn = workflowOnBlock(smoke);
     const gateOn = workflowOnBlock(branchGate);
-    expect(smokeOn).not.toMatch(/paths:\s*$/m);
-    expect(gateOn).not.toMatch(/paths:\s*$/m);
+    // Native GitHub path filters hide rename sources; these workflows must not use them.
+    expect(smokeOn).not.toMatch(/\bpaths-ignore:/);
+    expect(gateOn).not.toMatch(/\bpaths-ignore:/);
+    expect(smokeOn).not.toMatch(/\bpaths:/);
+    expect(gateOn).not.toMatch(/\bpaths:/);
   });
 });

--- a/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
+++ b/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
@@ -116,8 +116,22 @@ describe("artifact-only lifecycle CI lane (#3678)", () => {
     expect(ci).toContain("artifact_only:");
     expect(ci).toContain("compute-artifact-only.sh");
     expect(script).toContain("git diff --name-only --no-renames");
-    expect(script).toContain("artifact-only-lifecycle.mjs");
+    expect(script).toContain("ARTIFACT_ONLY_SCRIPT");
     expect(script).toMatch(/\$\{BASE\}\.\.\.\$\{TIP\}/);
+  });
+
+  it("predicate scripts run from the merge-base copy, not PR HEAD", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    const smoke = readText(".github/workflows/greenfield-python-free-smoke.yml");
+    const script = readText(".github/scripts/compute-artifact-only.sh");
+    for (const text of [ci, smoke]) {
+      expect(text).toMatch(/git cat-file -e "\$\{BASE\}:\$\{MJS\}"/);
+      expect(text).toContain("Trusted predicate absent");
+      expect(text).toMatch(/git show "\$\{BASE\}:\$\{MJS\}"/);
+      expect(text).toContain("export ARTIFACT_ONLY_SCRIPT=");
+      expect(text).not.toMatch(/^        run: bash \.github\/scripts\/compute-artifact-only\.sh\s*$/m);
+    }
+    expect(script).toContain("ARTIFACT_ONLY_SCRIPT unset");
   });
 
   it("ci.yml does not use workflow-level paths filters (required aggregator must report)", () => {

--- a/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
+++ b/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readText, repoRoot } from "./_helpers.js";
+
+/** Top-level job mapping block in a workflow YAML file. */
+function jobBlock(yaml: string, id: string): string {
+  const lines = yaml.split("\n");
+  const start = lines.indexOf(`  ${id}:`);
+  if (start < 0) {
+    throw new Error(`job ${id} not found`);
+  }
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {2}[A-Za-z][A-Za-z0-9_-]*:/.test(lines[i] ?? "")) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+const SCRIPT = join(repoRoot(), ".github", "scripts", "artifact-only-lifecycle.mjs");
+
+/** Real two-file leftover-completion shape from sampled lifecycle PRs (#3678). */
+const TWO_FILE_SHAPE = [
+  "CHANGELOG.md",
+  "xbrief/completed/2026-08-24-3671-leftover-completed-tracked.xbrief.json",
+] as const;
+
+function artifactOnly(paths: string[]): boolean {
+  const out = execFileSync(process.execPath, [SCRIPT, ...paths], { encoding: "utf8" }).trim();
+  const match = /^artifact_only=(true|false)$/m.exec(out);
+  if (!match?.[1]) {
+    throw new Error(`unexpected predicate output: ${JSON.stringify(out)}`);
+  }
+  return match[1] === "true";
+}
+
+function workflowOnBlock(text: string): string {
+  const start = text.indexOf("\non:");
+  const onAt = start >= 0 ? start + 1 : text.startsWith("on:") ? 0 : -1;
+  if (onAt < 0) {
+    throw new Error("workflow on: block not found");
+  }
+  const after = text.slice(onAt);
+  const perm = after.search(/\npermissions:/);
+  if (perm < 0) {
+    throw new Error("permissions: not found after on:");
+  }
+  return after.slice(0, perm);
+}
+
+describe("artifact-only lifecycle CI lane (#3678)", () => {
+  it("two-file leftover shape (completed xBRIEF + CHANGELOG) routes to the lane", () => {
+    expect(artifactOnly([...TWO_FILE_SHAPE])).toBe(true);
+  });
+
+  it("CHANGELOG-only head routes to the lane", () => {
+    expect(artifactOnly(["CHANGELOG.md"])).toBe(true);
+  });
+
+  it("xbrief/completed-only is in the allowlist (paired with CHANGELOG in real PRs)", () => {
+    expect(artifactOnly(["xbrief/completed/2026-08-24-example.xbrief.json"])).toBe(true);
+  });
+
+  it("empty diff fails closed to the full stack", () => {
+    expect(artifactOnly([])).toBe(false);
+  });
+
+  it("allowlist is exactly CHANGELOG.md and xbrief/completed/**", () => {
+    expect(artifactOnly(["docs/CHANGELOG.md"])).toBe(false);
+    expect(artifactOnly(["xbrief/completed"])).toBe(false);
+    expect(artifactOnly(["xbrief/completed-extra.json"])).toBe(false);
+    expect(artifactOnly(["xbrief/active/foo.xbrief.json"])).toBe(false);
+    expect(artifactOnly(["xbrief/pending/foo.xbrief.json"])).toBe(false);
+  });
+
+  it("a diff touching packages/** takes the full stack", () => {
+    expect(artifactOnly([...TWO_FILE_SHAPE, "packages/core/src/index.ts"])).toBe(false);
+  });
+
+  it("a diff touching .github/** takes the full stack", () => {
+    expect(artifactOnly([...TWO_FILE_SHAPE, ".github/workflows/ci.yml"])).toBe(false);
+  });
+
+  it("a diff touching xbrief/proposed/** takes the full stack", () => {
+    expect(artifactOnly([...TWO_FILE_SHAPE, "xbrief/proposed/2026-08-24-next.xbrief.json"])).toBe(
+      false,
+    );
+  });
+
+  it("product commits behind an artifact-only tip still take the full stack", () => {
+    // Merge-base evaluation: the complete diff includes earlier product files.
+    expect(
+      artifactOnly([
+        "packages/core/src/foo.ts",
+        "CHANGELOG.md",
+        "xbrief/completed/2026-08-24-tip.xbrief.json",
+      ]),
+    ).toBe(false);
+  });
+
+  it("ci.yml changes job diffs against the merge base and exposes artifact_only", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    expect(ci).toContain("  changes:");
+    expect(ci).toMatch(/name:\s*Changes \(artifact-only predicate\)/);
+    expect(ci).toContain("artifact_only:");
+    expect(ci).toContain("git diff --name-only");
+    expect(ci).toContain("artifact-only-lifecycle.mjs");
+    expect(ci).toMatch(/\$\{BASE\}\.\.\.\$\{TIP\}/);
+  });
+
+  it("ci.yml does not use workflow-level paths filters (required aggregator must report)", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    const onBlock = workflowOnBlock(ci);
+    expect(onBlock).not.toMatch(/\bpaths:/);
+    expect(onBlock).not.toMatch(/\bpaths-ignore:/);
+  });
+
+  it("exactly one job publishes the required TypeScript check name", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    const matches = ci.match(/name:\s*TypeScript \(build \+ lint \+ test\)/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(ci).toContain("  ts:");
+  });
+
+  it("required-check comment map matches live protection (only TypeScript is YES)", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    expect(ci).toMatch(
+      /\|\s*Aggregator\s*\|\s*ts\s+\|\s*TypeScript \(build \+ lint \+ test\)\s+\|\s*YES\s+\|/,
+    );
+    expect(ci).toMatch(/\|\s*Aggregator\s*\|\s*go\s+\|\s*Go \(test \+ build\)\s+\|\s*no\s+\|/);
+    expect(ci).toMatch(
+      /\|\s*Aggregator\s*\|\s*merge-gate\s+\|\s*Merge gate \(task check\)\s+\|\s*no\s+\|/,
+    );
+    expect(ci).not.toMatch(/\|\s*Aggregator\s*\|\s*go\s+\|\s*Go \(test \+ build\)\s+\|\s*YES\s+\|/);
+    expect(ci).not.toMatch(
+      /\|\s*Aggregator\s*\|\s*merge-gate\s+\|\s*Merge gate \(task check\)\s+\|\s*YES\s+\|/,
+    );
+  });
+
+  it("non-required ci.yml jobs gate on the artifact-only output", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    const skipIf = "if: always() && needs.changes.outputs.artifact_only != 'true'";
+    expect(ci).toContain("  go-primary:");
+    expect(ci).toContain("  merge-gate-primary:");
+    expect(ci).toContain("  windows-task-dispatch:");
+    const goPrimary = jobBlock(ci, "go-primary");
+    const mergePrimary = jobBlock(ci, "merge-gate-primary");
+    const windows = jobBlock(ci, "windows-task-dispatch");
+    const goAgg = jobBlock(ci, "go");
+    const mergeAgg = jobBlock(ci, "merge-gate");
+    for (const block of [goPrimary, mergePrimary, windows, goAgg, mergeAgg]) {
+      expect(block).toContain(skipIf);
+      expect(block).toMatch(/needs:\s*\[changes/);
+    }
+  });
+
+  it("TypeScript aggregator stays ungated by the artifact-only predicate", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    const job = jobBlock(ci, "ts");
+    expect(job).toContain("name: TypeScript (build + lint + test)");
+    expect(job).toContain("if: always()");
+    expect(job).not.toContain("artifact_only");
+  });
+
+  it("watchdog and arm do not treat skipped Go/merge-gate as capacity death on artifact-only", () => {
+    const ci = readText(".github/workflows/ci.yml");
+    expect(ci).toContain("ARTIFACT_ONLY:");
+    expect(ci).toContain("needs.changes.outputs.artifact_only");
+    expect(ci).toMatch(/ARTIFACT_ONLY" == "true"/);
+  });
+
+  it("resolver still treats a skipped primary as failure, not success", () => {
+    const resolver = readText(".github/scripts/resolve-ci-authoritative-lane.mjs");
+    expect(resolver).toContain('conclusion === "success"');
+    expect(resolver).not.toMatch(/skipped.*success|success.*skipped/i);
+    expect(resolver).toContain("isCapacityDeath");
+  });
+
+  it("smoke and branch-gate ignore only the measured two-file allowlist", () => {
+    const smoke = readText(".github/workflows/greenfield-python-free-smoke.yml");
+    const branchGate = readText(".github/workflows/branch-gate.yml");
+    for (const text of [smoke, branchGate]) {
+      expect(text).toContain("paths-ignore:");
+      expect(text).toContain('"xbrief/completed/**"');
+      expect(text).toContain('"CHANGELOG.md"');
+    }
+    const smokeOn = workflowOnBlock(smoke);
+    const gateOn = workflowOnBlock(branchGate);
+    expect(smokeOn).not.toMatch(/paths:\s*$/m);
+    expect(gateOn).not.toMatch(/paths:\s*$/m);
+  });
+});

--- a/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
+++ b/packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
@@ -129,7 +129,7 @@ describe("artifact-only lifecycle CI lane (#3678)", () => {
       expect(text).toContain("Trusted predicate absent");
       expect(text).toMatch(/git show "\$\{BASE\}:\$\{MJS\}"/);
       expect(text).toContain("export ARTIFACT_ONLY_SCRIPT=");
-      expect(text).not.toMatch(/^        run: bash \.github\/scripts\/compute-artifact-only\.sh\s*$/m);
+      expect(text).not.toMatch(/run: bash \.github\/scripts\/compute-artifact-only\.sh/);
     }
     expect(script).toContain("ARTIFACT_ONLY_SCRIPT unset");
   });


### PR DESCRIPTION
## Summary
- Leftover-completion PRs whose merge-base diff is only a completed xBRIEF and CHANGELOG skip Windows, Go, merge-gate, smoke, and branch-gate.
- The required TypeScript aggregator still reports over a real lane. No second job uses that name, and a skipped primary is still not success.
- Allowlist is exactly {xbrief/completed/**, CHANGELOG.md}. This PR touches .github/**, so it takes the full stack.

## Notes
- Optional TypeScript early-exit inside ci-lane.yml was left out: it saves about one billed minute and would duplicate the merge-base check in the reusable lane.
- CodeQL Analyze stays out of scope (default setup; no workflow file).
- Active xBRIEF is not in this PR: #3145 requires a human-minted approved-scope digest on the merge base before co-landing a scoped active brief, and an agent shell cannot mint.

## Test plan
- [ ] Local: pnpm exec vitest run packages/core/src/content-contracts/standards/ci_lifecycle_lane.test.ts
- [ ] Confirm this PR head ran the full job stack (predicate must not skip .github/**)
- [ ] After merge, leftover-completion PRs skip the non-required jobs

Closes #3678
