### PR TITLE
Land completed xBRIEF for #3738

### DIFF
--- a/xbrief/completed/2026-08-25-3738-bughooks-cache-fresh-is-in-the-write-gates-required-set-and.xbrief.json
+++ b/xbrief/completed/2026-08-25-3738-bughooks-cache-fresh-is-in-the-write-gates-required-set-and.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #3738",
-    "updated": "2026-08-25T22:04:57Z"
+    "updated": "2026-08-26T00:15:26Z"
   },
   "plan": {
     "title": "bug(hooks): cache_fresh is in the write gate's required set and does live forge I/O to satisfy it (80.4s measured on a clean cache)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(hooks): cache_fresh is in the write gate's required set and does live forge I/O to satisfy it (80.4s measured on a clean cache)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3738",
@@ -43,7 +43,30 @@
         "schema": "deft.scope.intended_placement.v1",
         "files": [],
         "module_boundary": ""
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3744,
+        "prBase": null,
+        "mergeCommit": "13addcece8682aaa41a6bded3635eb4e8312158e",
+        "deliveryBranch": "master",
+        "deliveryCommit": "13addcece8682aaa41a6bded3635eb4e8312158e",
+        "verifiedAt": "2026-08-26T00:15:26Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-26T00:15:26Z"
+      },
+      "completedAt": "2026-08-26T00:15:26Z",
+      "capacityBucket": "technical-debt"
     },
     "acceptance": {
       "commands": [],
@@ -96,6 +119,6 @@
       ],
       "ambiguity_attestation": "none_found"
     },
-    "updated": "2026-08-25T22:04:57Z"
+    "updated": "2026-08-26T00:15:26Z"
   }
 }


### PR DESCRIPTION
## Summary

Land the completed #3738 scope xBRIEF after squash merge of PR #3744 (13addcec). scope:complete already ran with --merge-commit and --pr.

## Related Issues

Refs #3738

## Checklist

- [x] /deft:change <name> — N/A: lifecycle stamp only
- [x] CHANGELOG.md — N/A: product CHANGELOG already landed on #3744
- [x] ROADMAP.md — N/A
- [x] Tests pass locally — lifecycle move only
