### PR TITLE
Inject identity-bound worker credentials at spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Identity-bound worker credential injection at spawn (#1351).** A dispatcher that holds a user-bearing worker credential validates it with the existing principal check, injects it into the worker process environment, and stamps the expected GitHub login so comparison is not optional. Installation credentials still fail closed. Closes #1351.
+
 - **Land leftover completed-tracked artifact for #3650 (#3264 / #1358).** The #3650 xBRIEF stayed untracked after squash of PR 3706. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
 
 - **Land leftover completed-tracked artifact for #3674 (#3264 / #1358).** The #3674 xBRIEF stayed untracked after squash of PR 3698. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -130,6 +130,7 @@ When present, document the fields in a separate `## Runtime and GitHub auth mode
 
 - `runtime_mode`: one of `local-unsandboxed`, `cursor-native-sandbox`, or `cloud-headless` -- the execution envelope the worker runs in (from the read-only runtime probe, #1557a).
 - `github_auth_mode`: one of `host-gh` or `injected-token` -- which GitHub credential rule applies to this worker (#1557b).
+- `expected_github_login`: the bound user login when the dispatcher injected a user-bearing credential (#1351 / #3665). Login only -- never a token value. Omit when `github_auth_mode` is `host-gh` and no injection occurred.
 
 Launch-manifest entries (#1387 C2 contract) carry the same two fields at the top level alongside `allocation_context`. Workers MUST read the dispatch envelope (or launch manifest) and apply the identity-separation rules in §8 according to `github_auth_mode`, not the historical one-size-fits-all injected-token default.
 
@@ -149,9 +150,23 @@ Worked example (cloud / headless worker):
 
 - runtime_mode: cloud-headless
 - github_auth_mode: injected-token
+- expected_github_login: deft-swarm-bot
 ```
 
 Reference: `packages/core/src/platform/platform-capabilities.ts` (#1557a), `packages/core/src/intake/github-auth-modes.ts` (#1557b), issue #1557.
+
+## 2.75 Identity-bound worker credential injection (#1351)
+
+When a dispatcher holds a user-bearing worker credential, it MUST inject that credential at spawn on the grok-build and local hybrid paths. Injection binds an identity; it does not only place a token. This helper is the operator-implemented injection the §8 conjunction names -- a dispatcher-invoked function, not a prompt-embedded token.
+
+- ! Before spawn, call `prepareWorkerCredentialInjection` (`packages/core/src/swarm/launch.ts`). It validates the held credential as a **user** principal with the existing `validateGithubAuthForWorker`. Do not write a second validator and do not invent a second approval surface.
+- ! On success, apply the returned `spawnEnv` to the worker **process environment** (`GH_TOKEN` plus `DEFT_EXPECTED_GITHUB_LOGIN`) and copy `envelopeSection` into the dispatch envelope. Stamp `expected_github_login` on the launch-manifest entry when launch already validated the same credential.
+- ! On no available credential and a write-requiring injected-token operation, halt `BLOCKED`, naming the missing credential (`GH_TOKEN` / `GITHUB_TOKEN` / `GH_ENTERPRISE_TOKEN`) and the dispatcher-side remedy. Do not spawn.
+- ⊗ Inject an App-installation credential. Those fail closed as `installation_identity_unverifiable` (#3693).
+- ⊗ Continue under a detected host or maintainer identity, or fall back to the host `gh` token (`patterns/multi-agent.md` :70-75).
+- ⊗ Place a credential value in the dispatch prompt, a transcript, or a launch-manifest entry. `spawnEnv` is process-env only.
+
+Token minting remains an operator-owned #983 non-goal. This helper delivers a credential the dispatcher already holds; it does not mint one.
 
 ## 3. PowerShell 5.1 non-ASCII rule (#798)
 
@@ -449,6 +464,8 @@ Applies to local interactive workers (`runtime_mode: local-unsandboxed` or, afte
 - ~ When `runtime_mode: cursor-native-sandbox`, host `gh` may fail inside the sandbox even when the parent session is authenticated. Fail loud with remediation (full-access execution, trusted-path allowlist, or switch to injected-token handoff) rather than assuming parent auth is visible to the worker.
 
 Dispatchers MUST inject worker credentials for injected-token / cloud-headless dispatches and MUST record the selected `github_auth_mode` in the launch manifest and dispatch envelope. v1 deliberately keeps token injection operator-implemented; mode labels make the contract explicit without placing token values in prompts or transcripts.
+
+#1351 supplies the identity-bound delivery helper in §2.75. Dispatchers on grok-build and local hybrid still record the mode on **both** the launch manifest and the dispatch envelope. They apply `prepareWorkerCredentialInjection` at spawn so the worker receives the token in process env and a stamped `DEFT_EXPECTED_GITHUB_LOGIN` / `expected_github_login`, not a prompt-embedded secret.
 
 This rule is complementary to §5 (REST-by-default) and §7 (rate-limit-aware throttle): REST-by-default reduces GraphQL demand on whichever bucket the worker is using; rate-limit throttle keeps the worker from exhausting its own bucket; mode-aware identity separation prevents the worker bucket from being the maintainer's bucket when injected-token mode applies. All three are required for stable swarm operation.
 

--- a/packages/core/src/swarm/launch.test.ts
+++ b/packages/core/src/swarm/launch.test.ts
@@ -224,16 +224,25 @@ describe("prepareWorkerCredentialInjection (#1351)", () => {
 
   it("validates the selected token, not a sibling enterprise token", () => {
     const enterpriseToken = "gho_enterprise_other_principal_1351";
-    const seen: { ghToken?: string; enterprise?: string } = {};
+    const seen: {
+      ghToken?: string;
+      githubToken?: string;
+      enterprise?: string;
+      configDir?: string;
+    } = {};
     const runGh: GhRunner = (args, environ) => {
       seen.ghToken = environ.GH_TOKEN;
+      seen.githubToken = environ.GITHUB_TOKEN;
       seen.enterprise = environ.GH_ENTERPRISE_TOKEN;
+      seen.configDir = environ.GH_CONFIG_DIR;
       return stubGh({})(args, environ);
     };
     const result = prepareWorkerCredentialInjection({
       environ: {
         GH_TOKEN: FAKE_TOKEN,
         GH_ENTERPRISE_TOKEN: enterpriseToken,
+        GH_HOST: "ghe.example.invalid",
+        GH_CONFIG_DIR: "/tmp/other-gh-store",
         GH_REPO: TARGET_REPO,
       },
       githubAuthMode: "injected-token",
@@ -246,9 +255,13 @@ describe("prepareWorkerCredentialInjection (#1351)", () => {
       return;
     }
     expect(result.spawnEnv.GH_TOKEN).toBe(FAKE_TOKEN);
+    expect(result.spawnEnv.GITHUB_TOKEN).toBe(FAKE_TOKEN);
+    expect(result.spawnEnv.GH_ENTERPRISE_TOKEN).toBe(FAKE_TOKEN);
     expect(result.expectedLogin).toBe(WORKER_LOGIN);
     expect(seen.ghToken).toBe(FAKE_TOKEN);
-    expect(seen.enterprise).toBeUndefined();
+    expect(seen.githubToken).toBe(FAKE_TOKEN);
+    expect(seen.enterprise).toBe(FAKE_TOKEN);
+    expect(seen.configDir).toBeUndefined();
     expect(JSON.stringify(result)).not.toContain(enterpriseToken);
   });
 

--- a/packages/core/src/swarm/launch.test.ts
+++ b/packages/core/src/swarm/launch.test.ts
@@ -222,6 +222,36 @@ describe("prepareWorkerCredentialInjection (#1351)", () => {
     }
   });
 
+  it("validates the selected token, not a sibling enterprise token", () => {
+    const enterpriseToken = "gho_enterprise_other_principal_1351";
+    const seen: { ghToken?: string; enterprise?: string } = {};
+    const runGh: GhRunner = (args, environ) => {
+      seen.ghToken = environ.GH_TOKEN;
+      seen.enterprise = environ.GH_ENTERPRISE_TOKEN;
+      return stubGh({})(args, environ);
+    };
+    const result = prepareWorkerCredentialInjection({
+      environ: {
+        GH_TOKEN: FAKE_TOKEN,
+        GH_ENTERPRISE_TOKEN: enterpriseToken,
+        GH_REPO: TARGET_REPO,
+      },
+      githubAuthMode: "injected-token",
+      runtimeMode: "cloud-headless",
+      dispatchPath: "grok-build",
+      runGh,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.injected) {
+      return;
+    }
+    expect(result.spawnEnv.GH_TOKEN).toBe(FAKE_TOKEN);
+    expect(result.expectedLogin).toBe(WORKER_LOGIN);
+    expect(seen.ghToken).toBe(FAKE_TOKEN);
+    expect(seen.enterprise).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain(enterpriseToken);
+  });
+
   it("never continues under host identity from injected-token mode", () => {
     const result = prepareWorkerCredentialInjection({
       environ: { GH_REPO: TARGET_REPO },
@@ -268,6 +298,18 @@ describe("formatDispatchAuthEnvelope (#1351)", () => {
         githubAuthMode: "injected-token",
       }),
     ).toThrow(/credential value/i);
+  });
+
+  it("collapses newlines in envelope fields so they stay on one bullet", () => {
+    const section = formatDispatchAuthEnvelope({
+      runtimeMode: "cloud-headless\ninjected",
+      githubAuthMode: "injected-token\nextra",
+      expectedGithubLogin: `${WORKER_LOGIN}\nnot-a-new-block`,
+    });
+    expect(section).toContain("runtime_mode: cloud-headless injected");
+    expect(section).toContain("github_auth_mode: injected-token extra");
+    expect(section).toContain(`expected_github_login: ${WORKER_LOGIN} not-a-new-block`);
+    expect(section.split("\n").filter((line) => line.startsWith("- "))).toHaveLength(3);
   });
 
   it("rejects a credential-shaped expected login", () => {
@@ -372,6 +414,25 @@ describe("swarmLaunch identity-bound injection (#1351)", () => {
     const manifest = JSON.parse(result.stdout) as Record<string, unknown>[];
     expect(manifest[0]?.github_auth_mode).toBe("host-gh");
     expect(manifest[0]?.expected_github_login).toBeUndefined();
+    expect(result.stdout).not.toContain(FAKE_TOKEN);
+  });
+
+  it("fails launch when injected-token has no credential", () => {
+    const project = launchProject();
+    const result = swarmLaunch({
+      stories: ["1351"],
+      projectRoot: project,
+      autonomous: true,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["cloud-headless", "injected-token"],
+      environ: { CURSOR_AGENT: "1", GH_REPO: TARGET_REPO },
+      runGh: stubGh({}),
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/BLOCKED/i);
+    expect(result.stderr).toMatch(/GH_TOKEN|GITHUB_TOKEN|GH_ENTERPRISE_TOKEN/);
+    expect(result.stderr).toMatch(/dispatcher/i);
     expect(result.stdout).not.toContain(FAKE_TOKEN);
   });
 

--- a/packages/core/src/swarm/launch.test.ts
+++ b/packages/core/src/swarm/launch.test.ts
@@ -1,0 +1,416 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ENV_EXPECTED_GITHUB_LOGIN,
+  FAILURE_INSTALLATION_IDENTITY_UNVERIFIABLE,
+  FAILURE_MISSING_INJECTED_TOKEN,
+  FAILURE_PRINCIPAL_MISMATCH,
+  type GhRunner,
+} from "../intake/github-auth-modes.js";
+import type { CompletedProcess } from "../scm/call.js";
+import {
+  buildManifest,
+  formatDispatchAuthEnvelope,
+  prepareWorkerCredentialInjection,
+  type ResolvedStory,
+  swarmLaunch,
+} from "./launch.js";
+
+const story: ResolvedStory = {
+  token: "story-a",
+  story_id: "story-a",
+  path: "/abs/story-a.xbrief.json",
+  relpath: "xbrief/active/story-a.xbrief.json",
+};
+
+const TARGET_REPO = "acme/widgets";
+const WORKER_LOGIN = "deft-swarm-bot";
+const FAKE_TOKEN = "gho_test_injection_token_1351";
+const PREAMBLE_PATH = join(process.cwd(), "content/templates/agent-prompt-preamble.md");
+
+function proc(
+  returncode: number,
+  stdout = "",
+  stderr = "",
+  args: readonly string[] = [],
+): CompletedProcess {
+  return { returncode, stdout, stderr, args: [...args] };
+}
+
+function stubGh(options: {
+  authCode?: number;
+  user?: { code: number; stdout?: string; stderr?: string };
+  repoCode?: number;
+}): GhRunner {
+  return (args) => {
+    if (args[0] === "auth") {
+      return proc(options.authCode ?? 0, "ok", "", args);
+    }
+    if (args[0] === "api" && args[1] === "user") {
+      const user = options.user ?? { code: 0, stdout: `{"login":"${WORKER_LOGIN}"}` };
+      return proc(user.code, user.stdout ?? "", user.stderr ?? "", args);
+    }
+    if (args[0] === "api" && String(args[1]).startsWith("repos/")) {
+      const code = options.repoCode ?? 0;
+      return proc(code, code === 0 ? "{}" : "", code === 0 ? "" : "denied", args);
+    }
+    return proc(1, "", `unexpected: ${args.join(" ")}`, args);
+  };
+}
+
+const INSTALLATION_USER_403 = {
+  code: 1,
+  stdout: '{"message":"Resource not accessible by integration","status":"403"}',
+  stderr: "gh: Resource not accessible by integration (HTTP 403)",
+};
+
+function writeReadyStory(project: string, storyId: string, issue: number): void {
+  const full = join(project, "xbrief", "active", `${storyId}.xbrief.json`);
+  mkdirSync(join(project, "xbrief", "active"), { recursive: true });
+  writeFileSync(
+    full,
+    `${JSON.stringify({
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        id: storyId,
+        title: storyId,
+        status: "running",
+        references: [
+          {
+            uri: `https://github.com/deftai/directive/issues/${issue}`,
+            type: "x-vbrief/github-issue",
+          },
+        ],
+        metadata: { kind: "story", swarm: { readiness: "ready" } },
+      },
+    })}\n`,
+    "utf8",
+  );
+}
+
+describe("prepareWorkerCredentialInjection (#1351)", () => {
+  it("injects a user-bearing credential on the grok-build path and stamps expected login", () => {
+    const result = prepareWorkerCredentialInjection({
+      environ: { GH_TOKEN: FAKE_TOKEN, GH_REPO: TARGET_REPO },
+      githubAuthMode: "injected-token",
+      runtimeMode: "cloud-headless",
+      dispatchPath: "grok-build",
+      runGh: stubGh({}),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.injected).toBe(true);
+    expect(result.githubAuthMode).toBe("injected-token");
+    expect(result.expectedLogin).toBe(WORKER_LOGIN);
+    expect(result.spawnEnv.GH_TOKEN).toBe(FAKE_TOKEN);
+    expect(result.spawnEnv[ENV_EXPECTED_GITHUB_LOGIN]).toBe(WORKER_LOGIN);
+    expect(result.envelopeSection).toContain("github_auth_mode: injected-token");
+    expect(result.envelopeSection).toContain(`expected_github_login: ${WORKER_LOGIN}`);
+    expect(result.envelopeSection).not.toContain(FAKE_TOKEN);
+  });
+
+  it("injects a held user-bearing credential on the local-hybrid path", () => {
+    const result = prepareWorkerCredentialInjection({
+      environ: { GITHUB_TOKEN: FAKE_TOKEN, GH_REPO: TARGET_REPO },
+      githubAuthMode: "host-gh",
+      runtimeMode: "local-unsandboxed",
+      dispatchPath: "local-hybrid",
+      runGh: stubGh({}),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.injected) {
+      return;
+    }
+    expect(result.githubAuthMode).toBe("injected-token");
+    expect(result.spawnEnv.GH_TOKEN).toBe(FAKE_TOKEN);
+    expect(result.spawnEnv[ENV_EXPECTED_GITHUB_LOGIN]).toBe(WORKER_LOGIN);
+  });
+
+  it("does not inject on authorized host-gh local-hybrid when no token is held", () => {
+    const result = prepareWorkerCredentialInjection({
+      environ: { GH_REPO: TARGET_REPO },
+      githubAuthMode: "host-gh",
+      runtimeMode: "local-unsandboxed",
+      dispatchPath: "local-hybrid",
+      runGh: stubGh({}),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.injected).toBe(false);
+    expect(result.githubAuthMode).toBe("host-gh");
+    expect(result.spawnEnv).toEqual({});
+    expect(result.envelopeSection).toContain("github_auth_mode: host-gh");
+    expect(result.envelopeSection).not.toContain("GH_TOKEN");
+  });
+
+  it("halts BLOCKED when injected-token has no credential, naming the remedy", () => {
+    const result = prepareWorkerCredentialInjection({
+      environ: { GH_REPO: TARGET_REPO },
+      githubAuthMode: "injected-token",
+      runtimeMode: "cloud-headless",
+      dispatchPath: "grok-build",
+      runGh: stubGh({}),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.blocked).toBe(true);
+    expect(result.failureKind).toBe(FAILURE_MISSING_INJECTED_TOKEN);
+    expect(result.missingCredential).toMatch(/GH_TOKEN|GITHUB_TOKEN|GH_ENTERPRISE_TOKEN/);
+    expect(result.detail).toMatch(/BLOCKED/i);
+    expect(result.remedy).toMatch(/dispatcher/i);
+    expect(result.remedy).toMatch(/prepareWorkerCredentialInjection|inject/i);
+    expect(result.remedy).toMatch(/Do not fall back to the host gh token/i);
+    expect(JSON.stringify(result)).not.toContain(FAKE_TOKEN);
+  });
+
+  it("refuses an installation credential instead of injecting it", () => {
+    const result = prepareWorkerCredentialInjection({
+      environ: { GH_TOKEN: FAKE_TOKEN, GH_REPO: TARGET_REPO },
+      githubAuthMode: "injected-token",
+      runtimeMode: "cloud-headless",
+      dispatchPath: "grok-build",
+      runGh: stubGh({ user: INSTALLATION_USER_403 }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.failureKind).toBe(FAILURE_INSTALLATION_IDENTITY_UNVERIFIABLE);
+    expect(result.detail).toMatch(/#3693|installation/i);
+    expect("spawnEnv" in result).toBe(false);
+  });
+
+  it("binds the operator-supplied expected login and fail-closes on mismatch", () => {
+    const match = prepareWorkerCredentialInjection({
+      environ: {
+        GH_TOKEN: FAKE_TOKEN,
+        GH_REPO: TARGET_REPO,
+        [ENV_EXPECTED_GITHUB_LOGIN]: WORKER_LOGIN,
+      },
+      githubAuthMode: "injected-token",
+      runtimeMode: "cloud-headless",
+      dispatchPath: "grok-build",
+      runGh: stubGh({}),
+    });
+    expect(match.ok).toBe(true);
+    if (match.ok && match.injected) {
+      expect(match.spawnEnv[ENV_EXPECTED_GITHUB_LOGIN]).toBe(WORKER_LOGIN);
+    }
+
+    const mismatch = prepareWorkerCredentialInjection({
+      environ: {
+        GH_TOKEN: FAKE_TOKEN,
+        GH_REPO: TARGET_REPO,
+        [ENV_EXPECTED_GITHUB_LOGIN]: "someone-else",
+      },
+      githubAuthMode: "injected-token",
+      runtimeMode: "cloud-headless",
+      dispatchPath: "grok-build",
+      runGh: stubGh({}),
+    });
+    expect(mismatch.ok).toBe(false);
+    if (!mismatch.ok) {
+      expect(mismatch.failureKind).toBe(FAILURE_PRINCIPAL_MISMATCH);
+    }
+  });
+
+  it("never continues under host identity from injected-token mode", () => {
+    const result = prepareWorkerCredentialInjection({
+      environ: { GH_REPO: TARGET_REPO },
+      githubAuthMode: "injected-token",
+      runtimeMode: "local-unsandboxed",
+      dispatchPath: "local-hybrid",
+      runGh: stubGh({}),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.remedy).not.toMatch(/use the host|fall back to host/i);
+      expect(result.githubAuthMode).toBe("injected-token");
+    }
+  });
+});
+
+describe("formatDispatchAuthEnvelope (#1351)", () => {
+  it("records github_auth_mode and expected login without a credential value", () => {
+    const section = formatDispatchAuthEnvelope({
+      runtimeMode: "cloud-headless",
+      githubAuthMode: "injected-token",
+      expectedGithubLogin: WORKER_LOGIN,
+    });
+    expect(section).toContain("## Runtime and GitHub auth mode");
+    expect(section).toContain("runtime_mode: cloud-headless");
+    expect(section).toContain("github_auth_mode: injected-token");
+    expect(section).toContain(`expected_github_login: ${WORKER_LOGIN}`);
+    expect(section).not.toContain("GH_TOKEN=");
+    expect(section).not.toContain(FAKE_TOKEN);
+    expect(section).not.toContain("ghp_");
+    expect(section).not.toContain("github_pat_");
+  });
+
+  it("omits a blank expected login and rejects a credential-shaped runtime label", () => {
+    const omitted = formatDispatchAuthEnvelope({
+      runtimeMode: "local-unsandboxed",
+      githubAuthMode: "host-gh",
+      expectedGithubLogin: "   ",
+    });
+    expect(omitted).not.toContain("expected_github_login");
+    expect(() =>
+      formatDispatchAuthEnvelope({
+        runtimeMode: FAKE_TOKEN,
+        githubAuthMode: "injected-token",
+      }),
+    ).toThrow(/credential value/i);
+  });
+
+  it("rejects a credential-shaped expected login", () => {
+    expect(() =>
+      formatDispatchAuthEnvelope({
+        runtimeMode: "cloud-headless",
+        githubAuthMode: "injected-token",
+        expectedGithubLogin: FAKE_TOKEN,
+      }),
+    ).toThrow(/credential value/i);
+  });
+});
+
+describe("buildManifest auth-mode and identity stamps (#1351)", () => {
+  it("writes github_auth_mode and expected_github_login without a token value", () => {
+    const [entry] = buildManifest([story], {
+      projectRoot: "/p",
+      dispatchKind: "solo",
+      allocationPlanId: null,
+      batchingRationale: null,
+      operatorApprovalEvidence: null,
+      runtimeMode: "cloud-headless",
+      githubAuthMode: "injected-token",
+      expectedGithubLogin: WORKER_LOGIN,
+    });
+    expect(entry?.github_auth_mode).toBe("injected-token");
+    expect(entry?.expected_github_login).toBe(WORKER_LOGIN);
+    expect(entry?.runtime_mode).toBe("cloud-headless");
+    const rendered = JSON.stringify(entry);
+    expect(rendered).not.toContain(FAKE_TOKEN);
+    expect(rendered).not.toContain("ghp_");
+    expect(Object.keys(entry ?? {})).not.toContain("GH_TOKEN");
+    expect(Object.keys(entry ?? {})).not.toContain("GITHUB_TOKEN");
+  });
+});
+
+describe("swarmLaunch identity-bound injection (#1351)", () => {
+  const savedRouting = process.env.DEFT_ROUTING_PATH;
+  const cleanups: string[] = [];
+  afterEach(() => {
+    if (savedRouting === undefined) {
+      delete process.env.DEFT_ROUTING_PATH;
+    } else {
+      process.env.DEFT_ROUTING_PATH = savedRouting;
+    }
+    while (cleanups.length > 0) {
+      const dir = cleanups.pop();
+      if (dir !== undefined) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  function launchProject(): string {
+    const project = mkdtempSync(join(tmpdir(), "launch-inject-"));
+    cleanups.push(project);
+    writeReadyStory(project, "story-a", 1351);
+    const routePath = join(project, "routing.local.json");
+    writeFileSync(
+      routePath,
+      JSON.stringify({
+        cursor: { "leaf-implementation": { model: "composer-2.5-fast", mode: "pinned" } },
+      }),
+    );
+    process.env.DEFT_ROUTING_PATH = routePath;
+    return project;
+  }
+
+  it("stamps expected_github_login on the manifest when a user credential is held", () => {
+    const project = launchProject();
+    const result = swarmLaunch({
+      stories: ["1351"],
+      projectRoot: project,
+      autonomous: true,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["cloud-headless", "injected-token"],
+      environ: { CURSOR_AGENT: "1", GH_TOKEN: FAKE_TOKEN, GH_REPO: TARGET_REPO },
+      runGh: stubGh({}),
+    });
+    expect(result.exitCode).toBe(0);
+    const manifest = JSON.parse(result.stdout) as Record<string, unknown>[];
+    expect(manifest[0]?.github_auth_mode).toBe("injected-token");
+    expect(manifest[0]?.expected_github_login).toBe(WORKER_LOGIN);
+    expect(result.stdout).not.toContain(FAKE_TOKEN);
+    expect(JSON.stringify(manifest)).not.toContain(FAKE_TOKEN);
+  });
+
+  it("does not auto-promote host-gh to injected-token just because GH_TOKEN is set", () => {
+    const project = launchProject();
+    const result = swarmLaunch({
+      stories: ["1351"],
+      projectRoot: project,
+      autonomous: true,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["local-unsandboxed", "host-gh"],
+      environ: { CURSOR_AGENT: "1", GH_TOKEN: FAKE_TOKEN, GH_REPO: TARGET_REPO },
+      runGh: stubGh({}),
+    });
+    expect(result.exitCode).toBe(0);
+    const manifest = JSON.parse(result.stdout) as Record<string, unknown>[];
+    expect(manifest[0]?.github_auth_mode).toBe("host-gh");
+    expect(manifest[0]?.expected_github_login).toBeUndefined();
+    expect(result.stdout).not.toContain(FAKE_TOKEN);
+  });
+
+  it("fails launch when the held credential is an installation token", () => {
+    const project = launchProject();
+    const result = swarmLaunch({
+      stories: ["1351"],
+      projectRoot: project,
+      autonomous: true,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["cloud-headless", "injected-token"],
+      environ: { CURSOR_AGENT: "1", GH_TOKEN: FAKE_TOKEN, GH_REPO: TARGET_REPO },
+      runGh: stubGh({ user: INSTALLATION_USER_403 }),
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/BLOCKED/i);
+    expect(result.stderr).toMatch(/installation|#3693/i);
+    expect(result.stdout).not.toContain(FAKE_TOKEN);
+  });
+});
+
+describe("preamble envelope half of the auth-mode contract (#1351)", () => {
+  const preamble = readFileSync(PREAMBLE_PATH, "utf8");
+
+  it("documents github_auth_mode on the dispatch envelope and keeps the :451 / :127 conjunction", () => {
+    expect(preamble).toContain("github_auth_mode");
+    expect(preamble).toContain("expected_github_login");
+    expect(preamble).toContain(ENV_EXPECTED_GITHUB_LOGIN);
+    expect(preamble).toContain(
+      "These fields are policy labels only -- they MUST NOT contain `GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`, or any secret token value.",
+    );
+    expect(preamble).toContain(
+      "Dispatchers MUST inject worker credentials for injected-token / cloud-headless dispatches and MUST record the selected `github_auth_mode` in the launch manifest and dispatch envelope. v1 deliberately keeps token injection operator-implemented; mode labels make the contract explicit without placing token values in prompts or transcripts.",
+    );
+    expect(preamble).toContain("prepareWorkerCredentialInjection");
+    expect(preamble).toContain("validateGithubAuthForWorker");
+    expect(preamble).not.toContain("ghp_");
+    expect(preamble).not.toContain("github_pat_");
+    expect(preamble).not.toContain(FAKE_TOKEN);
+  });
+});

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -1,7 +1,18 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { containedWrite } from "../fs/contained-write.js";
-import { inferGithubAuthMode } from "../intake/github-auth-modes.js";
+import {
+  ENV_EXPECTED_GITHUB_LOGIN,
+  type ExpectedGithubWorkerPrincipal,
+  FAILURE_INSTALLATION_IDENTITY_UNVERIFIABLE,
+  FAILURE_MISSING_INJECTED_TOKEN,
+  findInjectedToken,
+  type GhRunner,
+  GITHUB_AUTH_MODE_HOST_GH,
+  GITHUB_AUTH_MODE_INJECTED_TOKEN,
+  inferGithubAuthMode,
+  validateGithubAuthForWorker,
+} from "../intake/github-auth-modes.js";
 import { getPlatformCapabilities } from "../intake/platform-capabilities.js";
 import {
   hasArtifactSuffix,
@@ -65,6 +76,207 @@ export const defaultRuntimeAuthProbe: RuntimeAuthProbeFn = () => {
   const report = getPlatformCapabilities();
   return [report.runtimeMode, inferGithubAuthMode(report)];
 };
+
+export type WorkerCredentialDispatchPath = "grok-build" | "local-hybrid";
+
+const CREDENTIAL_VALUE_PATTERN = /^(ghp_|gho_|ghu_|ghs_|github_pat_)/i;
+
+const INJECTION_MISSING_CREDENTIAL = "GH_TOKEN (or GITHUB_TOKEN / GH_ENTERPRISE_TOKEN)";
+
+const INJECTION_DISPATCHER_REMEDY =
+  "Dispatcher-side remedy: load an approved user-bearing worker credential into the dispatcher environment, then call prepareWorkerCredentialInjection before spawn. Do not fall back to the host gh token or continue under the maintainer identity. Installation credentials are not injectable; see #3693.";
+
+function looksLikeCredentialValue(value: string): boolean {
+  return CREDENTIAL_VALUE_PATTERN.test(value.trim());
+}
+
+function assertNoCredentialValue(value: string, label: string): void {
+  if (looksLikeCredentialValue(value)) {
+    throw new Error(`${label} must not contain a credential value`);
+  }
+}
+
+/**
+ * Dispatch-envelope half of the runtime / GitHub auth-mode contract (#1557 / #1351).
+ * Policy labels only — never a token value.
+ */
+export function formatDispatchAuthEnvelope(fields: {
+  runtimeMode: string;
+  githubAuthMode: string;
+  expectedGithubLogin?: string | null;
+}): string {
+  assertNoCredentialValue(fields.runtimeMode, "runtime_mode");
+  assertNoCredentialValue(fields.githubAuthMode, "github_auth_mode");
+  const lines = [
+    "## Runtime and GitHub auth mode",
+    "",
+    `- runtime_mode: ${fields.runtimeMode}`,
+    `- github_auth_mode: ${fields.githubAuthMode}`,
+  ];
+  if (fields.expectedGithubLogin !== undefined && fields.expectedGithubLogin !== null) {
+    const login = fields.expectedGithubLogin.trim();
+    if (login.length > 0) {
+      assertNoCredentialValue(login, "expected_github_login");
+      lines.push(`- expected_github_login: ${login}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export interface WorkerCredentialInjectionRequest {
+  environ?: NodeJS.ProcessEnv;
+  githubAuthMode: string;
+  runtimeMode?: string | null;
+  dispatchPath?: WorkerCredentialDispatchPath;
+  expectedPrincipal?: ExpectedGithubWorkerPrincipal | null;
+  repo?: string;
+  runGh?: GhRunner;
+  cwd?: string;
+}
+
+export type WorkerCredentialInjectionResult =
+  | {
+      ok: true;
+      injected: true;
+      githubAuthMode: typeof GITHUB_AUTH_MODE_INJECTED_TOKEN;
+      runtimeMode: string | null;
+      expectedLogin: string;
+      spawnEnv: { GH_TOKEN: string; DEFT_EXPECTED_GITHUB_LOGIN: string };
+      envelopeSection: string;
+    }
+  | {
+      ok: true;
+      injected: false;
+      githubAuthMode: typeof GITHUB_AUTH_MODE_HOST_GH;
+      runtimeMode: string | null;
+      expectedLogin: string | null;
+      spawnEnv: Record<string, never>;
+      envelopeSection: string;
+    }
+  | {
+      ok: false;
+      blocked: true;
+      githubAuthMode: string;
+      runtimeMode: string | null;
+      missingCredential: string;
+      remedy: string;
+      detail: string;
+      failureKind: string | null;
+      envelopeSection: string;
+    };
+
+function blockedInjection(fields: {
+  githubAuthMode: string;
+  runtimeMode: string | null;
+  failureKind: string | null;
+  detail: string;
+  missingCredential?: string;
+}): WorkerCredentialInjectionResult {
+  const detail = fields.detail.startsWith("BLOCKED") ? fields.detail : `BLOCKED: ${fields.detail}`;
+  return {
+    ok: false,
+    blocked: true,
+    githubAuthMode: fields.githubAuthMode,
+    runtimeMode: fields.runtimeMode,
+    missingCredential: fields.missingCredential ?? INJECTION_MISSING_CREDENTIAL,
+    remedy: INJECTION_DISPATCHER_REMEDY,
+    detail,
+    failureKind: fields.failureKind,
+    envelopeSection: formatDispatchAuthEnvelope({
+      runtimeMode: fields.runtimeMode ?? "unknown",
+      githubAuthMode: fields.githubAuthMode,
+    }),
+  };
+}
+
+/**
+ * Validate a held user-bearing worker credential and prepare spawn-time injection (#1351).
+ *
+ * Comparison is opt-in on the validator. This path always stamps
+ * `DEFT_EXPECTED_GITHUB_LOGIN` after a successful user-principal check so the
+ * worker envelope does not inherit "any user token is approved."
+ *
+ * Installation credentials fail closed via the existing validator (#3693).
+ * Token values belong only in the returned `spawnEnv` — never in prompts,
+ * transcripts, or manifest entries.
+ */
+export function prepareWorkerCredentialInjection(
+  request: WorkerCredentialInjectionRequest,
+): WorkerCredentialInjectionResult {
+  const environ = request.environ ?? process.env;
+  const runtimeMode = request.runtimeMode ?? null;
+  const token = findInjectedToken(environ);
+  const grokBuild = request.dispatchPath === "grok-build";
+  const effectiveMode =
+    grokBuild || token !== null ? GITHUB_AUTH_MODE_INJECTED_TOKEN : request.githubAuthMode;
+
+  if (effectiveMode === GITHUB_AUTH_MODE_HOST_GH && token === null) {
+    return {
+      ok: true,
+      injected: false,
+      githubAuthMode: GITHUB_AUTH_MODE_HOST_GH,
+      runtimeMode,
+      expectedLogin: null,
+      spawnEnv: {},
+      envelopeSection: formatDispatchAuthEnvelope({
+        runtimeMode: runtimeMode ?? "local-unsandboxed",
+        githubAuthMode: GITHUB_AUTH_MODE_HOST_GH,
+      }),
+    };
+  }
+
+  if (token === null) {
+    return blockedInjection({
+      githubAuthMode: GITHUB_AUTH_MODE_INJECTED_TOKEN,
+      runtimeMode,
+      failureKind: FAILURE_MISSING_INJECTED_TOKEN,
+      missingCredential: INJECTION_MISSING_CREDENTIAL,
+      detail:
+        "missing worker credential GH_TOKEN (or GITHUB_TOKEN / GH_ENTERPRISE_TOKEN) for a write-requiring injected-token dispatch",
+    });
+  }
+
+  const validated = validateGithubAuthForWorker(GITHUB_AUTH_MODE_INJECTED_TOKEN, {
+    environ,
+    runtimeReport: { runtimeMode: runtimeMode ?? "cloud-headless" },
+    repo: request.repo,
+    runGh: request.runGh,
+    expectedPrincipal: request.expectedPrincipal,
+    cwd: request.cwd,
+  });
+
+  if (!validated.ok || validated.login === null || validated.login.trim().length === 0) {
+    const installation = validated.failureKind === FAILURE_INSTALLATION_IDENTITY_UNVERIFIABLE;
+    return blockedInjection({
+      githubAuthMode: GITHUB_AUTH_MODE_INJECTED_TOKEN,
+      runtimeMode,
+      failureKind: validated.failureKind,
+      detail: installation
+        ? `${validated.detail} Installation credentials are not injectable (#3693).`
+        : validated.detail,
+    });
+  }
+
+  const expectedLogin = validated.login.trim();
+  assertNoCredentialValue(expectedLogin, "expected_github_login");
+  const spawnEnv = {
+    GH_TOKEN: token,
+    [ENV_EXPECTED_GITHUB_LOGIN]: expectedLogin,
+  };
+  return {
+    ok: true,
+    injected: true,
+    githubAuthMode: GITHUB_AUTH_MODE_INJECTED_TOKEN,
+    runtimeMode,
+    expectedLogin,
+    spawnEnv,
+    envelopeSection: formatDispatchAuthEnvelope({
+      runtimeMode: runtimeMode ?? "cloud-headless",
+      githubAuthMode: GITHUB_AUTH_MODE_INJECTED_TOKEN,
+      expectedGithubLogin: expectedLogin,
+    }),
+  };
+}
 
 function loadJson(path: string): Record<string, unknown> | null {
   try {
@@ -578,6 +790,7 @@ export function buildManifest(
     modelSource?: string | null;
     runtimeMode?: string | null;
     githubAuthMode?: string | null;
+    expectedGithubLogin?: string | null;
     occupancySessionId?: string | null;
   },
 ): Record<string, unknown>[] {
@@ -631,6 +844,10 @@ export function buildManifest(
     }
     if (options.githubAuthMode !== undefined && options.githubAuthMode !== null) {
       entry.github_auth_mode = options.githubAuthMode;
+    }
+    if (options.expectedGithubLogin !== undefined && options.expectedGithubLogin !== null) {
+      assertNoCredentialValue(options.expectedGithubLogin, "expected_github_login");
+      entry.expected_github_login = options.expectedGithubLogin;
     }
     manifest.push(entry);
   }
@@ -698,6 +915,9 @@ export interface LaunchArgs {
    * Defaults to `process.env` when unset.
    */
   environ?: NodeJS.ProcessEnv;
+  /** Optional gh runner for identity-bound credential injection (#1351). */
+  runGh?: GhRunner;
+  expectedPrincipal?: ExpectedGithubWorkerPrincipal | null;
 }
 
 export function swarmLaunch(args: LaunchArgs): {
@@ -890,6 +1110,36 @@ export function swarmLaunch(args: LaunchArgs): {
     };
   }
 
+  const launchEnviron = args.environ ?? process.env;
+  let expectedGithubLogin: string | null = null;
+  // Only the injected-token launch path auto-validates. An ambient GH_TOKEN on
+  // a host-gh probe is often the maintainer workaround, not a worker credential;
+  // local-hybrid injection is the explicit prepareWorkerCredentialInjection call.
+  if (
+    githubAuthMode === GITHUB_AUTH_MODE_INJECTED_TOKEN &&
+    findInjectedToken(launchEnviron) !== null
+  ) {
+    const injection = prepareWorkerCredentialInjection({
+      environ: launchEnviron,
+      githubAuthMode,
+      runtimeMode,
+      dispatchPath: "grok-build",
+      runGh: args.runGh,
+      expectedPrincipal: args.expectedPrincipal,
+      cwd: projectRoot,
+    });
+    if (!injection.ok) {
+      return {
+        exitCode: EXIT_GATE_FAILED,
+        stdout: "",
+        stderr: `${injection.detail}\n${injection.remedy}\n`,
+      };
+    }
+    if (injection.injected) {
+      expectedGithubLogin = injection.expectedLogin;
+    }
+  }
+
   const manifest = buildManifest(ordered, {
     projectRoot,
     group: args.group ?? null,
@@ -906,6 +1156,7 @@ export function swarmLaunch(args: LaunchArgs): {
     modelSource,
     runtimeMode,
     githubAuthMode,
+    expectedGithubLogin,
     occupancySessionId: occupancy.sessionId,
   });
 

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -86,7 +86,8 @@ const INJECTION_MISSING_CREDENTIAL = "GH_TOKEN (or GITHUB_TOKEN / GH_ENTERPRISE_
 const INJECTION_DISPATCHER_REMEDY =
   "Dispatcher-side remedy: load an approved user-bearing worker credential into the dispatcher environment, then call prepareWorkerCredentialInjection before spawn. Do not fall back to the host gh token or continue under the maintainer identity. Installation credentials are not injectable; see #3693.";
 
-const SIBLING_INJECTED_TOKEN_VARS = [
+const HELD_WORKER_TOKEN_VARS = [
+  "GH_TOKEN",
   "GITHUB_TOKEN",
   "GH_ENTERPRISE_TOKEN",
   "GITHUB_ENTERPRISE_TOKEN",
@@ -108,13 +109,35 @@ function sanitizeEnvelopeField(value: string, label: string): string {
   return cleaned;
 }
 
-/** Present only the selected token so validation cannot bind a sibling env var. */
+/**
+ * Bind validation to the selected token. Stamp it into every gh token slot and
+ * drop GH_CONFIG_DIR so a host/enterprise config cannot authenticate as someone
+ * else. GH_HOST stays: it selects the API host, not the secret.
+ */
 function isolateHeldWorkerToken(environ: NodeJS.ProcessEnv, token: string): NodeJS.ProcessEnv {
-  const isolated: NodeJS.ProcessEnv = { ...environ, GH_TOKEN: token };
-  for (const name of SIBLING_INJECTED_TOKEN_VARS) {
-    delete isolated[name];
+  const isolated: NodeJS.ProcessEnv = { ...environ };
+  for (const name of HELD_WORKER_TOKEN_VARS) {
+    isolated[name] = token;
   }
+  delete isolated.GH_CONFIG_DIR;
   return isolated;
+}
+
+function boundWorkerSpawnEnv(
+  token: string,
+  expectedLogin: string,
+): {
+  GH_TOKEN: string;
+  GITHUB_TOKEN: string;
+  GH_ENTERPRISE_TOKEN: string;
+  DEFT_EXPECTED_GITHUB_LOGIN: string;
+} {
+  return {
+    GH_TOKEN: token,
+    GITHUB_TOKEN: token,
+    GH_ENTERPRISE_TOKEN: token,
+    [ENV_EXPECTED_GITHUB_LOGIN]: expectedLogin,
+  };
 }
 
 /**
@@ -161,7 +184,12 @@ export type WorkerCredentialInjectionResult =
       githubAuthMode: typeof GITHUB_AUTH_MODE_INJECTED_TOKEN;
       runtimeMode: string | null;
       expectedLogin: string;
-      spawnEnv: { GH_TOKEN: string; DEFT_EXPECTED_GITHUB_LOGIN: string };
+      spawnEnv: {
+        GH_TOKEN: string;
+        GITHUB_TOKEN: string;
+        GH_ENTERPRISE_TOKEN: string;
+        DEFT_EXPECTED_GITHUB_LOGIN: string;
+      };
       envelopeSection: string;
     }
   | {
@@ -280,10 +308,7 @@ export function prepareWorkerCredentialInjection(
 
   const expectedLogin = validated.login.trim();
   assertNoCredentialValue(expectedLogin, "expected_github_login");
-  const spawnEnv = {
-    GH_TOKEN: token,
-    [ENV_EXPECTED_GITHUB_LOGIN]: expectedLogin,
-  };
+  const spawnEnv = boundWorkerSpawnEnv(token, expectedLogin);
   return {
     ok: true,
     injected: true,

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -86,6 +86,12 @@ const INJECTION_MISSING_CREDENTIAL = "GH_TOKEN (or GITHUB_TOKEN / GH_ENTERPRISE_
 const INJECTION_DISPATCHER_REMEDY =
   "Dispatcher-side remedy: load an approved user-bearing worker credential into the dispatcher environment, then call prepareWorkerCredentialInjection before spawn. Do not fall back to the host gh token or continue under the maintainer identity. Installation credentials are not injectable; see #3693.";
 
+const SIBLING_INJECTED_TOKEN_VARS = [
+  "GITHUB_TOKEN",
+  "GH_ENTERPRISE_TOKEN",
+  "GITHUB_ENTERPRISE_TOKEN",
+] as const;
+
 function looksLikeCredentialValue(value: string): boolean {
   return CREDENTIAL_VALUE_PATTERN.test(value.trim());
 }
@@ -94,6 +100,21 @@ function assertNoCredentialValue(value: string, label: string): void {
   if (looksLikeCredentialValue(value)) {
     throw new Error(`${label} must not contain a credential value`);
   }
+}
+
+function sanitizeEnvelopeField(value: string, label: string): string {
+  const cleaned = value.replace(/\r?\n/g, " ").trim();
+  assertNoCredentialValue(cleaned, label);
+  return cleaned;
+}
+
+/** Present only the selected token so validation cannot bind a sibling env var. */
+function isolateHeldWorkerToken(environ: NodeJS.ProcessEnv, token: string): NodeJS.ProcessEnv {
+  const isolated: NodeJS.ProcessEnv = { ...environ, GH_TOKEN: token };
+  for (const name of SIBLING_INJECTED_TOKEN_VARS) {
+    delete isolated[name];
+  }
+  return isolated;
 }
 
 /**
@@ -105,18 +126,17 @@ export function formatDispatchAuthEnvelope(fields: {
   githubAuthMode: string;
   expectedGithubLogin?: string | null;
 }): string {
-  assertNoCredentialValue(fields.runtimeMode, "runtime_mode");
-  assertNoCredentialValue(fields.githubAuthMode, "github_auth_mode");
+  const runtimeMode = sanitizeEnvelopeField(fields.runtimeMode, "runtime_mode");
+  const githubAuthMode = sanitizeEnvelopeField(fields.githubAuthMode, "github_auth_mode");
   const lines = [
     "## Runtime and GitHub auth mode",
     "",
-    `- runtime_mode: ${fields.runtimeMode}`,
-    `- github_auth_mode: ${fields.githubAuthMode}`,
+    `- runtime_mode: ${runtimeMode}`,
+    `- github_auth_mode: ${githubAuthMode}`,
   ];
   if (fields.expectedGithubLogin !== undefined && fields.expectedGithubLogin !== null) {
-    const login = fields.expectedGithubLogin.trim();
+    const login = sanitizeEnvelopeField(fields.expectedGithubLogin, "expected_github_login");
     if (login.length > 0) {
-      assertNoCredentialValue(login, "expected_github_login");
       lines.push(`- expected_github_login: ${login}`);
     }
   }
@@ -236,8 +256,9 @@ export function prepareWorkerCredentialInjection(
     });
   }
 
+  const isolatedEnviron = isolateHeldWorkerToken(environ, token);
   const validated = validateGithubAuthForWorker(GITHUB_AUTH_MODE_INJECTED_TOKEN, {
-    environ,
+    environ: isolatedEnviron,
     runtimeReport: { runtimeMode: runtimeMode ?? "cloud-headless" },
     repo: request.repo,
     runGh: request.runGh,
@@ -1112,13 +1133,11 @@ export function swarmLaunch(args: LaunchArgs): {
 
   const launchEnviron = args.environ ?? process.env;
   let expectedGithubLogin: string | null = null;
-  // Only the injected-token launch path auto-validates. An ambient GH_TOKEN on
-  // a host-gh probe is often the maintainer workaround, not a worker credential;
-  // local-hybrid injection is the explicit prepareWorkerCredentialInjection call.
-  if (
-    githubAuthMode === GITHUB_AUTH_MODE_INJECTED_TOKEN &&
-    findInjectedToken(launchEnviron) !== null
-  ) {
+  // Only the injected-token launch path auto-validates (and fail-closes on a
+  // missing token). An ambient GH_TOKEN on a host-gh probe is often the
+  // maintainer workaround, not a worker credential; local-hybrid injection is
+  // the explicit prepareWorkerCredentialInjection call.
+  if (githubAuthMode === GITHUB_AUTH_MODE_INJECTED_TOKEN) {
     const injection = prepareWorkerCredentialInjection({
       environ: launchEnviron,
       githubAuthMode,


### PR DESCRIPTION
## Summary

Dispatchers that already hold a user-bearing worker credential now validate it with the existing principal check, inject it into the worker process environment, and stamp the expected GitHub login so identity comparison is not optional.

- `prepareWorkerCredentialInjection` binds an identity, not merely a token (`DEFT_EXPECTED_GITHUB_LOGIN` / envelope `expected_github_login`).
- App-installation credentials still fail closed (`installation_identity_unverifiable`). Installation identity remains #3693.
- Token values stay in process env only — never in prompts, transcripts, or launch manifests.
- `task swarm:launch` auto-validates only when the probed mode is already `injected-token` and a token is held. Ambient `GH_TOKEN` on `host-gh` is not auto-promoted (that path is the maintainer workaround).

## Related Issues

Tracking: #1351

Product change only. The active xBRIEF is parked for a leftover `scope:complete` land after merge so provenance can pass on this PR.

## Checklist

- [x] `/deft:change <name>` — N/A (scoped story #1351 with existing xBRIEF; one surface)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (#1351 is not a ROADMAP-tracked item)
- [x] Tests pass locally (`packages/core/src/swarm/launch.test.ts` 15/15)

## Test plan

- [x] Helper injects token + expected login on grok-build and local-hybrid when a user-bearing credential validates
- [x] Missing token on an injected-token write path is BLOCKED with the named credential and dispatcher-side remedy
- [x] Installation identity fails closed; no host-gh fallback and no continue-under-host-identity
- [x] Envelope and launch manifest never contain a token value
- [x] Launch does not auto-promote ambient `GH_TOKEN` when the probe is `host-gh`

## Post-Merge

- [ ] `task verify:orphan-active -- --issue 1351` exits 0
- [ ] `task scope:complete` (leftover land PR if needed — never hand-write `xbrief/completed/`)
- [ ] `task verify:completed-tracked -- --issue 1351` exits 0 on `origin/master`
