### PR TITLE
fix(scope): stop treating prose verb mentions as stated acceptance commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A verb mentioned in issue prose is no longer a stated acceptance command (#3721).** Inline backticks in a sentence stay advisory mentions. Labeled lines, `$` prompts, and fences still require promotion. An operator can list a capture under `literal_acceptance_not_commands` instead of promoting it. `scope:complete --help` now lists `--merge-commit` and `--pr`. Closes #3721.
 - **Completed-write guard refuses oversized completed/ artifacts (#3679).** Newly added completed briefs larger than 1 MiB fail with the file path and the limit instead of an unbounded read. The lifecycle-stamp check is unchanged.
 - **Concurrent launcher no longer tells you to set `readiness=sequential` (#3666).** Gate A now says a `parallel_safe: false` story is not eligible for `swarm:launch` and points at the interactive swarm-skill path, which is not gated by a non-zero `swarm:readiness` exit (exit 0 gates concurrent workers only). Gate B is unchanged. Closes #3666.
 - **Scope provenance is no longer described as warn-only (#3712).** Agents now read that `--enforce` governs only the empty-scope case, and that a declared file scope without base approval fails closed. Test-boundary stays warn-only until authored policy; missing check-composition still fails closed. Closes #3712.

--- a/packages/core/src/literal-acceptance/capture-branches.test.ts
+++ b/packages/core/src/literal-acceptance/capture-branches.test.ts
@@ -87,10 +87,16 @@ describe("captureLiteralAcceptanceCommands branch matrix (#3287)", () => {
     expect(cmds).not.toContain("pnpm --version");
   });
 
-  it("extracts inline backtick spans next to verify/run language", () => {
+  it("records inline backtick spans as advisory mentions, not stated commands (#3721)", () => {
     const text = "Please run `task check` before done and verify `pnpm test`.";
-    const cmds = captureLiteralAcceptanceCommands(text).map((c) => c.command);
-    expect(cmds).toEqual(expect.arrayContaining(["task check", "pnpm test"]));
+    const detailed = captureLiteralAcceptanceCommandsDetailed(text);
+    expect(detailed.commands.map((c) => c.command)).not.toEqual(
+      expect.arrayContaining(["task check", "pnpm test"]),
+    );
+    expect(detailed.rejected.map((r) => r.command)).toEqual(
+      expect.arrayContaining(["task check", "pnpm test"]),
+    );
+    expect(detailed.rejected.every((r) => (r.sourceSpan ?? "").startsWith("inline@"))).toBe(true);
   });
 
   it("dedupes identical command+cwd+exit and records rejected ledger lines", () => {

--- a/packages/core/src/literal-acceptance/capture.ts
+++ b/packages/core/src/literal-acceptance/capture.ts
@@ -118,7 +118,26 @@ function pushCommand(buckets: CaptureBuckets, cmd: LiteralAcceptanceCommand): vo
     return;
   }
   const key = commandDedupeKey(cmd);
-  if (buckets.seen.has(key)) return;
+  if (buckets.seen.has(key)) {
+    const idx = buckets.out.findIndex((row) => commandDedupeKey(row) === key);
+    const existing = idx >= 0 ? buckets.out[idx] : undefined;
+    if (
+      existing !== undefined &&
+      idx >= 0 &&
+      isInlineProseMention(existing) &&
+      isExecutableSource(cmd.source)
+    ) {
+      buckets.out[idx] = {
+        command: cmd.command,
+        cwd: cmd.cwd ?? null,
+        expectedStdout: cmd.expectedStdout ?? null,
+        expectedExitCode: cmd.expectedExitCode ?? 0,
+        source: cmd.source,
+        sourceSpan: cmd.sourceSpan ?? null,
+      };
+    }
+    return;
+  }
   buckets.seen.add(key);
   buckets.out.push({
     command: cmd.command,
@@ -609,7 +628,7 @@ export function readStoredLiteralAcceptanceDetailed(
       // literal_acceptance_commands rows already loaded — do not invent a
       // null-cwd duplicate for the same command text.
       const alreadyHasCommand = (command: string): boolean =>
-        buckets.out.some((c) => c.command === command);
+        buckets.out.some((c) => c.command === command && !isInlineProseMention(c));
       for (const cmd of coerceCommandList(
         swarm.verify_commands,
         "verify_commands",

--- a/packages/core/src/literal-acceptance/capture.ts
+++ b/packages/core/src/literal-acceptance/capture.ts
@@ -15,7 +15,11 @@ import type {
   LiteralAcceptanceSource,
   RejectedLiteralCommand,
 } from "./types.js";
-import { EXECUTABLE_LITERAL_SOURCES, LITERAL_ACCEPTANCE_REJECTED_METADATA_KEY } from "./types.js";
+import {
+  EXECUTABLE_LITERAL_SOURCES,
+  LITERAL_ACCEPTANCE_NOT_COMMANDS_METADATA_KEY,
+  LITERAL_ACCEPTANCE_REJECTED_METADATA_KEY,
+} from "./types.js";
 
 /** Labeled keywords (single-token, linear match). */
 const LABELED_KEYWORDS = new Set(["verify", "command", "run", "check", "exec", "shell"]);
@@ -420,8 +424,9 @@ function matchMarkdownHeading(line: string): { level: number; text: string } | n
  * marker). Mid-line label capture is deliberately not attempted (#3484): a
  * `verify:<verb>` token inside ordinary prose has no terminator, so the capture
  * swallowed the rest of the paragraph and the phantom then blocked completion on
- * the safety ledger. Commands stated mid-sentence must live in a fence, a `$`
- * prompt, or an inline backtick span — all of which have real delimiters.
+ * the safety ledger. Commands stated mid-sentence must live in a fence or a `$`
+ * prompt. An inline backtick inside a prose sentence is a reference, not a
+ * stated command (#3721).
  */
 function extractFromLabeledLines(text: string, buckets: CaptureBuckets): void {
   const lines = text.split(/\r?\n/);
@@ -450,9 +455,15 @@ function extractFromLabeledLines(text: string, buckets: CaptureBuckets): void {
   }
 }
 
+/** Reason stamped when an inline backtick is recorded as a mention, not AC (#3721). */
+export const INLINE_PROSE_MENTION_REASON =
+  "inline backtick in prose is a mention, not a stated acceptance command (#3721)";
+
 /**
  * Extract inline `` `command` `` spans that follow verify/run language on the same line.
- * Example: `run \`task check\` before done`
+ * These are references, not stated acceptance commands (#3721). Recorded on the
+ * rejected ledger with an `inline@` span so #3511 demotes them to advisory.
+ * They must not enter the stated-command list (that would require promotion).
  */
 function extractInlineVerifySpans(text: string, buckets: CaptureBuckets): void {
   const lines = text.split(/\r?\n/);
@@ -472,9 +483,24 @@ function extractInlineVerifySpans(text: string, buckets: CaptureBuckets): void {
       if (inner.includes("\n")) continue;
       const normalized = normalizeCommand(inner);
       if (normalized === null || !looksLikeShellCommand(normalized)) continue;
-      pushUnique(buckets, normalized, "task_statement", `inline@L${i + 1}`);
+      recordRejected(buckets, normalized, INLINE_PROSE_MENTION_REASON, `inline@L${i + 1}`);
     }
   }
+}
+
+/**
+ * True when a capture-only row came from an inline backtick in prose (#3721).
+ * Those mentions are not stated acceptance commands. Labeled, prompt, and fence
+ * spans stay stated.
+ */
+export function isInlineProseMention(cmd: {
+  readonly source?: string;
+  readonly sourceSpan?: string | null;
+}): boolean {
+  if (cmd.source !== "task_statement") return false;
+  const span = cmd.sourceSpan;
+  if (span === null || span === undefined) return false;
+  return span.startsWith("inline@");
 }
 
 function emptyBuckets(): CaptureBuckets {
@@ -886,6 +912,39 @@ export function hasStructuredAcceptanceCommands(
   const swarm = asRecord(metadata.swarm);
   if (swarm === null) return false;
   return hasNonEmptyCommandList(swarm.verify_commands);
+}
+
+/**
+ * Command strings the operator recorded as not acceptance commands (#3721).
+ * Listing a string here dispositions a capture without asserting it is AC.
+ */
+export function readNotAcceptanceCommands(
+  plan: Record<string, unknown> | null | undefined,
+): ReadonlySet<string> {
+  const rec = asRecord(plan);
+  if (rec === null) return new Set();
+  const metadata = asRecord(rec.metadata);
+  if (metadata === null) return new Set();
+  const raw =
+    metadata[LITERAL_ACCEPTANCE_NOT_COMMANDS_METADATA_KEY] ??
+    metadata.literalAcceptanceNotCommands ??
+    null;
+  const out = new Set<string>();
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    out.add(raw.trim());
+    return out;
+  }
+  if (!Array.isArray(raw)) return out;
+  for (const entry of raw) {
+    if (typeof entry === "string" && entry.trim().length > 0) {
+      out.add(entry.trim());
+      continue;
+    }
+    const row = asRecord(entry);
+    if (row === null) continue;
+    if (isNonEmptyString(row.command)) out.add(row.command.trim());
+  }
+  return out;
 }
 
 /** Format rejected ledger for CLI / complete-gate messages. */

--- a/packages/core/src/literal-acceptance/evaluate.ts
+++ b/packages/core/src/literal-acceptance/evaluate.ts
@@ -7,7 +7,10 @@ import { resolve } from "node:path";
 import {
   captureLiteralAcceptanceCommandsDetailed,
   formatRejectedLedger,
+  INLINE_PROSE_MENTION_REASON,
+  isInlineProseMention,
   isProseDerivedRejection,
+  readNotAcceptanceCommands,
   readStoredLiteralAcceptanceDetailed,
 } from "./capture.js";
 import { runLiteralAcceptanceCommands } from "./run.js";
@@ -86,11 +89,33 @@ export function resolveLiteralAcceptanceDetailed(
   options: { readonly captureFromNarratives?: boolean } = {},
 ): ResolvedLiteralAcceptance {
   const raw = resolveRawLiteralAcceptance(plan, options);
+  const notCommands = readNotAcceptanceCommands(plan);
+  const stated: LiteralAcceptanceCommand[] = [];
+  const mentionAdvisory: RejectedLiteralCommand[] = [];
+  for (const c of raw.commands) {
+    if (isInlineProseMention(c)) {
+      mentionAdvisory.push({
+        command: c.command,
+        reason: INLINE_PROSE_MENTION_REASON,
+        sourceSpan: c.sourceSpan ?? null,
+      });
+      continue;
+    }
+    if (notCommands.has(c.command)) {
+      mentionAdvisory.push({
+        command: c.command,
+        reason: "operator recorded this capture as not an acceptance command (#3721)",
+        sourceSpan: c.sourceSpan ?? null,
+      });
+      continue;
+    }
+    stated.push(c);
+  }
   const split = partitionRejected(raw.rejected);
   return {
-    commands: raw.commands,
+    commands: stated,
     rejected: split.blocking,
-    advisoryRejected: split.advisory,
+    advisoryRejected: [...split.advisory, ...mentionAdvisory],
     transcriptPromptSkipped: raw.transcriptPromptSkipped,
   };
 }

--- a/packages/core/src/literal-acceptance/evaluate.ts
+++ b/packages/core/src/literal-acceptance/evaluate.ts
@@ -101,7 +101,7 @@ export function resolveLiteralAcceptanceDetailed(
       });
       continue;
     }
-    if (notCommands.has(c.command)) {
+    if (c.source === "task_statement" && notCommands.has(c.command)) {
       mentionAdvisory.push({
         command: c.command,
         reason: "operator recorded this capture as not an acceptance command (#3721)",

--- a/packages/core/src/literal-acceptance/fence-transcript-capture.test.ts
+++ b/packages/core/src/literal-acceptance/fence-transcript-capture.test.ts
@@ -181,8 +181,10 @@ describe("output-shaped fences are not captured (#3511)", () => {
       "verify: task check",
       "Please run `pnpm test` before done.",
     ].join("\n");
-    const cmds = captureLiteralAcceptanceCommandsDetailed(text).commands.map((c) => c.command);
-    expect(cmds).toEqual(expect.arrayContaining(["task check", "pnpm test"]));
+    const detailed = captureLiteralAcceptanceCommandsDetailed(text);
+    expect(detailed.commands.map((c) => c.command)).toContain("task check");
+    // Inline backtick in the following prose sentence is a mention, not stated (#3721).
+    expect(detailed.commands.map((c) => c.command)).not.toContain("pnpm test");
   });
 
   it("still captures a genuine command next to a comment in an acceptance fence", () => {

--- a/packages/core/src/literal-acceptance/index.ts
+++ b/packages/core/src/literal-acceptance/index.ts
@@ -13,7 +13,10 @@ export {
   captureLiteralAcceptanceCommandsDetailed,
   formatRejectedLedger,
   hasStructuredAcceptanceCommands,
+  INLINE_PROSE_MENTION_REASON,
+  isInlineProseMention,
   isProseDerivedRejection,
+  readNotAcceptanceCommands,
   readStoredLiteralAcceptanceCommands,
   readStoredLiteralAcceptanceDetailed,
 } from "./capture.js";
@@ -55,6 +58,7 @@ export {
   EXECUTABLE_LITERAL_SOURCES,
   LITERAL_ACCEPTANCE_METADATA_KEY,
   LITERAL_ACCEPTANCE_METADATA_KEY_CAMEL,
+  LITERAL_ACCEPTANCE_NOT_COMMANDS_METADATA_KEY,
   LITERAL_ACCEPTANCE_REJECTED_METADATA_KEY,
   type LiteralAcceptanceCommand,
   type LiteralAcceptanceGateResult,

--- a/packages/core/src/literal-acceptance/inline-prose-mention.test.ts
+++ b/packages/core/src/literal-acceptance/inline-prose-mention.test.ts
@@ -194,6 +194,65 @@ describe("inline backtick in prose is not a stated command (#3721)", () => {
     expect(result.runs).toEqual([]);
   });
 
+  it("does not let a not-command disposition drop a promoted verify_commands peer", () => {
+    const plan = {
+      title: "t",
+      narratives: { Overview: "The critic mentioned `task check` while describing verify." },
+      metadata: {
+        literal_acceptance_commands: [
+          { command: "task check", source: "task_statement", sourceSpan: "inline@L1" },
+          { command: "task check", source: "verify_commands", sourceSpan: "swarm.verify_commands" },
+        ],
+        swarm: { verify_commands: ["task check"] },
+        literal_acceptance_not_commands: ["task check"],
+      },
+      items: [],
+    };
+    const result = evaluateLiteralAcceptanceFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: false,
+      runner: () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.commands.some((c) => c.source === "verify_commands")).toBe(true);
+    expect(result.runs).toHaveLength(1);
+  });
+
+  it("still runs a structured plan.acceptance.commands peer that shares mention text", () => {
+    const plan = {
+      title: "t",
+      narratives: { Overview: "A critic mentioned `task doctor` while describing verify." },
+      metadata: {
+        literal_acceptance_commands: [
+          { command: "task doctor", source: "task_statement", sourceSpan: "inline@L1" },
+          {
+            command: "task doctor",
+            source: "verify_commands",
+            sourceSpan: "swarm.verify_commands",
+          },
+        ],
+        swarm: { verify_commands: ["task doctor"] },
+      },
+      acceptance: {
+        commands: [{ command: "task doctor" }],
+        none_stated: false,
+        source_rung: "stated",
+      },
+      items: [],
+    };
+    let executions = 0;
+    const result = evaluateVerifyAcFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: false,
+      runner: () => {
+        executions += 1;
+        return { exitCode: 0, stdout: "ok", stderr: "" };
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(executions).toBeGreaterThan(0);
+  });
+
   it("lets the complete verify:ac walk pass the #3712 shape without promotion", () => {
     const walk = evaluateScopeCompleteAcceptanceWalk(
       plan3712Shape({

--- a/packages/core/src/literal-acceptance/inline-prose-mention.test.ts
+++ b/packages/core/src/literal-acceptance/inline-prose-mention.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { evaluateVerifyAcFromPlan } from "../product-first-done-gate/evaluate.js";
+import { evaluateScopeCompleteAcceptanceWalk } from "../scope/acceptance-evidence.js";
 import { renderVerbHelp } from "../triage/help/index.js";
 import {
   captureLiteralAcceptanceCommandsDetailed,
@@ -171,6 +173,44 @@ describe("inline backtick in prose is not a stated command (#3721)", () => {
     expect(result.advisoryRejected?.map((r) => r.command)).toContain("task check");
     const swarm = (plan.metadata as { swarm?: { verify_commands?: string[] } }).swarm;
     expect(swarm?.verify_commands ?? []).not.toContain("task check");
+  });
+
+  it("does not execute ingest-stamped plan.acceptance.commands that are inline mentions", () => {
+    const plan = plan3712Shape({
+      acceptance: {
+        commands: [{ command: "deft verify:*" }],
+        none_stated: false,
+        source_rung: "stated",
+      },
+    });
+    const result = evaluateVerifyAcFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: true,
+      runner: () => {
+        throw new Error("must not run deft verify:* from the #3449 fallback");
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.runs).toEqual([]);
+  });
+
+  it("lets the complete verify:ac walk pass the #3712 shape without promotion", () => {
+    const walk = evaluateScopeCompleteAcceptanceWalk(
+      plan3712Shape({
+        acceptance: {
+          commands: [{ command: "deft verify:*" }],
+          none_stated: false,
+          source_rung: "stated",
+        },
+      }),
+      {
+        projectRoot: process.cwd(),
+        runner: () => {
+          throw new Error("must not spawn on the complete walk");
+        },
+      },
+    );
+    expect(walk.ok).toBe(true);
   });
 
   it("still blocks an unsafe command stated in a structured field", () => {

--- a/packages/core/src/literal-acceptance/inline-prose-mention.test.ts
+++ b/packages/core/src/literal-acceptance/inline-prose-mention.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import { renderVerbHelp } from "../triage/help/index.js";
+import {
+  captureLiteralAcceptanceCommandsDetailed,
+  INLINE_PROSE_MENTION_REASON,
+  isInlineProseMention,
+  readNotAcceptanceCommands,
+} from "./capture.js";
+import { evaluateLiteralAcceptanceFromPlan, resolveLiteralAcceptanceDetailed } from "./evaluate.js";
+import { runLiteralAcceptanceCommands } from "./run.js";
+
+/**
+ * #3721: inline-backticked verb mentions in issue/comment prose must not become
+ * stated acceptance commands that block scope:complete.
+ *
+ * Shape matches the live #3712 failure (do not mutate that brief): Overview
+ * concatenates body + comment thread; ingest stored one inline@ task_statement;
+ * complete re-scans Overview and used to add more unpromoted peers.
+ */
+
+const OVERVIEW_3712_SHAPE = [
+  "Correct one sentence in AGENTS.md about scope provenance.",
+  "",
+  "The CI workflow cites `run: task check:merge` in a path.",
+  "That clause covers `deft verify:*` and related verbs.",
+  "",
+  "## Issue comment thread",
+  "",
+  "### Comment by critic",
+  "",
+  "I did not run `task verify:scope-provenance`. Method was in-process evaluate.",
+].join("\n");
+
+function plan3712Shape(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: "docs(agents): scope provenance is not warn-on-empty only",
+    narratives: {
+      Overview: OVERVIEW_3712_SHAPE,
+    },
+    metadata: {
+      literal_acceptance_commands: [
+        {
+          command: "deft verify:*",
+          source: "task_statement",
+          sourceSpan: "inline@L47",
+        },
+      ],
+      swarm: {},
+    },
+    items: [],
+    ...overrides,
+  };
+}
+
+describe("inline backtick in prose is not a stated command (#3721)", () => {
+  it("does not capture backticked verbs from #3712-shaped Overview as stated commands", () => {
+    const detailed = captureLiteralAcceptanceCommandsDetailed(OVERVIEW_3712_SHAPE);
+    const stated = detailed.commands.map((c) => c.command);
+    expect(stated).not.toContain("task check");
+    expect(stated).not.toContain("deft verify:*");
+    expect(stated).not.toContain("task verify:scope-provenance");
+    expect(detailed.rejected.map((r) => r.command)).toEqual(
+      expect.arrayContaining(["deft verify:*", "task verify:scope-provenance"]),
+    );
+    expect(detailed.rejected.every((r) => r.reason === INLINE_PROSE_MENTION_REASON)).toBe(true);
+  });
+
+  it("completes a brief whose Overview contains backticked verb prose without promotion", () => {
+    const plan = plan3712Shape();
+    const resolved = resolveLiteralAcceptanceDetailed(plan, { captureFromNarratives: true });
+    expect(resolved.commands.filter((c) => c.source === "task_statement")).toEqual([]);
+    expect(resolved.rejected).toEqual([]);
+
+    const result = evaluateLiteralAcceptanceFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: true,
+      runner: () => {
+        throw new Error("must not spawn; no stated executable AC");
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).not.toMatch(/gate FAILED/i);
+    expect(result.message).not.toMatch(/capture-only/);
+  });
+
+  it("demotes a stored inline@ task_statement row so ingest leftovers do not block", () => {
+    expect(
+      isInlineProseMention({
+        source: "task_statement",
+        sourceSpan: "inline@L47",
+      }),
+    ).toBe(true);
+    expect(
+      isInlineProseMention({
+        source: "task_statement",
+        sourceSpan: "labeled@L1",
+      }),
+    ).toBe(false);
+
+    const result = runLiteralAcceptanceCommands(
+      [{ command: "deft verify:*", source: "task_statement", sourceSpan: "inline@L47" }],
+      {
+        projectRoot: process.cwd(),
+        runner: () => {
+          throw new Error("must not execute an inline prose mention");
+        },
+      },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("still requires promotion for a labeled verify: line (protection preserved)", () => {
+    const plan = {
+      title: "t",
+      narratives: { Overview: "verify: task check" },
+      items: [],
+    };
+    const result = evaluateLiteralAcceptanceFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: true,
+      runner: () => {
+        throw new Error("must fail closed on unpromoted labeled statement");
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.commands.map((c) => c.command)).toContain("task check");
+    expect(result.message).toMatch(/capture-only|Promote|verify_commands/);
+    expect(result.message).toMatch(/literal_acceptance_not_commands/);
+  });
+
+  it("still requires promotion for a fenced acceptance command (fences stay stated)", () => {
+    const plan = {
+      title: "t",
+      narratives: {
+        Overview: ["## Acceptance", "```bash", "task doctor", "```"].join("\n"),
+      },
+      items: [],
+    };
+    const result = evaluateLiteralAcceptanceFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: true,
+      runner: () => {
+        throw new Error("must fail closed on unpromoted fence statement");
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.commands.map((c) => c.command)).toContain("task doctor");
+  });
+
+  it("lets the operator disposition a labeled capture without promoting it", () => {
+    const plan = {
+      title: "t",
+      narratives: { Overview: "verify: task check" },
+      metadata: {
+        literal_acceptance_not_commands: [
+          { command: "task check", reason: "mentioned in critic footnote, not story AC" },
+        ],
+      },
+      items: [],
+    };
+    expect(readNotAcceptanceCommands(plan).has("task check")).toBe(true);
+    const result = evaluateLiteralAcceptanceFromPlan(plan, {
+      projectRoot: process.cwd(),
+      captureFromNarratives: true,
+      runner: () => {
+        throw new Error("must not run a dispositioned capture");
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.commands.map((c) => c.command)).not.toContain("task check");
+    expect(result.advisoryRejected?.map((r) => r.command)).toContain("task check");
+    const swarm = (plan.metadata as { swarm?: { verify_commands?: string[] } }).swarm;
+    expect(swarm?.verify_commands ?? []).not.toContain("task check");
+  });
+
+  it("still blocks an unsafe command stated in a structured field", () => {
+    const plan = {
+      title: "t",
+      metadata: {
+        swarm: { verify_commands: ["task check; rm -rf /tmp/x"] },
+      },
+      items: [],
+    };
+    const resolved = resolveLiteralAcceptanceDetailed(plan, { captureFromNarratives: false });
+    expect(resolved.rejected.map((r) => r.sourceSpan)).toEqual(["swarm.verify_commands"]);
+    expect(resolved.advisoryRejected).toEqual([]);
+  });
+});
+
+describe("readNotAcceptanceCommands (#3721)", () => {
+  it("reads string, camelCase, and mixed array forms; ignores junk", () => {
+    expect(readNotAcceptanceCommands(null).size).toBe(0);
+    expect(readNotAcceptanceCommands({}).size).toBe(0);
+    expect(
+      readNotAcceptanceCommands({
+        metadata: { literal_acceptance_not_commands: "task check" },
+      }).has("task check"),
+    ).toBe(true);
+    const mixed = readNotAcceptanceCommands({
+      metadata: {
+        literalAcceptanceNotCommands: ["  pnpm test  ", "", 3, { command: "task doctor" }],
+      },
+    });
+    expect(mixed.has("pnpm test")).toBe(true);
+    expect(mixed.has("task doctor")).toBe(true);
+    expect(mixed.size).toBe(2);
+  });
+
+  it("treats a missing sourceSpan as stated, not an inline mention", () => {
+    expect(isInlineProseMention({ source: "task_statement", sourceSpan: null })).toBe(false);
+    expect(isInlineProseMention({ source: "explicit", sourceSpan: "inline@L1" })).toBe(false);
+  });
+});
+
+describe("scope:complete --help lists delivery flags (#3721)", () => {
+  it("registry help names --merge-commit and --pr", () => {
+    const text = renderVerbHelp("task scope:complete");
+    expect(text).toMatch(/--merge-commit/);
+    expect(text).toMatch(/--pr N/);
+  });
+});

--- a/packages/core/src/literal-acceptance/literal-acceptance.test.ts
+++ b/packages/core/src/literal-acceptance/literal-acceptance.test.ts
@@ -60,11 +60,11 @@ describe("captureLiteralAcceptanceCommands", () => {
     expect(cmds.map((c) => c.command)).toEqual(["task verify:branch", "pnpm test"]);
   });
 
-  it("captures inline verify spans", () => {
+  it("does not treat inline backtick spans in prose as stated commands (#3721)", () => {
     const cmds = captureLiteralAcceptanceCommands(
       "Before done, verify `pnpm test --filter ac` and claim nothing else.",
     );
-    expect(cmds.map((c) => c.command)).toContain("pnpm test --filter ac");
+    expect(cmds.map((c) => c.command)).not.toContain("pnpm test --filter ac");
   });
 });
 

--- a/packages/core/src/literal-acceptance/run.ts
+++ b/packages/core/src/literal-acceptance/run.ts
@@ -8,6 +8,7 @@
 
 import { spawnSync } from "node:child_process";
 import { isAbsolute, resolve } from "node:path";
+import { isInlineProseMention } from "./capture.js";
 import { evaluateCommandSafety, isExecutableLiteralSource } from "./safety.js";
 import type {
   LiteralAcceptanceCommand,
@@ -133,7 +134,10 @@ export function runLiteralAcceptanceCommands(
   }
 
   const untrusted = commands.filter(
-    (c) => c.source === "task_statement" && options.allowTaskStatement !== true,
+    (c) =>
+      c.source === "task_statement" &&
+      options.allowTaskStatement !== true &&
+      !isInlineProseMention(c),
   );
   const executable = commands.filter(
     (c) =>
@@ -192,8 +196,11 @@ export function runLiteralAcceptanceCommands(
       message:
         `Literal acceptance-command gate FAILED (#3267): ${unpromoted.length} stated command(s) ` +
         `are capture-only (source=task_statement) and have no matching agent-promoted peer.\n` +
-        `Promote the exact command strings (and cwd/expectedStdout/expectedExitCode when stated) ` +
-        `into plan.metadata.swarm.verify_commands (or plan item / explicit metadata), then re-run.\n` +
+        `If the command is this story's acceptance, promote the exact strings ` +
+        `(and cwd/expectedStdout/expectedExitCode when stated) into ` +
+        `plan.metadata.swarm.verify_commands (or plan item / explicit metadata), then re-run.\n` +
+        `If the capture is not an acceptance command, record the exact string in ` +
+        `plan.metadata.literal_acceptance_not_commands without promoting it (#3721).\n` +
         `Note: an unrelated executable peer or a same-text peer with different context does not waive.\n` +
         listed,
       commands,

--- a/packages/core/src/literal-acceptance/types.ts
+++ b/packages/core/src/literal-acceptance/types.ts
@@ -92,6 +92,14 @@ export interface LiteralAcceptanceGateResult {
 /** Metadata key for operator-visible rejected command ledger (#3267). */
 export const LITERAL_ACCEPTANCE_REJECTED_METADATA_KEY = "literal_acceptance_rejected" as const;
 
+/**
+ * Metadata key: command strings the operator recorded as *not* acceptance
+ * commands (#3721). Disposition without promotion — listing a string here does
+ * not assert it is the story's verification.
+ */
+export const LITERAL_ACCEPTANCE_NOT_COMMANDS_METADATA_KEY =
+  "literal_acceptance_not_commands" as const;
+
 /** Injectable shell runner for tests (default: spawnSync shell). */
 export type LiteralAcceptanceRunner = (input: {
   readonly command: string;

--- a/packages/core/src/product-first-done-gate/evaluate.ts
+++ b/packages/core/src/product-first-done-gate/evaluate.ts
@@ -19,10 +19,13 @@ import {
   appendLiteralAcceptanceAdvisory,
   type EvaluateLiteralAcceptanceOptions,
   evaluateLiteralAcceptanceFromPlan,
+  isInlineProseMention,
   isNoopRefusalReason,
   type LiteralAcceptanceGateResult,
   type LiteralAcceptanceRunner,
   type RejectedLiteralCommand,
+  readNotAcceptanceCommands,
+  readStoredLiteralAcceptanceCommands,
   runLiteralAcceptanceCommands,
   stripLiteralAcceptanceAdvisory,
 } from "../literal-acceptance/index.js";
@@ -360,10 +363,11 @@ export function evaluateVerifyAcFromPlan(
   // the #3267 ledger is a parallel store and can be empty while stated commands exist.
   // Stated was previously excluded, so rung=stated + empty ledger printed "nothing to run".
   // Do not override a blocking rejected ledger or a config error.
-  if (shouldRunPlanAcceptanceDirectly(base, acceptance)) {
+  if (shouldRunPlanAcceptanceDirectly(base, acceptance, plan)) {
     const runner: LiteralAcceptanceRunner | undefined = optionsWithScope.runner;
+    const directCommands = statedAcceptanceCommands(acceptance, plan);
     const direct = runLiteralAcceptanceCommands(
-      acceptance.commands.map((c) => ({
+      directCommands.map((c) => ({
         command: c.command,
         cwd: c.cwd ?? null,
         expectedStdout: c.expectedStdout ?? null,
@@ -446,11 +450,27 @@ export function evaluateVerifyAcFromPlan(
   return applyOracle(annotate(base, acceptance, optionsWithScope.quiet), optionsWithScope, plan);
 }
 
+function isInlineScrapedAcceptanceCommand(plan: Record<string, unknown>, command: string): boolean {
+  if (readNotAcceptanceCommands(plan).has(command)) return true;
+  return readStoredLiteralAcceptanceCommands(plan).some(
+    (c) => c.command === command && isInlineProseMention(c),
+  );
+}
+
+/** plan.acceptance.commands minus inline-prose scrapes and operator dispositions (#3721). */
+function statedAcceptanceCommands(
+  acceptance: PlanAcceptance,
+  plan: Record<string, unknown>,
+): PlanAcceptance["commands"] {
+  return acceptance.commands.filter((c) => !isInlineScrapedAcceptanceCommand(plan, c.command));
+}
+
 function shouldRunPlanAcceptanceDirectly(
   base: LiteralAcceptanceGateResult,
   acceptance: PlanAcceptance,
+  plan: Record<string, unknown>,
 ): boolean {
-  if (acceptance.commands.length === 0) return false;
+  if (statedAcceptanceCommands(acceptance, plan).length === 0) return false;
   if (base.runs.length > 0) return false;
   if (base.code === 2) return false;
   if ((base.rejected?.length ?? 0) > 0) return false;

--- a/packages/core/src/product-first-done-gate/evaluate.ts
+++ b/packages/core/src/product-first-done-gate/evaluate.ts
@@ -19,6 +19,7 @@ import {
   appendLiteralAcceptanceAdvisory,
   type EvaluateLiteralAcceptanceOptions,
   evaluateLiteralAcceptanceFromPlan,
+  isExecutableLiteralSource,
   isInlineProseMention,
   isNoopRefusalReason,
   type LiteralAcceptanceGateResult,
@@ -450,19 +451,46 @@ export function evaluateVerifyAcFromPlan(
   return applyOracle(annotate(base, acceptance, optionsWithScope.quiet), optionsWithScope, plan);
 }
 
-function isInlineScrapedAcceptanceCommand(plan: Record<string, unknown>, command: string): boolean {
-  if (readNotAcceptanceCommands(plan).has(command)) return true;
+function hasNonDefaultAcceptanceContext(command: PlanAcceptance["commands"][number]): boolean {
+  const cwd = command.cwd !== undefined && command.cwd !== null && String(command.cwd).trim();
+  const stdout =
+    command.expectedStdout !== undefined &&
+    command.expectedStdout !== null &&
+    String(command.expectedStdout).length > 0;
+  const exit = typeof command.expectedExitCode === "number" && command.expectedExitCode !== 0;
+  return Boolean(cwd) || stdout || exit;
+}
+
+function hasStructuredAcceptancePeer(plan: Record<string, unknown>, command: string): boolean {
   return readStoredLiteralAcceptanceCommands(plan).some(
-    (c) => c.command === command && isInlineProseMention(c),
+    (c) => c.command === command && isExecutableLiteralSource(c.source),
   );
 }
 
-/** plan.acceptance.commands minus inline-prose scrapes and operator dispositions (#3721). */
+/**
+ * True when a plan.acceptance.commands row is only an ingest copy of an inline
+ * prose mention (or an operator not-command disposition) and has no structured
+ * peer. Independently authored rows — promoted verify_commands, or a command
+ * with its own cwd/expectedStdout/exit — still run (#3721 Greptile).
+ */
+function isInlineScrapedAcceptanceCommand(
+  plan: Record<string, unknown>,
+  command: PlanAcceptance["commands"][number],
+): boolean {
+  if (hasNonDefaultAcceptanceContext(command)) return false;
+  if (hasStructuredAcceptancePeer(plan, command.command)) return false;
+  if (readNotAcceptanceCommands(plan).has(command.command)) return true;
+  return readStoredLiteralAcceptanceCommands(plan).some(
+    (c) => c.command === command.command && isInlineProseMention(c),
+  );
+}
+
+/** plan.acceptance.commands minus ingest-copied inline mentions (#3721). */
 function statedAcceptanceCommands(
   acceptance: PlanAcceptance,
   plan: Record<string, unknown>,
 ): PlanAcceptance["commands"] {
-  return acceptance.commands.filter((c) => !isInlineScrapedAcceptanceCommand(plan, c.command));
+  return acceptance.commands.filter((c) => !isInlineScrapedAcceptanceCommand(plan, c));
 }
 
 function shouldRunPlanAcceptanceDirectly(

--- a/packages/core/src/scope/main.test.ts
+++ b/packages/core/src/scope/main.test.ts
@@ -70,6 +70,28 @@ describe("lifecycleMain", () => {
     expect(lifecycleMain([])).toBe(2);
   });
 
+  it("scope:complete --help lists --merge-commit and --pr (#3721)", () => {
+    const err: string[] = [];
+    const out: string[] = [];
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      err.push(String(chunk));
+      return true;
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      out.push(String(chunk));
+      return true;
+    });
+    try {
+      expect(lifecycleMain(["complete", "--help"])).toBe(0);
+      const text = `${out.join("")}${err.join("")}`;
+      expect(text).toMatch(/--merge-commit/);
+      expect(text).toMatch(/--pr/);
+    } finally {
+      stderrSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    }
+  });
+
   it("scope:promote --help does not dump scope_lifecycle.py required action (#3439)", () => {
     const err: string[] = [];
     const out: string[] = [];

--- a/packages/core/src/scope/main.ts
+++ b/packages/core/src/scope/main.ts
@@ -82,10 +82,12 @@ const LIFECYCLE_USAGE_STDERR =
   "usage: deft scope:<action> [file] [--batch] [--from-issue N] [--repo OWNER/NAME]\n" +
   "                          [--force] [--project-root PATH] [--strict] [--force-no-cache]\n" +
   "                          [--path PATH]\n" +
+  "  complete also accepts: --merge-commit SHA --pr N [--pr-base BRANCH] [--delivery-branch BRANCH]\n" +
   "  actions: activate, block, cancel, complete, fail, promote, restore, unblock\n" +
   "The verb already encodes the action (e.g. deft scope:promote <file>). Do not pass the action again.\n" +
   "(promote --batch may omit file and promotes all proposed/ scopes; #3011)\n" +
-  "(promote --from-issue=N may omit file; #1136)\n";
+  "(promote --from-issue=N may omit file; #1136)\n" +
+  "(complete --merge-commit / --pr are required for code-bearing delivery evidence; #3041 / #3721)\n";
 
 function parseLifecycleArgv(argv: string[]): { args: LifecycleArgs | null; error?: string } {
   if (argv.length < 1) {

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -868,16 +868,31 @@ export const registryData = {
     "task scope:complete": {
       name: "task scope:complete",
       summary: "active/ -> completed/ (set status completed)",
-      refs: "(#845)",
+      refs: "(#845, #3041, #3721)",
       description:
-        "Mark an active vBRIEF complete and move it to vbrief/completed/. Terminal transition; use scope:undo if you need reversibility (refused on terminal actions per D15).",
-      usage: "task scope:complete -- <file>",
+        "Mark an active vBRIEF complete and move it to vbrief/completed/. Terminal transition; use scope:undo if you need reversibility (refused on terminal actions per D15). Code-bearing completion requires delivery evidence: --merge-commit and --pr. Those flags feed the delivery gate; they do not skip literal-AC.",
+      usage: "task scope:complete -- <file> [--merge-commit SHA] [--pr N]",
       flags: [
         ["<file>", "(required)", "Path to vBRIEF."],
         ["--project-root PATH", "(detected)", "Consumer project root override."],
+        [
+          "--merge-commit SHA",
+          "(required for code-bearing)",
+          "Merge commit SHA for delivery evidence (#3041).",
+        ],
+        [
+          "--pr N",
+          "(required for code-bearing)",
+          "Merged PR number for delivery evidence (#3041).",
+        ],
+        ["--pr-base BRANCH", "(optional)", "PR base branch for delivery evidence."],
+        ["--delivery-branch BRANCH", "(optional)", "Delivery branch tip for completed-tracked."],
       ],
-      examples: ["task scope:complete -- vbrief/active/2026-05-19-foo.vbrief.json"],
-      see_also: ["task scope:fail", "task scope:cancel", "#1119 / #845"],
+      examples: [
+        "task scope:complete -- vbrief/active/2026-05-19-foo.vbrief.json",
+        "task scope:complete -- xbrief/active/story.xbrief.json --merge-commit abc123 --pr 42",
+      ],
+      see_also: ["task scope:fail", "task scope:cancel", "#1119 / #845", "#3041"],
       placeholder: false,
     },
     "task scope:fail": {

--- a/xbrief/decisions/2026-08-25-inline-backticks-in-prose-are-mentions-not-stated-acceptance-com.decision.json
+++ b/xbrief/decisions/2026-08-25-inline-backticks-in-prose-are-mentions-not-stated-acceptance-com.decision.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "inline-backticks-in-prose-are-mentions-not-stated-acceptance-com",
+  "decision": "Inline backticks in prose are mentions, not stated acceptance commands",
+  "governingRule": {
+    "description": "Do not weaken the literal-AC gate beyond the identified false-positive class; a genuinely stated command must still be caught (#3156 / #3721)",
+    "path": "packages/core/src/literal-acceptance/capture.ts",
+    "rfc2119": "MUST"
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Demote all task_statement captures to advisory the way #3511 did for fences",
+      "whyNot": "Would drop promotion for labeled verify: lines and fenced AC. That is the Greptile P1 ambient-authority protection, not the false-positive class."
+    },
+    {
+      "option": "Exclude the comment-thread suffix of Overview from the complete re-scan",
+      "whyNot": "Two of the three #3712 blockers came from the issue body, not comments. Insufficient and would hide AC stated only in a later maintainer comment (#2143)."
+    },
+    {
+      "option": "Keep the block and only add a disposition field",
+      "whyNot": "Would still turn a verb mentioned in prose into a stated command until an operator acts. AC 1 requires the mention not become stated by itself."
+    }
+  ],
+  "whyWinner": "The measured failure is extractInlineVerifySpans treating a backtick on a verify/run line as stated AC. Narrowing that scraper plus evaluate-time demotion of stored inline@ rows unblocks #3712 without promotion. Labeled lines, $ prompts, and fences stay fail-closed. literal_acceptance_not_commands dispositions remaining uncertain labeled/fence captures without asserting they are AC.",
+  "confidence": "high",
+  "activeScopeRefs": [
+    "xbrief/active/2026-08-25-3721-bugscope-a-verb-discussed-in-issue-prose-becomes-a-stated-ac.xbrief.json"
+  ],
+  "timestamp": "2026-08-25T15:00:02Z",
+  "revisitTrigger": "If a legitimate story states AC only as an inline backtick in a prose sentence and that command is missed",
+  "tags": [
+    "process",
+    "literal-ac",
+    "scope-complete"
+  ],
+  "relatedIssues": [
+    3721
+  ]
+}


### PR DESCRIPTION
## Summary

Inline-backticked verb mentions in issue/comment prose are no longer stated acceptance commands.

`issue:ingest` concatenates body plus comments into `plan.narratives.Overview`. The literal-AC extractor then treated a backtick on a line that said verify/run/execute/acceptance as `source=task_statement`, and `scope:complete` failed closed until those strings were promoted. For #3712 that produced three capture-only blockers (`deft verify:*`, `task check`, `task verify:scope-provenance`) — two from the issue body, one from a critic saying they did not run the command.

### Direction

Narrow inline capture (recut candidate 2), plus an honest disposition (candidate 4).

- An inline backtick inside a prose sentence is a mention. It is recorded on the advisory ledger with `inline@` and reason `#3721`. It does not require promotion.
- A leftover ingest row with `source=task_statement` and `sourceSpan` starting `inline@` is peeled the same way, so stored captures cannot re-block.
- `plan.acceptance.commands` that match those mentions (or `plan.metadata.literal_acceptance_not_commands`) are not executed on the #3449 fallback. That path was re-spawning the same strings as `source=explicit`.
- An operator can list a capture under `literal_acceptance_not_commands` without asserting it is acceptance.

Rejected alternatives:

- Demote every `task_statement` (candidate 1) — that would also drop promotion for labeled `verify:` lines, `$` prompts, and fences (Greptile P1 ambient-authority).
- Exclude the comment-thread suffix from Overview scan (candidate 3) — two of the three #3712 blockers are in the issue body.
- Promotion-only unblock — declaring `task check` as a docs story's acceptance is the #3156 failure mode.

Activate-versus-complete stays split. Capture-only promotion still runs only at complete.

### Protection preserved

These still fail closed until promoted or honestly dispositioned:

- labeled `verify:` / `run:` lines
- `$` prompt lines
- fenced acceptance commands (#3511 already demotes fence *rejections* to advisory; fence *captures* stay stated)
- structured-field rejects (`swarm.verify_commands`, plan items)

How we know: tests in `inline-prose-mention.test.ts` assert labeled, fence, and structured-field cases still block. #3511 fence-transcript tests still pass.

### Help

`scope:complete --help` now lists `--merge-commit` and `--pr` (registry + lifecycle usage). Those flags still feed the delivery gate only; they do not skip literal-AC.

### #3712 brief

In-process `evaluateLiteralAcceptanceFromPlan` on the live main-repo #3712 brief (read-only, not mutated): `ok: true`, 0 stated commands, 0 blocking rejects, 32 advisory. The three former blockers are `inline@` mentions.

A #3712-shaped fixture (same Overview mentions + stored `inline@` + ingest-stamped `plan.acceptance.commands`) completes the verify:ac walk without promotion.

The live #3712 brief still has its own #3497 clause walk (docs clauses with no artifact paths). That is #3712's completion, not this defect. This PR removes the #3267 capture-only stop that was the observed hard stop.

## Test plan

- [x] Fixture: Overview with backticked verb prose completes without promotion
- [x] Live #3712 brief: literal-AC gate passes (read-only evaluate)
- [x] Labeled `verify:`, fenced AC, and structured-field rejects still fail closed
- [x] Operator disposition via `literal_acceptance_not_commands` does not promote
- [x] `scope:complete --help` lists `--merge-commit` and `--pr`
- [x] CHANGELOG union after rebase: #3708, #1351, #3650, #3712, #3713, #3673, #3690, plus landed #3679 / #3666

Closes #3721
