### PR TITLE
Land leftover completed-tracked artifact for #1351

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Land leftover completed-tracked artifact for #1351 (#3264 / #1358).** The #1351 xBRIEF stayed untracked after squash of PR 3705. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
+
 - **Identity-bound worker credential injection at spawn (#1351).** A dispatcher that holds a user-bearing worker credential validates it with the existing principal check, injects it into the worker process environment, and stamps the expected GitHub login so comparison is not optional. Installation credentials still fail closed. Closes #1351.
 
 - **Land leftover completed-tracked artifact for #3650 (#3264 / #1358).** The #3650 xBRIEF stayed untracked after squash of PR 3706. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-08-24-1351-feat-orchestrator-injects-approved-worker-credentials-at-spawn.xbrief.json
+++ b/xbrief/completed/2026-08-24-1351-feat-orchestrator-injects-approved-worker-credentials-at-spawn.xbrief.json
@@ -1,0 +1,302 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Story xBRIEF for #1351 dispatcher-side credential injection; bound by arc 2 successor lean after #3665 landed a user principal.",
+    "updated": "2026-08-25T01:25:17Z"
+  },
+  "plan": {
+    "title": "feat(swarm,intake): dispatcher injects an identity-bound worker credential at spawn",
+    "status": "completed",
+    "narratives": {
+      "Description": "An orchestrator that holds a worker credential has no way to supply it to a sub-agent at spawn. Workers inherit the parent environment or halt. #3665 landed a representable user principal with live comparison, which was the gate this issue waited on, so the delivery mechanism is now buildable for user-bearing credentials. The critical constraint from arc 2: injection must bind an identity, not merely place a token, because principal comparison is opt-in and an injector that writes GH_TOKEN and stops would create the first production worker-credential path with no identity bind.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1351",
+      "Overview": "Two arcs. Arc 1 (2026-08-24 01:35-02:05) closed at the dual-stop ceiling and bound the mechanism. Arc 2 ran against a changed tree after #3665 merged as a1015030, returned UPHELD with zero blocking findings, and moved only the sequencing language plus one new acceptance clause. Bound SoT is the arc-2 successor lean. RE-DERIVE ALL CITATIONS: #3665 moved lines in github-auth-modes.ts and readiness.ts, and master has moved several times today.",
+      "Labels": "enhancement, urgent, area:skills, design-critique:triage-ready",
+      "UserStory": "As an orchestrator dispatching a sub-agent, I want to hand it an approved, identity-bound credential at spawn, so that the worker neither inherits my identity nor halts for a human export step.",
+      "ImplementationPlan": "1. Re-derive every citation at current origin/master before editing. 2. Implement dispatcher-side injection on the grok-build and local hybrid paths. The manifest half of the auth-mode contract already exists -- launch.ts:580 and :632-633 write github_auth_mode onto manifest entries -- so the work is the injection itself plus the envelope half. 3. Before spawn, validate the held credential as a USER principal with the existing validateGithubAuthForWorker (github-auth-modes.ts:666). Do not write a second validator and do not invent a second approval surface. 4. On success, inject the token AND stamp DEFT_EXPECTED_GITHUB_LOGIN or the envelope expected-principal, so the comparison is not left optional on the path this story creates. 5. On no available credential with a write-requiring operation, halt BLOCKED naming the missing credential and the dispatcher-side remedy. 6. Put the selected github_auth_mode on every applicable dispatch envelope, matching the manifest half, with regression coverage on both surfaces. The envelope half is prose in content/templates/agent-prompt-preamble.md rather than code. 7. Ensure credential values never appear in prompts, transcripts, or manifest entries. 8. CHANGELOG [Unreleased] line.",
+      "LockedDecisions": "Arc-2 successor lean is bound SoT. Buildable for USER-BEARING credentials only; App-installation identity is #3693 and is NOT a blocker on this story. Do not widen this issue to own dispatcher vouching -- arc 2 refuted that: delivery is #1351, proof is #3665 landed plus #3693 remaining, source is #3656, and the deft dispatcher is not the minter, so vouching-by-minter does not apply to a platform-file-login host. KEEP the file-login scope bound; it is a source exclusion owned by #3656, not an injection-surface gap. Token-mint plumbing is an explicit #983 non-goal (multi-agent.md:204-206). FORBIDDEN: a worker-side pragmatic override or any continue-under-host-identity -- multi-agent.md:70-75 prohibits falling back to the host gh token; maintainer PAT remains forbidden. Do not change the conjunction at preamble :451 / :127; if it is judged wrong that is a separate justified contract change. Out of scope: worker-envelope re-validation (#3663), cloud source authorization (#3656), gh auth status credential exposure (#3664), App principal definition (#3693).",
+      "AcceptanceJustification": "Six clauses. Five carry over from arc 1 unchanged; clause 6 is arc 2's addition and is the one that prevents shipping a credential path with no identity bind."
+    },
+    "items": [
+      {
+        "id": "s1",
+        "title": "Dispatcher injects at spawn",
+        "status": "completed",
+        "effort": "L",
+        "narrative": {
+          "When": "When a dispatcher holds a worker credential, it injects it at spawn without a human export step, on at least the grok-build and local hybrid paths.",
+          "Acceptance": "When a dispatcher holds a worker credential, it injects it at spawn without a human export step, on at least the grok-build and local hybrid paths.",
+          "Traces": "FR-1351-s1"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/swarm/launch.test.ts injects on grok-build and local-hybrid; vitest 18/18",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      },
+      {
+        "id": "s2",
+        "title": "BLOCKED without a credential",
+        "status": "completed",
+        "effort": "M",
+        "narrative": {
+          "When": "When a worker has no available credential and a write-requiring operation, it halts BLOCKED naming the missing credential and the dispatcher-side remedy.",
+          "Acceptance": "When a worker has no available credential and a write-requiring operation, it halts BLOCKED naming the missing credential and the dispatcher-side remedy.",
+          "Traces": "FR-1351-s2"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/swarm/launch.test.ts BLOCKED missing token + swarmLaunch injected-token with no credential; vitest 18/18",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      },
+      {
+        "id": "s3",
+        "title": "No continue-under-host-identity",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When a worker detects a host or maintainer identity, no path continues under it.",
+          "Acceptance": "When a worker detects a host or maintainer identity, no path continues under it.",
+          "Traces": "FR-1351-s3"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/swarm/launch.test.ts never continues under host identity; installation fail-closed; vitest 18/18",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      },
+      {
+        "id": "s4",
+        "title": "Auth mode on envelope and manifest",
+        "status": "completed",
+        "effort": "M",
+        "narrative": {
+          "When": "When a dispatch is made, the selected github_auth_mode is present on the dispatch envelope as well as the launch-manifest entry, with regression coverage on both.",
+          "Acceptance": "When a dispatch is made, the selected github_auth_mode is present on the dispatch envelope as well as the launch-manifest entry, with regression coverage on both.",
+          "Traces": "FR-1351-s4"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/swarm/launch.test.ts formatDispatchAuthEnvelope + buildManifest github_auth_mode; vitest 18/18",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      },
+      {
+        "id": "s5",
+        "title": "No credential values in artifacts",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When prompts, transcripts and manifest entries are inspected, no credential value appears in any of them.",
+          "Acceptance": "When prompts, transcripts and manifest entries are inspected, no credential value appears in any of them.",
+          "Traces": "FR-1351-s5"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/swarm/launch.test.ts envelope/manifest omit token values; vitest 18/18",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      },
+      {
+        "id": "s6",
+        "title": "Injection binds an identity",
+        "status": "completed",
+        "effort": "M",
+        "narrative": {
+          "When": "When the dispatcher injects a credential, it has first validated it as a user principal with the existing validateGithubAuthForWorker, and it stamps DEFT_EXPECTED_GITHUB_LOGIN or the envelope expected-principal so the comparison is not optional.",
+          "Acceptance": "When the dispatcher injects a credential, it has first validated it as a user principal with the existing validateGithubAuthForWorker, and it stamps DEFT_EXPECTED_GITHUB_LOGIN or the envelope expected-principal so the comparison is not optional.",
+          "Traces": "FR-1351-s6"
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/swarm/launch.test.ts stamps DEFT_EXPECTED_GITHUB_LOGIN / expected_github_login after validateGithubAuthForWorker; vitest 18/18",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      },
+      {
+        "id": "s7",
+        "title": "CHANGELOG entry",
+        "status": "completed",
+        "effort": "S",
+        "narrative": {
+          "When": "When CHANGELOG.md is read, an [Unreleased] line describes the user-visible change.",
+          "Acceptance": "When CHANGELOG.md is read, an [Unreleased] line describes the user-visible change.",
+          "Traces": "FR-1351-s7"
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "CHANGELOG.md Unreleased Added line for #1351; squash merge 1c0a8ceaf2f48172da357e42155ebea90bff46c4 PR 3705",
+          "recorded_at": "2026-08-25T01:25:07.771Z",
+          "recorded_by": "leaf-1351"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "urgent",
+      "area:skills",
+      "design-critique:triage-ready"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1351",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1351: orchestrator should pre-approve and inject GH credentials for sub-agents"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3665",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3665 (landed the user principal this story consumes)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3693",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3693 (App-installation identity; NOT a blocker on this story)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3663",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3663 (worker-envelope re-validation; out of scope)"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [],
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/core/src/swarm/launch.ts",
+          "packages/core/src/swarm/launch.test.ts",
+          "content/templates/agent-prompt-preamble.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/swarm/launch.test.ts"
+        ],
+        "expected_outputs": [
+          "dispatcher-side injection on grok-build and local hybrid paths",
+          "pre-spawn user-principal validation via the existing function",
+          "DEFT_EXPECTED_GITHUB_LOGIN or envelope expected-principal stamped on inject",
+          "github_auth_mode on the envelope as well as the manifest",
+          "BLOCKED with a dispatcher-side remedy when no credential is available"
+        ],
+        "depends_on": [],
+        "conflict_group": "swarm-launch",
+        "size": "L",
+        "file_scope_confidence": "medium",
+        "model_tier": "high",
+        "missing_traces_justification": [
+          "Traces are FR-1351-* ids on this story; no parent specification.xbrief requirement ids exist."
+        ],
+        "acceptance_criteria_justification": "Six clauses; five carry over from arc 1 and clause 6 is arc 2's addition preventing an unbound credential path."
+      },
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [
+          "packages/core/src/swarm/launch.ts",
+          "packages/core/src/swarm/launch.test.ts",
+          "content/templates/agent-prompt-preamble.md",
+          "CHANGELOG.md"
+        ],
+        "module_boundary": "packages/core/src/swarm",
+        "cohesion_exemption": "The worker preamble carries the envelope half of the auth-mode contract and must change with the code half; CHANGELOG.md is outside any module boundary."
+      },
+      "kind": "story",
+      "capacityBucket": "correctness",
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3705,
+        "prBase": null,
+        "mergeCommit": "1c0a8ceaf2f48172da357e42155ebea90bff46c4",
+        "deliveryBranch": "master",
+        "deliveryCommit": "1c0a8ceaf2f48172da357e42155ebea90bff46c4",
+        "verifiedAt": "2026-08-25T01:25:17Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "1233a762-68a0-4296-b3ed-93ef8f04c705"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-25T01:25:17Z",
+      "completedSessionId": "1233a762-68a0-4296-b3ed-93ef8f04c705"
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/swarm/launch.test.ts"
+      ],
+      "none_stated": false,
+      "source_rung": "stated",
+      "derived_reason": "Six clauses from the recut issue checklist after arc 2 upheld the bind and added the identity-bind clause.",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "A dispatcher holding a worker credential injects it at spawn without a human export step, on at least the grok-build and local hybrid paths",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "A worker with no available credential and a write-requiring operation halts BLOCKED, naming the missing credential and the dispatcher-side remedy",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "No worker-side path continues under a detected host or maintainer identity",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "The selected github_auth_mode is present on every applicable dispatch envelope as well as every launch-manifest entry, with regression coverage on both",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "Credential values never appear in prompts, transcripts, or manifest entries",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "Injection binds an identity: pre-spawn user-principal validation with the existing function, then inject and stamp DEFT_EXPECTED_GITHUB_LOGIN or the envelope expected-principal",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 7,
+          "text": "CHANGELOG [Unreleased] line",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "id": "issue-1351-dispatcher-credential-injection",
+    "updated": "2026-08-25T01:25:17Z"
+  },
+  "vBRIEFInfo": {
+    "version": "0.8",
+    "updated": "2026-08-25T01:25:17Z"
+  }
+}


### PR DESCRIPTION
## Summary

Tracks the #1351 xBRIEF that `scope:complete` moved after squash of PR 3705. Lifecycle land only.

## Related Issues

Tracking: #1351

Does not reopen or recut that issue. Refs #2321, #3476, #3264, #1358.

## Checklist

- [x] `/deft:change` — N/A (lifecycle leftover land)
- [x] `CHANGELOG.md` — leftover land line under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests — N/A (file-copy land)
