### PR TITLE
Make adoption-blocker the canonical consumer hard-stop label

### DIFF
--- a/.github/ISSUE_LABELS.md
+++ b/.github/ISSUE_LABELS.md
@@ -281,7 +281,7 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 7. ! Machine labels: closed set above; mirror is primary writer.
 8. ! Platform only for OS-intrinsic work.
 9. ~ Consumer projects: follow **#2611** kit when shipped — do not copy the full maintainer set by default.
-10. ! Consumer hard-stop uses `adoption-blocker` only, with body evidence (`content/scm/github.md` Issue Workflow). ⊗ Infer that a workaround exists from the label's absence. ⊗ Encode the classification in the issue title.
+10. ! Consumer hard-stop uses `adoption-blocker`, with body evidence (`content/scm/github.md` Issue Workflow); an upgrade-path hard stop also uses `Upgrade Blocker`. ⊗ Infer that a workaround exists from the label's absence. ⊗ Encode the classification in the issue title.
 
 Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) links here.
 

--- a/.github/ISSUE_LABELS.md
+++ b/.github/ISSUE_LABELS.md
@@ -240,6 +240,28 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 
 `urgent`, `adoption-blocker`, `agent-experience`, `blocks-merge`, `blocks-release-tag`, `Upgrade Blocker`
 
+#### `adoption-blocker` -- canonical consumer hard-blocker (#3650)
+
+**Positive-only:** this label means the issue is *classified as a blocker*. Its absence means *not classified* -- never that a workaround exists.
+
+**Definition:** a Directive consumer cannot complete an intended flow without a reasonable workaround. The range is install, first session, update, `task check`, and ship -- not first session alone.
+
+**GitHub description (100-char cap):** `Consumer cannot complete an intended Directive flow; no reasonable workaround`
+
+**Required evidence:** body must name affected consumer flow and version, documented alternatives attempted, observed recovery cost, and triage owner and date. Full test: `content/scm/github.md` Issue Workflow.
+
+**Ranking / display (verified, not newly built):** already in `plan.policy.triageRankingLabels` after `blocks-merge` and `blocks-release-tag`. `triage:queue` prints `(label: adoption-blocker)` on ranked rows. Do not add ranking code. Do not encode this classification in the title.
+
+**Distinguished from adjacent signals:**
+
+| Label | Means | Not `adoption-blocker` because |
+|---|---|---|
+| `Upgrade Blocker` | Blocks the user from upgrading | Upgrade path only. A hard stop at `task check` or ship is not this. |
+| `status:blocked` | *This* issue waits on something else | Lifecycle of the issue, not "consumer cannot complete an intended flow". |
+| `urgent` | High priority; ranks above `bug` | Priority, not hard-stop. An issue may be `urgent` and still not a blocker (this recut of #3650 is the example). |
+
+**Choice recorded:** broaden `adoption-blocker` rather than add a new slug. Onboarding-specific wording did not need preserving -- historical use already stretched past first session, and a second label would split the same class. Relabel of existing `BLOCKER`-titled issues is #3699, not this story.
+
 ### Process / workflow (selected)
 
 `process` (if present), `Workflow`, `triage`, `swarm`, `meta`, `scm`, `determinism`, `source-of-truth`, …
@@ -257,6 +279,7 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 7. ! Machine labels: closed set above; mirror is primary writer.
 8. ! Platform only for OS-intrinsic work.
 9. ~ Consumer projects: follow **#2611** kit when shipped — do not copy the full maintainer set by default.
+10. ! Consumer hard-stop uses `adoption-blocker` only, with body evidence (`content/scm/github.md` Issue Workflow). ⊗ Infer that a workaround exists from the label's absence. ⊗ Encode the classification in the issue title.
 
 Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) links here.
 
@@ -312,6 +335,7 @@ Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) 
 
 | Date | Change |
 |------|--------|
+| 2026-08-24 | Broaden `adoption-blocker` to the full intended-flow range; state positive-only semantics; distinguish from `Upgrade Blocker`, `status:blocked`, and `urgent` (#3650) |
 | 2026-08-21 | Design-critique stamp label `design-critique:mechanism-shaped` + write-back field `mechanism-shaped: true` (ADR-005 / #3434 Story 1) |
 | 2026-08-05 | Quarantine zero-open twins/synonyms as lowercase `legacy:<former>` (colon form wins) |
 | 2026-08-05 | Open-issue migration notes + re-run instructions (#3128) |

--- a/.github/ISSUE_LABELS.md
+++ b/.github/ISSUE_LABELS.md
@@ -248,7 +248,7 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 
 **GitHub description (100-char cap):** `Consumer cannot complete an intended Directive flow; no reasonable workaround`
 
-**Required evidence:** body must name affected consumer flow and version, documented alternatives attempted, observed recovery cost, and triage owner and date. Full test: `content/scm/github.md` Issue Workflow.
+**Required evidence:** body must name affected consumer flow and version; documented alternatives attempted, or why the documented alternatives are not a reasonable workaround; observed recovery cost; and triage owner and date. Full test: `content/scm/github.md` Issue Workflow.
 
 **Ranking / display (verified, not newly built):** already in `plan.policy.triageRankingLabels` after `blocks-merge` and `blocks-release-tag`. `triage:queue` prints `(label: adoption-blocker)` on ranked rows. Do not add ranking code. Do not encode this classification in the title.
 
@@ -256,9 +256,11 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 
 | Label | Means | Not `adoption-blocker` because |
 |---|---|---|
-| `Upgrade Blocker` | Blocks the user from upgrading | Upgrade path only. A hard stop at `task check` or ship is not this. |
+| `Upgrade Blocker` | Blocks the user from upgrading | Upgrade facet only. A hard stop at `task check` or ship is not this. |
 | `status:blocked` | *This* issue waits on something else | Lifecycle of the issue, not "consumer cannot complete an intended flow". |
 | `urgent` | High priority; ranks above `bug` | Priority, not hard-stop. An issue may be `urgent` and still not a blocker (this recut of #3650 is the example). |
+
+**Upgrade overlap:** when the stuck flow is upgrade, apply both. `adoption-blocker` is the ranking chip; `Upgrade Blocker` is the upgrade facet. `Upgrade Blocker` alone does not rank.
 
 **Choice recorded:** broaden `adoption-blocker` rather than add a new slug. Onboarding-specific wording did not need preserving -- historical use already stretched past first session, and a second label would split the same class. Relabel of existing `BLOCKER`-titled issues is #3699, not this story.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`adoption-blocker` is the canonical consumer hard-stop label.** It now covers any intended Directive flow (install, first session, update, `task check`, ship) with no reasonable workaround, not only first session. The label means classified as a blocker; its absence means not classified, never that a workaround exists. Classification requires body evidence. Closes #3650.
+
 - **Stop 1 premises stay outside parent substantiation; Stop 1 records `refutation-target:` (#3672).** The contract now states why a pre-critic premise is excluded. Stop 1 write-backs record a non-binding `refutation-target:`. Not an audit marker; never blocks bind. Closes #3672.
 
 - **Design-critique critics get a stated method (#3661).** The contract now says how to critique, at three distinct strengths, instead of only telling the parent how to dispatch. Stop 3's overloaded Charter heading is renamed to parent-facing dispatch rules. Closes #3661.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`adoption-blocker` is the canonical consumer hard-stop label.** It now covers any intended Directive flow (install, first session, update, `task check`, ship) with no reasonable workaround, not only first session. The label means classified as a blocker; its absence means not classified, never that a workaround exists. Classification requires body evidence. Closes #3650.
+- **`adoption-blocker` is the canonical consumer hard-stop label.** It now covers any intended Directive flow (install, first session, update, `task check`, ship) with no reasonable workaround, not only first session. The label means classified as a blocker; its absence means not classified, never that a workaround exists. Classification requires body evidence (attempted alternatives, or why documented alternatives are not reasonable). An upgrade-path hard stop wears this label plus `Upgrade Blocker`; `Upgrade Blocker` alone does not rank. Closes #3650.
 
 - **Stop 1 premises stay outside parent substantiation; Stop 1 records `refutation-target:` (#3672).** The contract now states why a pre-critic premise is excluded. Stop 1 write-backs record a non-binding `refutation-target:`. Not an audit marker; never blocks bind. Closes #3672.
 

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -377,6 +377,31 @@ Agent `edit_files` operations can fail when structured file sections contain Uni
 
 **Mirror** (if using `triage:classify -- --mirror`): at least `triaged`; optional `triage:deferred` / `triage:archived` when `actionLabels` maps them
 
+### Consumer hard-blocker (`adoption-blocker`)
+
+**Framework source (`deftai/directive` only).** Consumer kits do not ship this label; see `.github/ISSUE_LABELS.md`.
+
+**Positive-only:** the `adoption-blocker` label means the issue is *classified as a blocker*. Its absence means *not classified*. Absence never means a workaround exists.
+
+This is the canonical ranking label for **a Directive consumer cannot complete an intended flow and has no reasonable workaround**. The range is install, first session, update, `task check`, and ship -- not onboarding alone. Do not invent a second ranking label for that class, and do not encode it in the title.
+
+**Classification test** (all must hold, and a second person must be able to check them from the body):
+
+1. An intended consumer flow at a named version does not complete.
+2. Documented alternatives were tried and failed, or are not a reasonable workaround.
+3. Recovery cost is observed (time, lost work, or a stuck session), not inferred.
+
+**Required body evidence** -- apply the label only when all four are present:
+
+- affected consumer flow and version
+- documented alternatives attempted
+- observed recovery cost
+- triage owner and date
+
+**Not this label:** `Upgrade Blocker` is upgrade-specific. `status:blocked` means *this issue* waits on something else. `urgent` is priority; an issue may be `urgent` and still not a consumer hard stop.
+
+**Ranking / display:** `plan.policy.triageRankingLabels` already lists `adoption-blocker` (after `blocks-merge` and `blocks-release-tag`). `triage:queue` prints `(label: adoption-blocker)` on matched rows. Confirm participation; do not add ranking code.
+
 ### Post-1.0.0 Issue Linking
 
 Following a v1.0.0 release, commits:

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -394,11 +394,13 @@ This is the canonical ranking label for **a Directive consumer cannot complete a
 **Required body evidence** -- apply the label only when all four are present:
 
 - affected consumer flow and version
-- documented alternatives attempted
+- documented alternatives attempted, or why the documented alternatives are not a reasonable workaround
 - observed recovery cost
 - triage owner and date
 
-**Not this label:** `Upgrade Blocker` is upgrade-specific. `status:blocked` means *this issue* waits on something else. `urgent` is priority; an issue may be `urgent` and still not a consumer hard stop.
+**Upgrade path:** a hard stop on the upgrade flow is still a consumer hard stop. Apply `adoption-blocker` so it ranks. Also apply `Upgrade Blocker` as the upgrade-specific adjacent signal. `Upgrade Blocker` alone does not rank. A hard stop at `task check` or ship is `adoption-blocker` only.
+
+**Not this label:** `status:blocked` means *this issue* waits on something else. `urgent` is priority; an issue may be `urgent` and still not a consumer hard stop.
 
 **Ranking / display:** `plan.policy.triageRankingLabels` already lists `adoption-blocker` (after `blocks-merge` and `blocks-release-tag`). `triage:queue` prints `(label: adoption-blocker)` on matched rows. Confirm participation; do not add ranking code.
 

--- a/xbrief/decisions/2026-08-24-broaden-adoption-blocker-to-the-full-intended-flow-range-instead.decision.json
+++ b/xbrief/decisions/2026-08-24-broaden-adoption-blocker-to-the-full-intended-flow-range-instead.decision.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "broaden-adoption-blocker-to-the-full-intended-flow-range-instead",
+  "decision": "Broaden adoption-blocker to the full intended-flow range instead of adding a new ranking label",
+  "governingRule": {
+    "description": "Exactly one canonical label means consumer cannot complete an intended Directive flow with no reasonable workaround",
+    "path": "xbrief/active/2026-08-24-3650-featscmguidance-one-canonical-consumer-hard-blocker-label.xbrief.json",
+    "rfc2119": "MUST"
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Add a new ranking label (for example consumer-blocker) and keep adoption-blocker as first-session-only",
+      "whyNot": "Two labels would split the same class of harm. The story asks for exactly one canonical label. A new slug also needs ranking-config and live-label creation; adoption-blocker already ranks and displays."
+    },
+    {
+      "option": "Rename adoption-blocker to a fuller slug",
+      "whyNot": "Rename is a larger taxonomy change than this story asked for (search, ranking config, historical filters). The definition text is what agents read; the existing slug already participates in triageRankingLabels."
+    },
+    {
+      "option": "Use urgent as the consumer hard-stop signal",
+      "whyNot": "LockedDecision and the recut forbid this. urgent is broad priority; #3650 itself is urgent and explicitly not a blocker."
+    }
+  ],
+  "whyWinner": "Onboarding-specific wording need not be preserved: live historical use already stretched past first session (doctor, update, release hangs), only one open issue currently wears the label, and install through ship is one class of consumer hard stop. Broadening keeps a single ranking chip that triage:queue already consumes via matchedLabelFor. Upgrade Blocker stays the upgrade-specific adjacent signal.",
+  "confidence": "high",
+  "activeScopeRefs": [
+    "xbrief/active/2026-08-24-3650-featscmguidance-one-canonical-consumer-hard-blocker-label.xbrief.json"
+  ],
+  "timestamp": "2026-08-24T21:41:55Z",
+  "revisitTrigger": "Revisit if operators need a separate first-session-only queue distinct from update/check/ship hard stops, or if a measured title-only integration cannot display labels.",
+  "tags": [
+    "taxonomy",
+    "triage",
+    "scm"
+  ],
+  "relatedIssues": [
+    3650,
+    3699,
+    2609
+  ]
+}


### PR DESCRIPTION
## Summary

- `adoption-blocker` is now the one canonical consumer hard-stop label. It covers any intended Directive flow (install, first session, update, `task check`, ship) when there is no reasonable workaround — not first session alone.
- **Positive-only:** the label means the issue is classified as a blocker. Its absence means not classified. Absence never means a workaround exists.
- Classification requires body evidence: affected consumer flow and version, documented alternatives attempted, observed recovery cost, and triage owner and date. Distinguished from `Upgrade Blocker`, `status:blocked`, and `urgent`.

## Decision

Broaden the existing `adoption-blocker` slug rather than add a new ranking label. Onboarding-specific wording did not need preserving; a second slug would split the same class; the existing slug already ranks and displays. Recorded in `xbrief/decisions/2026-08-24-broaden-adoption-blocker-to-the-full-intended-flow-range-instead.decision.json`.

## What this does not do

- No title token and no title linter (refuted; withdrawn).
- Does not substitute `urgent`.
- Does not relabel the ten existing `BLOCKER`-titled issues — that is #3699.
- Does not add ranking code. `plan.policy.triageRankingLabels` already lists `adoption-blocker`; `triage:queue` already prints `(label: adoption-blocker)` on matched rows.

## Leftover scope land

The active xBRIEF is parked out of this product PR so `verify:scope-provenance` does not treat a same-PR brief edit as self-authorization. After merge, leftover land goes through `scope:complete` (never a hand-written completed husk).

## Live GitHub label

Update the live `adoption-blocker` description at merge (repo metadata, not gated by this PR) to: `Consumer cannot complete an intended Directive flow; no reasonable workaround`

## Test plan

- [ ] Read `content/scm/github.md` Issue Workflow: positive-only first, full range, classification test, required evidence
- [ ] Read `.github/ISSUE_LABELS.md`: distinction table vs `Upgrade Blocker`, `status:blocked`, `urgent`
- [ ] Confirm `task policy:show -- --field=plan.policy.triageRankingLabels` still lists `adoption-blocker` after the merge/release labels
- [ ] Diff contains no title-token convention and no title linter

Closes #3650
