### PR TITLE
docs(agents): stop calling scope provenance warn-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=17bafad6327d refreshed=2026-08-20T04:24:08Z session=ade3ecef62dc -->
+<!-- deft:managed-section v3 sha=963f62a7c397 refreshed=2026-08-25T05:19:01Z session=d70619e35772 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -284,7 +284,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ## Branch policy & branch verification
 
 ! Feature branches — `deft verify:branch`, `deft verify:forward-coverage` (90% warn-first changed-branch coverage, not the 75 floor, #3514), `deft coverage:hotspots`, hooks, `deft check` (#746 / #747) — `.deft/core/scm/github.md` § Branch policy.
-! Test placement + scope provenance (#3145) — `deft verify:test-boundary`, `deft verify:scope-provenance`, `deft verify:consumer-check-contract` (docs: `docs/test-boundary.md`, `docs/scope-provenance.md`, `docs/consumer-check-contract.md`); defaults warn-only until authored policy.
+! Test placement + scope provenance (#3145) — `deft verify:test-boundary` (warn-only until authored policy), `deft verify:scope-provenance` (`--enforce` is empty-scope only; declared `file_scope` without base approval fails closed), `deft verify:consumer-check-contract` (check composition fails closed; CI omissions warn) (docs: `docs/test-boundary.md`, `docs/scope-provenance.md`, `docs/consumer-check-contract.md`).
 
 ## Branch Policy Disclosure (#746)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scope provenance is no longer described as warn-only (#3712).** Agents now read that `--enforce` governs only the empty-scope case, and that a declared file scope without base approval fails closed. Test-boundary stays warn-only until authored policy; missing check-composition still fails closed. Closes #3712.
+
 - **Build skill completes after merge, not before PR handoff (#3674).** The generated build skill told workers to run `scope:complete` before handoff, which a delivered story cannot satisfy. The pack now points at the existing post-merge lifecycle instead of restating it. Closes #3674.
 
 - **GitHub worker validation names the expected user principal (#3665).** Deep auth checks take an expected login, compare it to `/user`, and derive the target repository. An installation-token `/user` 403 is reported as inapplicable, not unreachable; installation identity stays fail-closed until #3693. Closes #3665.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -122,7 +122,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ## Branch policy & branch verification
 
 ! Feature branches — `deft verify:branch`, `deft verify:forward-coverage` (90% warn-first changed-branch coverage, not the 75 floor, #3514), `deft coverage:hotspots`, hooks, `deft check` (#746 / #747) — `.deft/core/scm/github.md` § Branch policy.
-! Test placement + scope provenance (#3145) — `deft verify:test-boundary`, `deft verify:scope-provenance`, `deft verify:consumer-check-contract` (docs: `docs/test-boundary.md`, `docs/scope-provenance.md`, `docs/consumer-check-contract.md`); defaults warn-only until authored policy.
+! Test placement + scope provenance (#3145) — `deft verify:test-boundary` (warn-only until authored policy), `deft verify:scope-provenance` (`--enforce` is empty-scope only; declared `file_scope` without base approval fails closed), `deft verify:consumer-check-contract` (check composition fails closed; CI omissions warn) (docs: `docs/test-boundary.md`, `docs/scope-provenance.md`, `docs/consumer-check-contract.md`).
 
 ## Branch Policy Disclosure (#746)
 


### PR DESCRIPTION
## Summary
- AGENTS.md no longer tells agents that scope provenance is warn-only.
- The line now states the three #3145 verbs separately: test-boundary stays warn-only until authored policy; scope-provenance --enforce is empty-scope only and a declared file_scope without base approval fails closed; consumer-check-contract fails closed on missing check composition (CI omissions warn).
- The same sentence is in the consumer agents-entry template, then refreshed into the managed section.

## Test plan
- [x] Checked each verb against its CLI default, evaluator, Taskfile description, and docs
- [x] Ran agents-entry refresh; managed section matches the template
- [x] verify:agents-md-budget green (15887/15900 bytes) without raising the ratchet
- [x] No xBRIEF or approved-scope file in the change set

Closes #3712
