### PR TITLE
Stop recommending sequential on swarm:launch (#3666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Concurrent launcher no longer tells you to set `readiness=sequential` (#3666).** Gate A now says a `parallel_safe: false` story is not eligible for `swarm:launch` and points at the interactive swarm-skill path. Gate B is unchanged. Closes #3666.
+- **Concurrent launcher no longer tells you to set `readiness=sequential` (#3666).** Gate A now says a `parallel_safe: false` story is not eligible for `swarm:launch` and points at the interactive swarm-skill path, noting that `swarm:readiness` exit 0 gates concurrent workers only. Gate B is unchanged. Closes #3666.
 - **Scope provenance is no longer described as warn-only (#3712).** Agents now read that `--enforce` governs only the empty-scope case, and that a declared file scope without base approval fails closed. Test-boundary stays warn-only until authored policy; missing check-composition still fails closed. Closes #3712.
 
 - **Build skill completes after merge, not before PR handoff (#3674).** The generated build skill told workers to run `scope:complete` before handoff, which a delivered story cannot satisfy. The pack now points at the existing post-merge lifecycle instead of restating it. Closes #3674.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Concurrent launcher no longer tells you to set `readiness=sequential` (#3666).** Gate A now says a `parallel_safe: false` story is not eligible for `swarm:launch` and points at the interactive swarm-skill path, noting that `swarm:readiness` exit 0 gates concurrent workers only. Gate B is unchanged. Closes #3666.
+- **Concurrent launcher no longer tells you to set `readiness=sequential` (#3666).** Gate A now says a `parallel_safe: false` story is not eligible for `swarm:launch` and points at the interactive swarm-skill path, which is not gated by a non-zero `swarm:readiness` exit (exit 0 gates concurrent workers only). Gate B is unchanged. Closes #3666.
 - **Scope provenance is no longer described as warn-only (#3712).** Agents now read that `--enforce` governs only the empty-scope case, and that a declared file scope without base approval fails closed. Test-boundary stays warn-only until authored policy; missing check-composition still fails closed. Closes #3712.
 
 - **Build skill completes after merge, not before PR handoff (#3674).** The generated build skill told workers to run `scope:complete` before handoff, which a delivered story cannot satisfy. The pack now points at the existing post-merge lifecycle instead of restating it. Closes #3674.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Concurrent launcher no longer tells you to set `readiness=sequential` (#3666).** Gate A now says a `parallel_safe: false` story is not eligible for `swarm:launch` and points at the interactive swarm-skill path. Gate B is unchanged. Closes #3666.
 - **Scope provenance is no longer described as warn-only (#3712).** Agents now read that `--enforce` governs only the empty-scope case, and that a declared file scope without base approval fails closed. Test-boundary stays warn-only until authored policy; missing check-composition still fails closed. Closes #3712.
 
 - **Build skill completes after merge, not before PR handoff (#3674).** The generated build skill told workers to run `scope:complete` before handoff, which a delivered story cannot satisfy. The pack now points at the existing post-merge lifecycle instead of restating it. Closes #3674.

--- a/packages/core/src/scope/decompose.ts
+++ b/packages/core/src/scope/decompose.ts
@@ -23,6 +23,7 @@ import {
 import { resolveRepo } from "../triage/queue/repo.js";
 import { referenceWithDefaultTrust, slugify } from "../vbrief-build/build.js";
 import { EMITTED_VBRIEF_VERSION } from "../vbrief-build/constants.js";
+import { READY_REQUIRES_PARALLEL_SAFE } from "../vbrief-validation/story-quality.js";
 import { formatCoverageReportLine, validateCoverageMap } from "./coverage-map.js";
 import { buildParentLineageArtifact } from "./parent-lineage.js";
 import { formatBriefJson } from "./vbrief-json.js";
@@ -473,9 +474,7 @@ export function storyQualityIssues(opts: {
     issues.push(...fileScopeIssues(swarm));
     issues.push(...verifyCommandIssues(swarm));
     if (swarm.parallel_safe === false) {
-      issues.push(
-        "readiness=ready requires parallel_safe=true; use readiness=sequential or needs_refinement for non-concurrent work",
-      );
+      issues.push(READY_REQUIRES_PARALLEL_SAFE);
     }
     if (swarm.file_scope_confidence === "low") {
       issues.push("readiness=ready requires file_scope_confidence above low");

--- a/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
+++ b/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
@@ -1,0 +1,149 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { storyQualityIssues as decomposeStoryQualityIssues } from "../scope/decompose.js";
+import { readinessReport } from "../swarm/readiness.js";
+import { READY_REQUIRES_PARALLEL_SAFE, storyQualityIssues } from "./story-quality.js";
+
+const STORY_QUALITY_BASE = {
+  title: "Auth model",
+  description:
+    "Auth model persistence stores user identity and session state. The story covers focused model changes plus matching unit tests for save and load behavior.",
+  implementationPlan:
+    "- Update the src/auth model persistence code so valid payloads are saved through the model boundary.\n" +
+    "- Add focused tests for successful persistence and a missing-record fixture in tests/auth/model.",
+  userStory:
+    "As an auth maintainer, I want persisted user records, so that login state survives requests.",
+  acceptanceTexts: [
+    "Given a valid user payload, when the auth model saves it, then the user record persists.",
+    "Given an existing user, when the auth model loads it, then the saved identity returns.",
+  ],
+  acceptanceCountJustification: "",
+  swarm: {
+    file_scope: ["src/auth/model.ts", "tests/auth/model.test.ts"],
+    verify_commands: ["npm test -- auth/model"],
+    expected_outputs: ["ok"],
+    depends_on: [],
+    conflict_group: "auth",
+    size: "M",
+    file_scope_confidence: "high",
+    model_tier: "medium",
+    parallel_safe: false,
+  },
+};
+
+const FULL_SWARM = {
+  parallel_safe: false,
+  size: "M",
+  file_scope: ["src/auth/model.ts"],
+  verify_commands: ["npm test -- auth/model"],
+  expected_outputs: ["ok"],
+  depends_on: [],
+  conflict_group: "auth",
+  file_scope_confidence: "high",
+  model_tier: "medium",
+};
+
+const READINESS_STATES = ["ready", "sequential", "needs_refinement"] as const;
+
+/** Tokens that name a readiness value as the thing to set next. */
+const LAUNCH_REMEDIATION_READINESS = /use readiness=(sequential|needs_refinement|ready)/;
+
+function writeStory(
+  project: string,
+  storyId: string,
+  readiness: (typeof READINESS_STATES)[number],
+): string {
+  const full = join(project, "xbrief", "active", `${storyId}.xbrief.json`);
+  mkdirSync(join(project, "xbrief", "active"), { recursive: true });
+  writeFileSync(
+    full,
+    JSON.stringify({
+      plan: {
+        id: storyId,
+        title: storyId,
+        status: "running",
+        narratives: {
+          Description:
+            "Auth model persistence stores user identity and session state. The story covers focused model changes plus matching unit tests for save and load behavior.",
+          ImplementationPlan:
+            "- Update the src/auth model persistence code so valid payloads are saved through the model boundary.\n" +
+            "- Add focused tests for successful persistence and a missing-record fixture in tests/auth/model.",
+          UserStory:
+            "As an auth maintainer, I want persisted user records, so that login state survives requests.",
+          Traces: "FR-1",
+        },
+        items: [
+          {
+            id: "a1",
+            title: "A1",
+            status: "pending",
+            narrative: {
+              Acceptance:
+                "Given a valid user payload, when the auth model saves it, then the user record persists.",
+              Traces: "FR-1",
+            },
+          },
+          {
+            id: "a2",
+            title: "A2",
+            status: "pending",
+            narrative: {
+              Acceptance:
+                "Given an existing user, when the auth model loads it, then the saved identity returns.",
+              Traces: "FR-1",
+            },
+          },
+        ],
+        metadata: { kind: "story", swarm: { ...FULL_SWARM, readiness } },
+      },
+    }),
+    "utf8",
+  );
+  return full;
+}
+
+describe("READY_REQUIRES_PARALLEL_SAFE shared message (#3666 / #3252)", () => {
+  it("does not recommend a readiness value that the launch path then rejects", () => {
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/parallel_safe=true/);
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/not eligible for concurrent swarm:launch/);
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/interactive swarm-skill solo-worker path/);
+    expect(READY_REQUIRES_PARALLEL_SAFE).not.toMatch(LAUNCH_REMEDIATION_READINESS);
+  });
+
+  it("is the exact string both live validators emit", () => {
+    expect(storyQualityIssues(STORY_QUALITY_BASE)).toContain(READY_REQUIRES_PARALLEL_SAFE);
+    expect(decomposeStoryQualityIssues(STORY_QUALITY_BASE)).toContain(READY_REQUIRES_PARALLEL_SAFE);
+  });
+});
+
+describe("launch-path parallel_safe=false readiness matrix (#3666)", () => {
+  it("prints guidance that is not self-contradictory across readiness values", () => {
+    const project = mkdtempSync(join(tmpdir(), "sw-3666-"));
+    const reports = Object.fromEntries(
+      READINESS_STATES.map((readiness) => {
+        const path = writeStory(project, `issue-3666-${readiness}`, readiness);
+        const { exitCode, report } = readinessReport(project, [path]);
+        return [readiness, { exitCode, report }];
+      }),
+    ) as Record<(typeof READINESS_STATES)[number], { exitCode: number; report: string }>;
+
+    for (const readiness of READINESS_STATES) {
+      expect(reports[readiness].exitCode, readiness).toBe(1);
+      expect(reports[readiness].report, readiness).not.toMatch(LAUNCH_REMEDIATION_READINESS);
+    }
+
+    expect(reports.ready.report).toContain(READY_REQUIRES_PARALLEL_SAFE);
+    expect(reports.sequential.report).toContain(
+      "plan.metadata.swarm.readiness=ready for concurrent allocation",
+    );
+    expect(reports.needs_refinement.report).toContain(
+      "plan.metadata.swarm.readiness=ready for concurrent allocation",
+    );
+    expect(reports.sequential.report).not.toContain(READY_REQUIRES_PARALLEL_SAFE);
+    expect(reports.needs_refinement.report).not.toContain(READY_REQUIRES_PARALLEL_SAFE);
+
+    rmSync(project, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
+++ b/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
@@ -109,9 +109,8 @@ describe("READY_REQUIRES_PARALLEL_SAFE shared message (#3666 / #3252)", () => {
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/parallel_safe=true/);
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/not eligible for concurrent swarm:launch/);
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/interactive swarm-skill solo-worker path/);
-    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(
-      /swarm:readiness exit 0 gates concurrent workers only/,
-    );
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/not gated by swarm:readiness exiting 0/);
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/exit 0 gates concurrent workers only/);
     expect(READY_REQUIRES_PARALLEL_SAFE).not.toMatch(LAUNCH_REMEDIATION_READINESS);
   });
 

--- a/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
+++ b/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
@@ -109,6 +109,7 @@ describe("READY_REQUIRES_PARALLEL_SAFE shared message (#3666 / #3252)", () => {
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/parallel_safe=true/);
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/not eligible for concurrent swarm:launch/);
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/interactive swarm-skill solo-worker path/);
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/swarm:readiness exit 0 gates concurrent workers only/);
     expect(READY_REQUIRES_PARALLEL_SAFE).not.toMatch(LAUNCH_REMEDIATION_READINESS);
   });
 

--- a/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
+++ b/packages/core/src/vbrief-validation/ready-requires-parallel-safe.test.ts
@@ -109,7 +109,9 @@ describe("READY_REQUIRES_PARALLEL_SAFE shared message (#3666 / #3252)", () => {
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/parallel_safe=true/);
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/not eligible for concurrent swarm:launch/);
     expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/interactive swarm-skill solo-worker path/);
-    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(/swarm:readiness exit 0 gates concurrent workers only/);
+    expect(READY_REQUIRES_PARALLEL_SAFE).toMatch(
+      /swarm:readiness exit 0 gates concurrent workers only/,
+    );
     expect(READY_REQUIRES_PARALLEL_SAFE).not.toMatch(LAUNCH_REMEDIATION_READINESS);
   });
 

--- a/packages/core/src/vbrief-validation/story-quality.ts
+++ b/packages/core/src/vbrief-validation/story-quality.ts
@@ -301,6 +301,15 @@ export interface StoryQualityParams {
   readonly concurrentReady?: boolean;
 }
 
+/**
+ * Shared Gate A text for `readiness=ready` + `parallel_safe: false` (#3666 / #3252).
+ * Authoring (`scope:decompose`) and launch (`swarm:readiness` / `swarm:launch`)
+ * both emit this string. It must not recommend `readiness=sequential` as a
+ * launch remediation — Gate B rejects that value on the same call.
+ */
+export const READY_REQUIRES_PARALLEL_SAFE =
+  "readiness=ready requires parallel_safe=true. This story is not eligible for concurrent swarm:launch; dispatch non-concurrent work via the interactive swarm-skill solo-worker path (see #3669)";
+
 export function storyQualityIssues(params: StoryQualityParams): string[] {
   const issues: string[] = [];
   const concurrentReady = params.concurrentReady ?? true;
@@ -343,9 +352,7 @@ export function storyQualityIssues(params: StoryQualityParams): string[] {
     issues.push(...fileScopeIssues(params.swarm));
     issues.push(...verifyCommandIssues(params.swarm));
     if (params.swarm.parallel_safe === false) {
-      issues.push(
-        "readiness=ready requires parallel_safe=true; use readiness=sequential or needs_refinement for non-concurrent work",
-      );
+      issues.push(READY_REQUIRES_PARALLEL_SAFE);
     }
     if (params.swarm.file_scope_confidence === "low") {
       issues.push("readiness=ready requires file_scope_confidence above low");

--- a/packages/core/src/vbrief-validation/story-quality.ts
+++ b/packages/core/src/vbrief-validation/story-quality.ts
@@ -308,7 +308,7 @@ export interface StoryQualityParams {
  * launch remediation — Gate B rejects that value on the same call.
  */
 export const READY_REQUIRES_PARALLEL_SAFE =
-  "readiness=ready requires parallel_safe=true. This story is not eligible for concurrent swarm:launch; dispatch non-concurrent work via the interactive swarm-skill solo-worker path (swarm:readiness exit 0 gates concurrent workers only; see #3669)";
+  "readiness=ready requires parallel_safe=true. This story is not eligible for concurrent swarm:launch; dispatch non-concurrent work via the interactive swarm-skill solo-worker path (that path is not gated by swarm:readiness exiting 0; exit 0 gates concurrent workers only; see #3669)";
 
 export function storyQualityIssues(params: StoryQualityParams): string[] {
   const issues: string[] = [];

--- a/packages/core/src/vbrief-validation/story-quality.ts
+++ b/packages/core/src/vbrief-validation/story-quality.ts
@@ -308,7 +308,7 @@ export interface StoryQualityParams {
  * launch remediation — Gate B rejects that value on the same call.
  */
 export const READY_REQUIRES_PARALLEL_SAFE =
-  "readiness=ready requires parallel_safe=true. This story is not eligible for concurrent swarm:launch; dispatch non-concurrent work via the interactive swarm-skill solo-worker path (see #3669)";
+  "readiness=ready requires parallel_safe=true. This story is not eligible for concurrent swarm:launch; dispatch non-concurrent work via the interactive swarm-skill solo-worker path (swarm:readiness exit 0 gates concurrent workers only; see #3669)";
 
 export function storyQualityIssues(params: StoryQualityParams): string[] {
   const issues: string[] = [];


### PR DESCRIPTION
## Summary

- `task swarm:launch` / `swarm:readiness` no longer tells you to set `readiness=sequential` when that same call will then reject `sequential`.
- Gate A now says a `parallel_safe: false` story is not eligible for the concurrent launcher, and points at the interactive swarm-skill solo-worker path (see #3669). Both live copies share one message plus a parity test.
- Gate B is unchanged. This does not add an N=1 sequential launch mode.

Tracking: #3666
Refs #3669, #3032, #1387, #3156

## Why this is a text fix, not a gate change

The panel recut this issue after refuting the deadlock framing. Gate B (`readiness=ready` for concurrent allocation) is specified behavior. The defect is Gate A naming `sequential` as if that would make `swarm:launch` succeed.

#3718's adjacent intake / concurrent-allocation-block question stays on that issue. This PR does not expand into it.

## Related Issues

Tracking: #3666
Refs #3669, #3032, #1387, #3156

## Checklist

- [x] `/deft:change` — N/A: four files on one recut defect (shared message + parity test + CHANGELOG); not a new subsystem
- [x] `CHANGELOG.md` — `[Unreleased]` Fixed entry for #3666
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally (targeted story-quality / decompose / new parity suite)

## Test plan

- [x] Shared-message parity: both `story-quality` and `scope/decompose` emit `READY_REQUIRES_PARALLEL_SAFE`
- [x] Launch-path matrix: `parallel_safe: false` × `ready` / `sequential` / `needs_refinement` — no `use readiness=` remediation; guidance is not self-contradictory
- [x] Existing decompose / readiness / story-quality branch tests still pass
- [ ] CI green on this HEAD
