### PR TITLE
chore(xbrief): track queued proposed briefs and one decision record

### DIFF
--- a/xbrief/decisions/2026-08-24-plan-policy-review-mingreptileconfidence-stays-at-5-do-not-lower.decision.json
+++ b/xbrief/decisions/2026-08-24-plan-policy-review-mingreptileconfidence-stays-at-5-do-not-lower.decision.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "plan-policy-review-mingreptileconfidence-stays-at-5-do-not-lower",
+  "decision": "plan.policy.review.minGreptileConfidence stays at 5; do not lower it to reduce residual passes",
+  "governingRule": {
+    "description": "review-surface precedence (#2308)",
+    "path": null,
+    "rfc2119": null
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Lower the floor to 4 so 4/5 reviews merge without operator involvement"
+    },
+    {
+      "option": "Keep 5 but auto-override for docs and contract changes"
+    }
+  ],
+  "whyWinner": "Operator rationale: a 4/5 passed over has historically enthroned bugs that needed squashing. Extra residual passes are cheap; a shipped bug is not. The floor is deliberately strict and forces a human decision rather than a silent merge.",
+  "confidence": "high",
+  "activeScopeRefs": [],
+  "timestamp": "2026-08-24T21:04:44Z",
+  "revisitTrigger": "A measured distribution of 4/5 residuals over a meaningful window showing they are consistently non-defects, not a few same-day samples"
+}

--- a/xbrief/proposed/2026-08-25-3598-blocker-bugsetuprender-greenfield-export-handoff-regressed-a.xbrief.json
+++ b/xbrief/proposed/2026-08-25-3598-blocker-bugsetuprender-greenfield-export-handoff-regressed-a.xbrief.json
@@ -1,0 +1,147 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3598"
+  },
+  "plan": {
+    "title": "BLOCKER: bug(setup,render): greenfield export handoff regressed after #1502",
+    "status": "proposed",
+    "narratives": {
+      "Description": "BLOCKER: bug(setup,render): greenfield export handoff regressed after #1502",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3598",
+      "Overview": "# Summary\n\nThe `deft-directive-setup` end-of-Phase-3 export contract does not match the current greenfield xBRIEF runtime. A canonical xBRIEF-only project can export `SPECIFICATION.md`, but the exact commands taught by the setup skill have three correctness defects:\n\n1. `task prd:render` fails because it still requires `xbrief/specification.xbrief.json`, an artifact greenfield setup intentionally does not create.\n2. `task project:export-spec -- --audience=internal` does not include the just-created proposed scopes, despite the setup skill explicitly saying that it does.\n3. The generated xBRIEF export claims its source of truth is the legacy `vbrief/PROJECT-DEFINITION.vbrief.json` path.\n\nThis regresses the greenfield export resolution recorded on closed #1502 and PR #2051. It is a framework contract defect, not a consumer-project configuration problem.\n\n## Environment\n\n- Released runtime reproduced: `@deftai/directive` / `@deftai/directive-core` 0.105.0\n- Current `master` verified: `522643763423b57d4ca7e9ddb551785d3a2bfb84` (2026-08-21)\n- Host: macOS, zsh\n- Consumer layout: xBRIEF v0.8\n- Authority shape:\n  - `xbrief/PROJECT-DEFINITION.xbrief.json`\n  - one or more `xbrief/proposed/*.xbrief.json` scopes\n  - no `xbrief/specification.xbrief.json` (correct for greenfield setup)\n\n## Reproduction\n\nStarting from a greenfield project that has a non-empty `Overview` narrative and a proposed scope:\n\n```sh\ndeft project:export-spec \"$PROJECT_ROOT\" /tmp/internal.md --audience=internal\ndeft project:export-spec \"$PROJECT_ROOT\" /tmp/internal-with-scopes.md --audience=internal --include-scopes=current\ndeft prd:render --project-root \"$PROJECT_ROOT\" --output /tmp/PRD.md\n```\n\nEquivalent consumer task surfaces are:\n\n```sh\ntask deft:project:export-spec -- --audience=internal\ntask deft:prd:render\n```\n\n## Observed behavior\n\nThe first export exits 0 but contains neither `## Scope outlook` nor the proposed scope. The second export contains both, proving the missing `--include-scopes=current` is the behavioral difference.\n\nBoth exports begin with the wrong provenance marker:\n\n```md\n<!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json -->\n```\n\nThe PRD command exits 1:\n\n```text\nError: specification file not found: <project>/xbrief/specification.xbrief.json\n```\n\nThe setup flow therefore cannot satisfy its own `Yes — export spec (+ PRD if selected)` or `PRD.md only` branches without introducing an artifact the greenfield authority model intentionally omits. Its internal handoff path also silently hides the scope it just produced.\n\n## Current-master evidence\n\n- The setup skill offers PRD for greenfield projects and says `--audience=internal` includes proposed scopes: [setup skill lines 792-805](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/content/skills/deft-directive-setup/SKILL.md#L792-L805).\n- `exportSpec()` defaults `includeScopes` to `off`; `audience=internal` only enables proposed-scope filtering after scope rendering is separately enabled: [export-spec.ts lines 64-110](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/packages/core/src/render/export-spec.ts#L64-L110).\n- The tests encode this split explicitly: the internal-audience test passes `includeScopes: \"all\"`, while the default test requires no `Scope outlook`: [spec-authority.test.ts lines 120-157](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/packages/core/src/spec-authority/spec-authority.test.ts#L120-L157).\n- The greenfield banner hardcodes the legacy PD token even though an xBRIEF token is defined beside it: [constants.ts lines 4-35](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/packages/core/src/spec-authority/constants.ts#L4-L35).\n- `prd-render` only reads a specification artifact and fails if it is absent: [prd-render.ts lines 21-31](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/packages/core/src/render/prd-render.ts#L21-L31). The CLI resolves that artifact to `xbrief/specification.xbrief.json`: [prd-render-cli.ts lines 35-45](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/packages/cli/src/render-cli/prd-render-cli.ts#L35-L45).\n\n## Regression history and duplicate check\n\nClosed #1502 described the original greenfield export-contract conflict. Its close-out comment says PR #2051 implemented:\n\n- a PROJECT-DEFINITION-backed greenfield export,\n- a PROJECT-DEFINITION source-of-truth banner, and\n- proposed scopes gated by `--audience=internal`.\n\nThe current implementation retains the export path but no longer delivers the latter two behaviors through the command documented by setup, and PRD remains unavailable on the same authority shape.\n\nNo open issue owns this regression. Body/comment-level checks were performed for the plausible open neighbors:\n\n- #453 concerns rendering raw preparatory-strategy context, not setup's generated scope or PRD branches.\n- #630 concerns automatic rendering after legacy migration.\n- #1589 concerns reconstruction and drift freshness of long-lived specs.\n- #1812 concerns seed-document ingestion; it references the setup flow but does not own export behavior.\n\n## Expected behavior\n\nEvery export branch offered by greenfield setup should either work from the canonical greenfield authority (`PROJECT-DEFINITION` plus lifecycle scopes) or the skill should stop offering that unsupported branch. Generated files must identify their actual source paths, and the documented internal handoff command must include proposed scopes as promised.\n\n## Suggested implementation direction\n\n1. Give PRD export a greenfield authority path, preferably by reusing `resolveSpecAuthority()` / `resolveExportNarratives()` rather than creating a second authority model. A dedicated `project:export-prd` would also be coherent if `prd:render` remains full-spec-only.\n2. Make the setup command and renderer semantics agree for internal handoff: either teach `--include-scopes=current` in the setup skill or make `audience=internal` imply current scope inclusion on this surface. Preserve the compact stakeholder default.\n3. Select the generated PD banner from the resolved layout instead of hardcoding the legacy vBRIEF token.\n4. Add one end-to-end greenfield fixture that runs the exact commands printed by the setup skill. Unit tests that call `exportSpec()` with extra options or `renderPrd()` with a synthetic full spec do not protect this contract.\n\n## Acceptance criteria\n\n- [ ] On an xBRIEF-only greenfield fixture with no `specification.xbrief.json`, every export choice presented by `deft-directive-setup` has defined, truthful behavior.\n- [ ] The setup-documented internal export command includes proposed scopes under `## Scope outlook`.\n- [ ] Greenfield PRD export succeeds from current authority, or setup no longer offers `PRD.md` for that state and clearly documents the supported replacement.\n- [ ] Generated xBRIEF exports carry `<!-- Source of truth: xbrief/PROJECT-DEFINITION.xbrief.json -->`.\n- [ ] No workaround creates or dual-writes `xbrief/specification.xbrief.json` solely to satisfy export.\n- [ ] Consumer-task integration coverage invokes the exact setup command lines and checks output content, provenance, and exit status.\n\n\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @dbcall2 (2026-08-21T17:09:19Z)\n\n## Additional confirmed downstream blocker: cost phase cannot consume greenfield authority\n\nThis surfaced while following the build handoff from the same real greenfield onboarding on Directive 0.105.0. It also reproduces in current `master` at `522643763423b57d4ca7e9ddb551785d3a2bfb84`.\n\n### Reproduction state\n\nThe project is in the authority shape required by setup:\n\n- `xbrief/PROJECT-DEFINITION.xbrief.json`\n- `xbrief/proposed/YYYY-MM-DD-*.xbrief.json`\n- generated `SPECIFICATION.md`\n- no `xbrief/specification.xbrief.json` (intentional greenfield state)\n\nThe operator selects setup's **Continue to build** handoff.\n\n### Observed contract loop\n\n1. The build skill refuses implementation until `COST-ESTIMATE.md` contains a recorded decision: [build skill lines 152-190](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/content/skills/deft-directive-build/SKILL.md#L152-L190).\n2. The required cost skill says setup must have produced an approved `xbrief/specification.xbrief.json`, and makes that file a MUST input: [cost skill lines 25-69](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/content/skills/deft-directive-cost/SKILL.md#L25-L69).\n3. Greenfield setup intentionally does not create that artifact; creating it would reintroduce the legacy dual-write conflict fixed by #1502.\n4. The setup skill hands directly to build rather than routing through cost: [setup skill lines 814-819](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/content/skills/deft-directive-setup/SKILL.md#L814-L819).\n\nResult: a valid greenfield project reaches a hard loop:\n\n```text\nsetup -> build requires COST-ESTIMATE.md\ncost -> requires forbidden specification.xbrief.json\ncost -> redirects back to setup\n```\n\nThere is no conformant way to record the required cost decision. Manufacturing `specification.xbrief.json` breaks the greenfield authority contract; bypassing `COST-ESTIMATE.md` breaks the build gate.\n\n### Impact on #3598\n\nThis is the downstream build-blocking consequence of the same authority mismatch. Fixing only PRD, scope inclusion, and the banner would still leave setup unable to hand a greenfield project to build.\n\nThe build skill's prose also defines a current generated spec as requiring an xBRIEF specification artifact and specification-source banner, excluding PROJECT-DEFINITION-backed greenfield exports: [build skill lines 102-130](https://github.com/deftai/directive/blob/522643763423b57d4ca7e9ddb551785d3a2bfb84/content/skills/deft-directive-build/SKILL.md#L102-L130). The deterministic validator should remain authoritative, but the shipped skill must not teach a conflicting state model.\n\n### Acceptance additions\n\n- [ ] The cost skill resolves the same greenfield authority as `project:export-spec` (PROJECT-DEFINITION plus lifecycle scopes), without requiring or creating `specification.xbrief.json`.\n- [ ] Setup routes **Continue to build** through the required cost decision phase, or explicitly documents a deterministic equivalent.\n- [ ] Build's pre-cutover guidance recognizes a current PROJECT-DEFINITION-backed greenfield export.\n- [ ] An end-to-end consumer fixture covers `setup -> internal export -> cost decision -> build preflight` on an xBRIEF-only greenfield tree."
+    },
+    "items": [
+      {
+        "title": "On an xBRIEF-only greenfield fixture with no `specification.xbrief.json`, every export choice presented by `deft-directive-setup` has defined, truthful behavior.",
+        "status": "proposed"
+      },
+      {
+        "title": "The setup-documented internal export command includes proposed scopes under `## Scope outlook`.",
+        "status": "proposed"
+      },
+      {
+        "title": "Greenfield PRD export succeeds from current authority, or setup no longer offers `PRD.md` for that state and clearly documents the supported replacement.",
+        "status": "proposed"
+      },
+      {
+        "title": "Generated xBRIEF exports carry `<!-- Source of truth: xbrief/PROJECT-DEFINITION.xbrief.json -->`.",
+        "status": "proposed"
+      },
+      {
+        "title": "No workaround creates or dual-writes `xbrief/specification.xbrief.json` solely to satisfy export.",
+        "status": "proposed"
+      },
+      {
+        "title": "Consumer-task integration coverage invokes the exact setup command lines and checks output content, provenance, and exit status.",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3598",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3598: BLOCKER: bug(setup,render): greenfield export handoff regressed after #1502"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1502",
+        "type": "x-xbrief/closes",
+        "title": "Issue #1502"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [
+        {
+          "command": "deft project:export-spec \"$PROJECT_ROOT\" /tmp/internal.md --audience=internal",
+          "reason": "shell metacharacter \"$\" is not allowed in literal AC commands",
+          "sourceSpan": "fence@L28:sh"
+        },
+        {
+          "command": "deft project:export-spec \"$PROJECT_ROOT\" /tmp/internal-with-scopes.md --audience=internal --include-scopes=current",
+          "reason": "shell metacharacter \"$\" is not allowed in literal AC commands",
+          "sourceSpan": "fence@L28:sh"
+        },
+        {
+          "command": "deft prd:render --project-root \"$PROJECT_ROOT\" --output /tmp/PRD.md",
+          "reason": "shell metacharacter \"$\" is not allowed in literal AC commands",
+          "sourceSpan": "fence@L28:sh"
+        },
+        {
+          "command": "task deft:project:export-spec -- --audience=internal",
+          "reason": "wrapper subcommand must be check|doctor|verify:*|help|--version (scope/policy/swarm/scm/merge and other ambient-authority verbs denied)",
+          "sourceSpan": "fence@L36:sh"
+        },
+        {
+          "command": "task deft:prd:render",
+          "reason": "wrapper subcommand must be check|doctor|verify:*|help|--version (scope/policy/swarm/scm/merge and other ambient-authority verbs denied)",
+          "sourceSpan": "fence@L36:sh"
+        }
+      ],
+      "swarm": {},
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 7 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "On an xBRIEF-only greenfield fixture with no `specification.xbrief.json`, every export choice presented by `deft-directive-setup` has defined, truthful behavior.",
+          "artifact_path": "specification.xbrief.json",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "The setup-documented internal export command includes proposed scopes under `## Scope outlook`.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "Greenfield PRD export succeeds from current authority, or setup no longer offers `PRD.md` for that state and clearly documents the supported replacement.",
+          "artifact_path": "PRD.md",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "Generated xBRIEF exports carry `<!-- Source of truth: xbrief/PROJECT-DEFINITION.xbrief.json -->`.",
+          "artifact_path": "xbrief/PROJECT-DEFINITION.xbrief.json",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "No workaround creates or dual-writes `xbrief/specification.xbrief.json` solely to satisfy export.",
+          "artifact_path": "xbrief/specification.xbrief.json",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "Consumer-task integration coverage invokes the exact setup command lines and checks output content, provenance, and exit status.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 7,
+          "text": "--",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    }
+  }
+}

--- a/xbrief/proposed/2026-08-25-3599-fixsession-occupancy-lease-never-heartbeats-during-active-wo.xbrief.json
+++ b/xbrief/proposed/2026-08-25-3599-fixsession-occupancy-lease-never-heartbeats-during-active-wo.xbrief.json
@@ -1,0 +1,344 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3599"
+  },
+  "plan": {
+    "title": "fix(session): occupancy lease never heartbeats during active work, so a working session gets stolen (#3433)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "fix(session): occupancy lease never heartbeats during active work, so a working session gets stolen (#3433)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3599",
+      "Overview": "## What happened\n\nA mutation session claimed the occupancy lease on a worktree, worked for ~3.5 hours, and\nproduced three pushed commits. Its `heartbeat_at` never advanced past the original claim. A\nconcurrent agent correctly read that lease as abandoned and stole it.\n\n```json\n{\n  \"session_id\": \"285342a2-…\",\n  \"intent\": \"mutation\",\n  \"claimed_at\":   \"2026-08-21T13:24:13Z\",\n  \"heartbeat_at\": \"2026-08-21T13:24:13Z\"   // never advanced, across 3 commits\n}\n```\n\nNothing was lost here because the work was already pushed, but the steal is a data-loss\nmechanism in general: two sessions mutating one worktree is exactly what #3433 exists to\nprevent.\n\nThe stealing agent did nothing wrong. The lease genuinely looked dead.\n\n## Defect 1 — the write gate discards a liveness signal it already has\n\n`evaluateOccupancyWriteGate` (`packages/core/src/session/occupancy.ts:394`) runs on **every**\nproduct-path write. It resolves the live occupant, compares session ids, and returns `allow`:\n\n```ts\nconst live = liveOccupant(projectRoot, now);\nif (live === null) return { allow: true, message: null, occupant: null };\nconst incoming = input.sessionId?.trim() || (input.env ?? process.env).DEFT_SESSION_ID?.trim() || \"\";\nif (incoming.length > 0 && incoming === live.sessionId) {\n  return { allow: true, message: null, occupant: live };   // <-- no heartbeat\n}\n```\n\nSo a session that is *actively writing files* — the strongest available evidence of liveness —\nnever refreshes its own lease. Liveness is judged on a wall-clock timestamp that nothing\nadvances while work happens.\n\nThe same-session branch is the natural place to re-stamp: it already knows the identity\nmatches, it already runs on the cadence of real work, and it costs one write on a path that is\nalready writing.\n\n## Defect 2 — no way to refresh through the documented surface\n\n`task --list` exposes exactly one occupancy verb:\n\n```\n* occupancy:steal:   Supersede a live worktree occupancy lease (#3433). Flags: --confirm --occupant <id>\n```\n\nThere is no `occupancy:heartbeat` / `occupancy:renew`. Refreshing requires reverse-engineering:\n\n1. `resolveOccupancySessionId` (`occupancy.ts:106`) consults `DEFT_SESSION_ID`\n2. `applyWorktreeOccupancy` (`occupancy.ts:140`) treats an incoming id equal to the live\n   occupant as a heartbeat rather than a denial\n3. therefore `DEFT_SESSION_ID=<existing-id> task session:start` re-stamps\n\nNo agent or operator will discover that from the exposed surface. In practice **every**\nlong-running mutation session goes stale and becomes a steal candidate, which makes the\nmechanism actively misleading: `occupancy:steal` exists and works, while staying alive does not.\n\n## Why this matters more than a single lost lease\n\nThe lease is the only thing standing between two agents and concurrent mutation of one\nworktree. If the holder cannot signal liveness, the gate degrades into \"whoever ran most\nrecently wins,\" and the failure is silent on both sides — the holder gets no warning that its\nlease expired, and the stealer gets no signal that the occupant is mid-work.\n\n## Proposed fix\n\n- [ ] Re-stamp `heartbeat_at` in `evaluateOccupancyWriteGate`'s same-session branch (guard\n      against write amplification — e.g. only when the beat is older than some fraction of the\n      staleness window)\n- [ ] Expose `occupancy:heartbeat` (or `occupancy:renew`) as a task/CLI verb so refresh is\n      discoverable without reading source\n- [ ] Document the refresh path in `.deft/core/commands.md` § Session routing alongside\n      `occupancy:request` / `occupancy:steal`\n- [ ] Warn the holder when its own lease is within the staleness window rather than letting it\n      expire silently\n- [ ] Consider requiring `occupancy:steal --confirm` to report the occupant's last *write*\n      time, not just heartbeat age, so a mid-work occupant is visible to the stealer\n\n## Repro\n\n1. In a worktree, `task session:start` (mutation intent) — note `heartbeat_at`\n2. Make and commit file changes for longer than the staleness window\n3. Re-read `.deft/occupancy.json` — `heartbeat_at` is unchanged\n4. From another session, the lease reads as expired and `occupancy:steal` succeeds against an\n   actively-working holder\n\nFound while landing #3588. Refs #3433, #3110, #3597.\n\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-08-21T17:13:32Z)\n\n## Triage analysis\n\n_By: Grok 4.6 (xAI), 2026-08-21. Checked against issue body via REST (no comments), then `origin/master` occupancy + dispatcher. Working tree not modified._\n\n**Verdict:** accurate, desirable, ready as **one story** after locking a thin v1. Do not decompose children.\n\n`design-critique: warranted, because the lean proposes where liveness is stamped (write gate vs CLI verb vs steal reporting last write), which is the occupancy mechanism itself — not a copy-only bugfix.`\n\n### Accuracy\n\nHigh.\n\n- Same-session write allow **does not** re-stamp (`evaluateOccupancyWriteGate` `occupancy.ts:394–408`: identity match → `{ allow: true }` with no `heartbeatAt` write). Line numbers in the body match this SHA’s structure.\n- That function **is** on the product-write path (`hooks/dispatcher.ts:883`).\n- Same-session **`session:start` / `applyWorktreeOccupancy`** already heartbeats (`occupancy.ts:140–218`). The hole is the write gate, not claim.\n- TTL is 20 minutes (`OCCUPANCY_TTL_MS` `:27–28`). A 3.5h session with `heartbeat_at == claimed_at` is expired; steal is correct given the file.\n- Documented occupancy verbs: `tasks/occupancy.yml` exposes **only** `occupancy:steal`. `occupancy:heartbeat` / `occupancy:renew` do not exist. Refresh via `DEFT_SESSION_ID=<id> session:start` is real (`resolveOccupancySessionId` `:106` + same-id branch of `applyWorktreeOccupancy`) and undiscoverable from `task --list`.\n- Remediation names `occupancy:request` (`:102`) while the module header says join is **out of scope** (`:6`). False surface, same class as #3439’s missing verbs — footnote, not this story’s AC.\n\n### Desirability\n\nHigh. #3433 exists to stop two mutators on one tree. If the holder cannot stay live except by re-running ceremony, the lease becomes “whoever claimed last and then went quiet.” Steal is honest; staying alive is not.\n\n### Readiness\n\nYes, with a thin first ship. Body lists five bullets; do not boil:\n\n| In v1 | Out / follow-up |\n|---|---|\n| **A.** Re-stamp `heartbeat_at` on the same-session branch of `evaluateOccupancyWriteGate`, **debounced** (only if age > fraction of `OCCUPANCY_TTL_MS`, e.g. ¼ of 20 min) so a tight write loop does not hammer `.deft/occupancy.json` | Steal reporting “last write time” as a new field (needs a second timestamp; separate if still wanted) |\n| **B.** Discoverable refresh: `occupancy:heartbeat` **or** document that same-session `session:start` already renews — pick one, not both as required | Holder warning “your lease is about to expire” (needs a reader; not the fail-closed hole) |\n| **C.** `commands.md` § occupancy: name the actual refresh path; stop implying `occupancy:request` is a live verb unless it ships | Implementing `occupancy:request` join protocol |\n\n**Do not require B if A lands** and docs tell operators/agents that product writes keep the lease. B is still worth it: Shell-only mutation (#3438) may **never** hit `evaluateOccupancyWriteGate`. A covers Edit/Write; B covers long work that only shells. Cheap together.\n\nHostile/swarm: a headless leaf that never re-runs `session:start` and writes only via Bash still looks dead after 20 min even with A. Admit that residual (points at #3438) rather than pretending A closes all paths.\n\n### Disposition\n\n**Accept as one story.** Pair write-gate heartbeat (A) + discoverable refresh (B) + honest docs (C). Keep #3433 closed. Refs #3433, #3438 (Shell bypass of this gate), #3110, #3597.\n\n\n### Comment by @MScottAdams (2026-08-21T17:19:26Z)\n\nAdditional evidence: the heartbeat path itself works, it is just never invoked automatically and is undiscoverable.\n\nDemonstrated on a live lease — `DEFT_SESSION_ID=<existing-id> task session:start` in the worktree produced a true heartbeat (`claimed_at` unchanged at 17:04:05Z, `heartbeat_at` advanced to 17:17:50Z). So no new mechanism is needed for the refresh itself; the fix is (a) calling it from the same-session branch of `evaluateOccupancyWriteGate`, and (b) exposing it as a verb.\n\nOne more observation for the fix: **release deletes `.deft/occupancy.json` rather than marking it released.** After the lease on the primary checkout was released there was no file at all, so there is no record of who last held it or when. A tombstone (or an append-only lease log) would make steal-vs-release distinguishable after the fact — which matters when diagnosing exactly the kind of concurrent-mutation incident this gate exists to prevent.\n\n### Comment by @MScottAdams (2026-08-21T17:21:46Z)\n\n## Design critique of the triage comment (checked at `522643763423b57d4ca7e9ddb551785d3a2bfb84`)\n\n_By: Grok 4.5 (xAI)_\n\nCeiling: triage comment id `5372982342` only. Re-verified file:line claims against `origin/master` at the SHA above via `git show`. No product edits; no post-ceiling comments read.\n\n### What holds\n\n- **Defect is real and correctly located.** Same-session allow in `evaluateOccupancyWriteGate` returns without writing (`occupancy.ts:407–408`). Reproduced: that branch is `return { allow: true, message: null, occupant: live }` with no `heartbeatAt` / `writeOccupancyRecord` call.\n- **Product-write wiring holds.** Non-spawn mutation path calls the gate at `hooks/dispatcher.ts:881–883`.\n- **Claim/heartbeat path already exists and is separate.** `applyWorktreeOccupancy` same-session write path re-stamps `heartbeatAt: now` (`occupancy.ts:140–218`, esp. `:202`). `session:start` / `session:ready` already go through that path. The hole is the write gate, not claim.\n- **TTL / expiry math holds.** `OCCUPANCY_TTL_MS = 20 * 60 * 1000` (`:27–28`). A 3.5h session with `heartbeat_at == claimed_at` is expired; steal against that file is correct behavior.\n- **Discoverability claim holds (reproduced claimant method).** `tasks/occupancy.yml` exposes only `steal`. Live `task --list` shows only `occupancy:steal`. No `occupancy:heartbeat` / `occupancy:renew` task. Same-session renew via `DEFT_SESSION_ID=<id> session:start` is real (`resolveOccupancySessionId` `:106` + same-id branch of `applyWorktreeOccupancy`) and not listed as an occupancy verb.\n- **False-surface footnote holds.** Remediation names `occupancy:request` (`:102`) while the module header says join is out of scope (`:6`). `commands.md` Session routing already admits join is \"named in the remediation only\" (`content/commands.md:398` at this SHA).\n- **One-story / keep #3433 closed** is the right shape. This is a liveness-stamp hole in an existing lease, not a new concurrency model.\n- **design-critique warranted** judgment is sound: the lean proposes *where* liveness is stamped.\n\n### Findings\n\n1. **[blocks-the-design]** Side-effecting the pure write-gate evaluator must not fail closed on heartbeat I/O.\n   - Today `evaluateOccupancyWriteGate` is allow/deny only (`:394–413`); sole caller is the dispatcher (`dispatcher.ts:883`). Tests assert allow/deny only (`occupancy.test.ts` write-gate cases).\n   - If same-session re-stamp is inlined into that function and a lock/write failure flips `allow` to deny, active holders lose product writes because the liveness sidecar hiccuped — inverted fail-closed.\n   - v1 must keep deny criteria identity-only; heartbeat touch is **best-effort** after allow (dispatcher post-allow, or a separate `touchOccupancyHeartbeat` that never changes the gate verdict). Debounce alone does not solve this.\n\n2. **[sharpens-framing]** \"Do not require B if A lands\" contradicts the Shell residual the triage itself admits — and the residual is structural, not \"may\".\n   - Reproduced: `decideHook` early-returns Shell/Bash/MCP through `decideShellOrMcpRuntimeAuthority` at `dispatcher.ts:1268–1273` and **never** reaches `inspectMutationGates` / `evaluateOccupancyWriteGate`.\n   - So A (write-gate re-stamp) covers Edit/Write-class tools only. Headless leaves that mutate via Shell/Bash for >20 min stay steal-bait even after A.\n   - Triage correctly says \"A covers Edit/Write; B covers long work that only shells\" and \"admit that residual (points at #3438)\". Drop or rewrite \"Do not require B if A lands\". For v1, **B (or an equivalent renew path Shell can hit without ceremony) is required**, not optional polish. #3438 remains the scope-gate cousin; occupancy Shell bypass is the same router, proven here by early-return.\n\n3. **[sharpens-framing]** Docs already half-promise renew; C is corrective, not greenfield.\n   - `content/commands.md:398` says \"Same-session re-arm heartbeats\" — true for `session:start` re-arm, easy to misread as \"active work keeps the lease\".\n   - C must state the actual refresh surfaces (same-session `session:start` / future `occupancy:heartbeat` / write-path touch if A lands) and that product Shell mutations do not refresh today. Stop implying a live `occupancy:request` verb beyond the existing remediation disclaimer.\n\n4. **[footnote]** Assist-scratch early-return also skips the occupancy gate (`dispatcher.ts:816–842` → allow `write-assist-scratch-ready` before `:881`). Not the incident class; do not expand v1 to scratch. Note it so A is not marketed as \"every PreToolUse write\".\n\n5. **[footnote]** `OCCUPANCY_JOIN_PROTOCOLS` includes `heartbeat-file` / `parent-message` (`occupancy.ts:31`) but join remains out of scope. Do not revive join protocol as this story's vehicle; keep A/B as lease touch, not join negotiation.\n\n### Existing mechanisms (inventory before new)\n\n| Mechanism | Role | Reuse? |\n|---|---|---|\n| `applyWorktreeOccupancy` same-session write | Already heartbeats | Prefer calling this (or shared write helper) over inventing a second serializer |\n| `session:start` / `session:ready` occupancy claim | Ceremony renew | Document; too heavy as the *only* long-session refresh |\n| `occupancy:steal` + `stealOccupancy` | Supersede | Keep; do not overload steal with renew |\n| `liveOccupant` / `isOccupancyExpired` / `OCCUPANCY_TTL_MS` | Liveness read model | Keep; do not \"fix\" by lengthening TTL alone (#3156) |\n| `formatOccupancyRemediation` | Operator text | Fix false `occupancy:request` when docs/verb land |\n| `DEFT_SESSION_ID` + `resolveOccupancySessionId` | Identity | Required for A and B; unset id still denies against a live occupant |\n| Swarm cohort `occupancy_session_id` (`commands.md:398`) | Close-out identity | Orthogonal; do not bind heartbeat to launch manifest |\n| Subagent heartbeat (`orchestration/subagent-monitor.ts`, `docs/subagent-heartbeat.md`) | Different SoT | Do not conflate agent-liveness files with worktree `occupancy.json` |\n\nNo second timestamp / last-write field exists on `OccupancyRecord` — correctly parked outside v1.\n\n### Injection / swarm lens\n\n- **Holder must keep `DEFT_SESSION_ID`.** A only re-stamps when incoming id matches live (`:407`). Lost env → deny against own lease, or empty-id deny — not a silent refresh.\n- **Spawn tools skip occupancy evaluation** (`dispatcher.ts:881–882` allow stub). Parent/worktree holder must renew; child Edit in the *same* tree needs the holder id in env or is denied. Cohort worktrees with their own leases are fine.\n- **Hostile / sleepy leaf:** Shell-only worker + A-only ship = still abandoned at 20 min. That is the steal path working as designed against a mute holder — unless B (or Shell-path touch) exists.\n- **Lock contention:** synchronous heartbeat inside the PreToolUse allow path can contend with steal; debounce + best-effort + shared lock helper keep steal fail-closed and writes moving.\n- **Cross-session:** steal after TTL remains the recovery; fixing refresh stops *false* abandonment, not legitimate reclaim.\n\n### Road not taken\n\n- **Lengthen TTL / disable expiry** — masks abandonment; violates gate integrity (#3156).\n- **Rely on ritual-state staleness** (`sessionRitualStalenessHours`, default 4h) — wrong SoT; occupancy header already forbids overloading ritual-state.\n- **Git pre-commit / commit hook heartbeat only** — misses long edit sessions that have not committed yet; too sparse and tool-coupled as the sole renew path.\n- **Stamp every PreToolUse including Shell without a renew verb** — closes Shell residual without B, but couples lease I/O to every shell command and still needs debounce + best-effort; possible alternative to B, not free.\n- **Implement `occupancy:request` join** — out of scope by design; different problem.\n- **Steal reports filesystem mtime as \"last write\"** — noisy, wrong boundary; keep last-write field deferred.\n\n### Score against Directive rules\n\n| Rule | Score |\n|---|---|\n| Authority ladder | Pass if B ships as a real `task`/`deft` verb; fail if docs-only \"use session:start\" remains the sole discoverable renew. |\n| Fail-closed | Steal-on-stale is correct. Missing renew is fail-open for the *holder*. Fix renew without weakening deny. |\n| Propose-not-apply | Triage proposes; good. |\n| Claim-cites-state (#2066) | Line cites matched this SHA; good. Open critique re-verified rather than trusting triage. |\n| Gate integrity (#3156) | Do not clear the incident by editing TTL or steal policy alone. |\n| Thin fail-closed (#3265) | Prefer **one** heartbeat touch helper + **one** discoverable renew verb; docs are remediation text, not a third gate. A+B+C as three *ship items* is fine if A and B share one writer. |\n\n### Disposition\n\n**Uphold accept-as-one-story**, with v1 locked as:\n\n1. **A** — best-effort same-session lease touch on the direct-write allow path (not verdict-changing inside the pure evaluator).\n2. **B** — discoverable `occupancy:heartbeat` (or documented equivalent Shell/agents can run) — **required**, not optional, given `dispatcher.ts:1268–1273`.\n3. **C** — honest `commands.md` refresh path; no live `occupancy:request` implication.\n\nKeep holder-expiry warning and steal \"last write time\" out. Keep #3433 closed. Point Shell residual at #3438 as sibling router debt, not as an excuse to ship A without B.\n\n**design-critique: complete (open-critique).** Ready for synthesis / first-ship lock.\n\n\n### Comment by @MScottAdams (2026-08-21T17:23:57Z)\n\n## Verified synthesis (critique-pass-1, 2026-08-21)\n\n_By: Grok 4.6 (xAI) — synthesizer, not a critic in this run. Triage author was also Grok 4.6; critic was Grok 4.5. Rows marked **hold** only on a primary-source re-read of `origin/master`, not on critic agreement._\n\nHand-run of #3434 Pass 3. Not implementation. Working tree not modified.\n\n**SHA:** `522643763423b57d4ca7e9ddb551785d3a2bfb84` (`origin/master` at synthesis; critic named the same tip).\n\n**Thread note:** After triage, the issue was amended by [additional evidence](https://github.com/deftai/directive/issues/3599#issuecomment-5373040255) (`id` 5373040255). The critic’s ceiling was the triage comment (`5372982342`), so that evidence was **out of the critic’s allowed inputs**. Synthesis reads the full thread.\n\nThread: issue body; [triage](https://github.com/deftai/directive/issues/3599#issuecomment-5372982342); [additional evidence](https://github.com/deftai/directive/issues/3599#issuecomment-5373040255); [R1 critique](https://github.com/deftai/directive/issues/3599#issuecomment-5373063874).\n\n### Disposition\n\n**Accept as one story.** Keep #3433 closed. Do not decompose children.\n\n| Slice | In v1 | Out |\n|---|---|---|\n| **A** | Best-effort same-session **lease touch** on the Edit/Write allow path. Reuse `applyWorktreeOccupancy` (author showed it already heartbeats). Debounce (fraction of `OCCUPANCY_TTL_MS`). **Must not** flip `evaluateOccupancyWriteGate` allow→deny on heartbeat I/O (critic F1). | Inlining a failing write into the pure evaluator’s verdict |\n| **B** | Discoverable `occupancy:heartbeat` (or equivalent Shell/agents can run without full ceremony) wrapping the **same** helper. **Required**, not optional: Shell/MCP early-return never hits A (`dispatcher.ts:1268–1273`). | Docs-only “use session:start” as the sole renew |\n| **C** | `commands.md`: name A/B surfaces; same-session `session:start` already renews; product Shell does not. Stop implying live `occupancy:request`. | Implementing join protocol |\n| **D tombstone** | | Release currently **deletes** `.deft/occupancy.json` (`removeOccupancyFile` `:569–572`). Author’s steal-vs-release log is a **follow-up**, not this hole. |\n| Holder warning / steal last-write field | | Follow-up |\n\nAuthor evidence: `DEFT_SESSION_ID=<id> session:start` advanced `heartbeat_at` and left `claimed_at` unchanged. **No new heartbeat serializer.** Call the existing path from A and B.\n\n### Verified claims\n\n| Claim | Claimant | Verdict | Method | Evidence at `52264376` |\n|---|---|---|---|---|\n| Same-session write gate does not re-stamp | body, triage, R1 | **hold** | `git show` | `occupancy.ts:407–408` allow, no write |\n| Gate is on non-spawn product writes | body, triage, R1 | **hold** | `git show` | `dispatcher.ts:881–883` (spawn stubs allow without occupancy) |\n| `applyWorktreeOccupancy` already heartbeats | body, triage, author comment, R1 | **hold** | `git show` + author live demo | `:140–218` `heartbeatAt: now`; comment 5373040255 |\n| TTL 20 min | body, triage, R1 | **hold** | `git show` | `OCCUPANCY_TTL_MS` `:27–28` |\n| Only `occupancy:steal` is a task | body, triage, R1 | **hold** | `git show` | `tasks/occupancy.yml` steal-only |\n| `occupancy:request` named, join out of scope | triage, R1 | **hold** | `git show` | `:6` and `:102`; `commands.md:398` “remediation only” |\n| Shell never reaches occupancy gate | triage residual, R1 F2 | **hold** | `git show` | `dispatcher.ts:1268–1273` |\n| Assist-scratch skips occupancy | R1 F4 | **hold** | `git show` | `dispatcher.ts:816–842` before `:881` |\n| Release deletes the file | author comment | **hold** | `git show` | `releaseOccupancy` `:380` → `removeOccupancyFile` `:572` `containedRemove` |\n| Live session:start heartbeat demo | author comment | **unverified here** | not re-run | code path makes the demo expected |\n\n### Finding → slice\n\n| Finding | Source | Slice |\n|---|---|---|\n| Heartbeat I/O must not deny product writes | R1 F1 | **A** (post-allow / separate touch) |\n| “Do not require B if A lands” is wrong | R1 F2 | **B required** |\n| Docs already half-promise renew | R1 F3, `commands.md:398` | **C** |\n| Release is delete not tombstone | author 5373040255 | **D follow-up** |\n| `occupancy:request` false verb | triage footnote | **C** |\n\n### What the triage got right\n\nDiagnosis, TTL/steal correctness, one story, #3433 stays closed, debounce, Shell residual pointing at #3438.\n\n### What changed after triage (load-bearing)\n\n1. **Author:** refresh mechanism already works; v1 is **invoke + discover**, not a new lease format.\n2. **Critic:** A must be best-effort; B is **required** because Shell never hits the write gate. Drop “do not require B if A lands.”\n3. **Author:** tombstone/log after release is real and **out of v1**.\n\n### Out of scope here\n\nLengthening TTL. Occupancy join. Steal last-write field. Folding #3438 Shell dest-form into this PR. Tombstone file.\n\n\n### Comment by @MScottAdams (2026-08-21T17:26:53Z)\n\nScope is wider than the single incident. Surveying every `.deft/occupancy.json` in the repo (13 worktrees) found **12 orphaned mutation leases**, none released:\n\n| Worktree | Last heartbeat | Age |\n| --- | --- | --- |\n| issue-3438-shell-dest-form | 2026-08-21 17:17Z | fresh (actively held) |\n| issue-3439-cli-namespace | 2026-08-21 03:30Z | ~14h |\n| 3545-appsec… | 2026-08-20 18:10Z | ~23h |\n| 3504 / 3505 / 3514 / 3528 | 2026-08-20 | ~1.5d |\n| 3449 / 3490 / 3511 | 2026-08-19 | ~1.8d |\n| 3437 / 3462 | 2026-08-18 | ~3d |\n| 3433-occupancy-lease | 2026-08-18 00:47Z | ~3.7d |\n\nSo there are two failure modes, not one:\n\n1. **Live sessions go stale** (the original report) — nothing heartbeats during work.\n2. **Finished sessions never release** — the lease outlives the session indefinitely, so dead locks accumulate. Every one of the 12 above is a worktree that now reads as occupied by a session that no longer exists.\n\nConsequence: a new agent entering any of those worktrees must either wait out a holder that will never return or `occupancy:steal`. That normalises stealing as routine, which is how an actively-working lease (mine) got taken — the habit is rational given the state of the repo.\n\nWorth considering alongside the heartbeat fix: release on session end where detectable, and treat a lease whose heartbeat is older than some hard ceiling as reapable without `--confirm`, distinct from stealing a live one.\n\nNoting for whoever picks this up: the oldest orphan is in `3433-occupancy-lease`, the worktree where this feature was built.\n\n### Comment by @MScottAdams (2026-08-21T17:29:24Z)\n\nSplit the second failure mode out to #3604 (leases never released outside swarm completion, 12 orphans as of filing). Keeping this issue scoped to the first: a live session's lease never heartbeats during work.\n\nRoot cause found for #3604 while separating them, and it is relevant here too: `releaseOccupancy` has only two callers — a stress-test harness and `releaseSwarmOccupancy` in `swarm/complete-cohort.ts:637`. There is no session-end hook and no release verb, so a lease is released only when a swarm cohort finishes. The two issues compound: nothing marks a live session alive, and nothing marks a dead session dead.\n\n### Comment by @MScottAdams (2026-08-21T17:39:39Z)\n\nCorrecting my own comments on this thread — I posted them without reading the triage, and two of them are wrong.\n\n**My \"additional evidence\" comment (17:19) was redundant and procedurally disruptive.** The triage at 17:13 had already established the same fact from primary source: refresh via `DEFT_SESSION_ID=<id> session:start` is real and undiscoverable from `task --list`. Mine added an empirical demo of a fact already documented. Worse, it landed between triage and critique — the critic's ceiling was the triage comment, so my comment was outside its allowed inputs and the synthesizer had to reconcile an input the critic never saw. That is my error; I should not have written into a thread mid-pass.\n\n**My scope-widening comments (17:26, 17:29) contradict the disposition.** Triage said \"ready as one story… Do not decompose children.\" I then argued two failure modes and split one to #3604. I defer to the one-story disposition for THIS issue. To be clear about #3604: it is an **adjacent defect, not a decomposition of this story** — it covers leases never being released at all (`releaseOccupancy` has two callers: a stress harness and `releaseSwarmOccupancy` at `swarm/complete-cohort.ts:637`), which the triage did not cover and which no part of A/B/C addresses. If the maintainers would rather fold it in or close it as out of scope, that is fine by me.\n\n**Two points from the triage that correct me and should survive into implementation:**\n\n1. **Debounce.** My proposal omitted it. Re-stamping on every product write hammers `.deft/occupancy.json`; gating on age > a fraction of `OCCUPANCY_TTL_MS` is required, not optional.\n2. **Fix A does not cover Bash-only agents.** The triage's residual is sharper than anything I wrote: a session mutating only through Shell may never reach `evaluateOccupancyWriteGate`, so it still reads dead after the 20-minute TTL even with A. That is a direct #3438 interaction — the Shell dest-form gate only routes *recognized* dest-forms through the mutation gates, and the large fail-open surface documented on #3597 never touches it at all. So B (a discoverable refresh verb) is not merely \"cheap together\" — it is the only cover for exactly the agents most likely to run long.\n\nStanding data that I believe is still accurate and unaffected by the above: the 12 orphaned leases (surveyed 17:18Z) and the release-deletes-the-file observation. Both are recorded on #3604.\n\n### Comment by @MScottAdams (2026-08-21T17:46:23Z)\n\nFiled #3607 for the process gap this thread exposed: there is no interlock on issue threads, so an agent in another worktree can post inside an open triage/critique pass and fall outside the critic's declared ceiling. That is what happened here at 17:19 — my comment landed between triage and critique, and the synthesizer had to reconcile an input the critic was never allowed to see.\n\nWorktree occupancy (#3433) cannot cover this: it is keyed on a worktree path, so two agents holding valid leases on two different worktrees have no interlock on issue #N at all. The signal has to live on the forge to be visible to another worktree or a headless host.\n\n### Comment by @MScottAdams (2026-08-21T18:08:11Z)\n\n## Note (not a new critique pass)\n\n_By: Grok 4.6 (xAI), 2026-08-21._\n\n**Pass 1 still stands.** The [verified synthesis](https://github.com/deftai/directive/issues/3599#issuecomment-5373084952) (`5373084952`) remains the v1 lock: A best-effort write-path heartbeat (debounced; must not deny on I/O), B `occupancy:heartbeat` **required**, C honest docs. One story. Do not decompose children. Keep #3433 closed.\n\nPost-synthesis comments do **not** reopen this story. The 17:26 scope-widening (12 orphans / never-release) was [withdrawn at 17:39](https://github.com/deftai/directive/issues/3599#issuecomment-5373238573) — treat it as superseded. [#3604](https://github.com/deftai/directive/issues/3604) is adjacent (leases never released), not a child. [#3607](https://github.com/deftai/directive/issues/3607) is the thread-ceiling process gap, not occupancy heartbeat.\n\nNo second triage/critic/synthesis pass. Implement against pass 1.\n\n\n### Comment by @MScottAdams (2026-08-21T18:23:51Z)\n\nGrouped under tracker #3613 (multi-agent coordination defects: lease liveness, lease lifecycle, issue-thread interlock).\n\nTo be explicit, since it touches the triage disposition: grouping does **not** decompose this issue. The `status:child` label records that it has a parent in the issue graph; the \"ready as one story — do not decompose children\" verdict stands unchanged.\n\n### Comment by @MScottAdams (2026-08-25T15:30:48Z)\n\nmodel: claude-opus-5-thinking-high-fast\nrole: parent\n\n## Companion filed: #3729 -- the non-claimant half\n\nReproduced this issue's core mechanism from a different direction and filed the complementary case.\n\nThis issue is the **owner-side** defect: a session that claimed correctly has `heartbeat_at` go stale during active work and gets legitimately stolen. **#3729** is the **non-claimant** case: `evaluateOccupancyWriteGate` returns `allow: true` whenever `liveOccupant` is `null` (`occupancy.ts:404`), so an actor that never claimed is never gated at all.\n\nThey compound rather than duplicate. This issue guarantees leases go stale; #3729 is why staleness means *no protection* instead of a warning. Refreshing a heartbeat that was never written does not help the non-claimant case, so #3599's fix leaves it untouched.\n\nFresh evidence supporting the heartbeat claim here, from a session on `C:\\Repos\\deft\\directive`:\n\n- The lease found at session start was **21 hours** past its `heartbeat_at` (`2026-08-24T23:14:37Z`, session `b71f5825`), against `OCCUPANCY_TTL_MS = 20 * 60 * 1000` (`occupancy.ts:28`).\n- Confirmed by grep that no occupancy heartbeat caller exists in `packages/core/src` or `packages/cli/src` -- every `heartbeat` hit belongs to the sub-agent monitor (#1365), a separate mechanism.\n\nSo the 21-hour record is consistent with this issue's diagnosis: a session that claimed properly and was never refreshed.",
+      "Labels": "bug, swarm, patterns:multi-agent, dogfood, status:child"
+    },
+    "items": [
+      {
+        "title": "Re-stamp `heartbeat_at` in `evaluateOccupancyWriteGate`'s same-session branch (guard",
+        "status": "proposed"
+      },
+      {
+        "title": "Expose `occupancy:heartbeat` (or `occupancy:renew`) as a task/CLI verb so refresh is",
+        "status": "proposed"
+      },
+      {
+        "title": "Document the refresh path in `.deft/core/commands.md` § Session routing alongside",
+        "status": "proposed"
+      },
+      {
+        "title": "Warn the holder when its own lease is within the staleness window rather than letting it",
+        "status": "proposed"
+      },
+      {
+        "title": "Consider requiring `occupancy:steal --confirm` to report the occupant's last *write*",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "swarm",
+      "patterns:multi-agent",
+      "dogfood",
+      "status:child"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3599",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3599: fix(session): occupancy lease never heartbeats during active work, so a working session gets stolen (#3433)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3433",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3433"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [
+        {
+          "command": "* occupancy:steal:   Supersede a live worktree occupancy lease (#3433). Flags: --confirm --occupant <id>",
+          "reason": "shell metacharacter \"(\" is not allowed in literal AC commands",
+          "sourceSpan": "fence@L50"
+        }
+      ],
+      "swarm": {},
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 26 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "`resolveOccupancySessionId` (`occupancy.ts:106`) consults `DEFT_SESSION_ID`",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "`applyWorktreeOccupancy` (`occupancy.ts:140`) treats an incoming id equal to the live",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "Document the refresh path in `.deft/core/commands.md` § Session routing alongside",
+          "artifact_path": ".deft/core/commands.md",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "Re-read `.deft/occupancy.json` — `heartbeat_at` is unchanged",
+          "artifact_path": ".deft/occupancy.json",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "Same-session write allow does not re-stamp (`evaluateOccupancyWriteGate` `occupancy.ts:394–408`: identity match → `{ allow: true }` with no `heartbeatAt` write). Line numbers in the body match this SHA’s structure.",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "That function is on the product-write path (`hooks/dispatcher.ts:883`).",
+          "artifact_path": "hooks/dispatcher.ts:883",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "That function is on the product-write path (`hooks/dispatcher.ts:883`). [reading: hooks/dispatcher.ts:883]",
+              "artifact_path": "hooks/dispatcher.ts:883"
+            },
+            {
+              "text": "That function is on the product-write path (`hooks/dispatcher.ts:883`). [reading: hooks/dispatcher.ts]",
+              "artifact_path": "hooks/dispatcher.ts"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        },
+        {
+          "id": 7,
+          "text": "Same-session `session:start` / `applyWorktreeOccupancy` already heartbeats (`occupancy.ts:140–218`). The hole is the write gate, not claim.",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 8,
+          "text": "Documented occupancy verbs: `tasks/occupancy.yml` exposes only `occupancy:steal`. `occupancy:heartbeat` / `occupancy:renew` do not exist. Refresh via `DEFT_SESSION_ID=<id> session:start` is real (`resolveOccupancySessionId` `:106` + same-id branch of `applyWorktreeOccupancy`) and undiscoverable from `task --list`.",
+          "artifact_path": "tasks/occupancy.yml",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 9,
+          "text": "Defect is real and correctly located. Same-session allow in `evaluateOccupancyWriteGate` returns without writing (`occupancy.ts:407–408`). Reproduced: that branch is `return { allow: true, message: null, occupant: live }` with no `heartbeatAt` / `writeOccupancyRecord` call.",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 10,
+          "text": "Product-write wiring holds. Non-spawn mutation path calls the gate at `hooks/dispatcher.ts:881–883`.",
+          "artifact_path": "hooks/dispatcher.ts:881–883",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "Product-write wiring holds. Non-spawn mutation path calls the gate at `hooks/dispatcher.ts:881–883`. [reading: hooks/dispatcher.ts:881–883]",
+              "artifact_path": "hooks/dispatcher.ts:881–883"
+            },
+            {
+              "text": "Product-write wiring holds. Non-spawn mutation path calls the gate at `hooks/dispatcher.ts:881–883`. [reading: hooks/dispatcher.ts]",
+              "artifact_path": "hooks/dispatcher.ts"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        },
+        {
+          "id": 11,
+          "text": "Claim/heartbeat path already exists and is separate. `applyWorktreeOccupancy` same-session write path re-stamps `heartbeatAt: now` (`occupancy.ts:140–218`, esp. `:202`). `session:start` / `session:ready` already go through that path. The hole is the write gate, not claim.",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 12,
+          "text": "Discoverability claim holds (reproduced claimant method). `tasks/occupancy.yml` exposes only `steal`. Live `task --list` shows only `occupancy:steal`. No `occupancy:heartbeat` / `occupancy:renew` task. Same-session renew via `DEFT_SESSION_ID=<id> session:start` is real (`resolveOccupancySessionId` `:106` + same-id branch of `applyWorktreeOccupancy`) and not listed as an occupancy verb.",
+          "artifact_path": "tasks/occupancy.yml",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 13,
+          "text": "False-surface footnote holds. Remediation names `occupancy:request` (`:102`) while the module header says join is out of scope (`:6`). `commands.md` Session routing already admits join is \"named in the remediation only\" (`content/commands.md:398` at this SHA).",
+          "artifact_path": "commands.md",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "False-surface footnote holds. Remediation names `occupancy:request` (`:102`) while the module header says join is out of scope (`:6`). `commands.md` Session routing already admits join is \"named in the remediation only\" (`content/commands.md:398` at this SHA). [reading: commands.md]",
+              "artifact_path": "commands.md"
+            },
+            {
+              "text": "False-surface footnote holds. Remediation names `occupancy:request` (`:102`) while the module header says join is out of scope (`:6`). `commands.md` Session routing already admits join is \"named in the remediation only\" (`content/commands.md:398` at this SHA). [reading: content/commands.md:398]",
+              "artifact_path": "content/commands.md:398"
+            },
+            {
+              "text": "False-surface footnote holds. Remediation names `occupancy:request` (`:102`) while the module header says join is out of scope (`:6`). `commands.md` Session routing already admits join is \"named in the remediation only\" (`content/commands.md:398` at this SHA). [reading: content/commands.md]",
+              "artifact_path": "content/commands.md"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        },
+        {
+          "id": 14,
+          "text": "Today `evaluateOccupancyWriteGate` is allow/deny only (`:394–413`); sole caller is the dispatcher (`dispatcher.ts:883`). Tests assert allow/deny only (`occupancy.test.ts` write-gate cases).",
+          "artifact_path": "occupancy.test.ts",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "Today `evaluateOccupancyWriteGate` is allow/deny only (`:394–413`); sole caller is the dispatcher (`dispatcher.ts:883`). Tests assert allow/deny only (`occupancy.test.ts` write-gate cases). [reading: occupancy.test.ts]",
+              "artifact_path": "occupancy.test.ts"
+            },
+            {
+              "text": "Today `evaluateOccupancyWriteGate` is allow/deny only (`:394–413`); sole caller is the dispatcher (`dispatcher.ts:883`). Tests assert allow/deny only (`occupancy.test.ts` write-gate cases). [reading: dispatcher.ts]",
+              "artifact_path": "dispatcher.ts"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        },
+        {
+          "id": 15,
+          "text": "Reproduced: `decideHook` early-returns Shell/Bash/MCP through `decideShellOrMcpRuntimeAuthority` at `dispatcher.ts:1268–1273` and never reaches `inspectMutationGates` / `evaluateOccupancyWriteGate`.",
+          "artifact_path": "dispatcher.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 16,
+          "text": "`content/commands.md:398` says \"Same-session re-arm heartbeats\" — true for `session:start` re-arm, easy to misread as \"active work keeps the lease\".",
+          "artifact_path": "content/commands.md:398",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "`content/commands.md:398` says \"Same-session re-arm heartbeats\" — true for `session:start` re-arm, easy to misread as \"active work keeps the lease\". [reading: content/commands.md:398]",
+              "artifact_path": "content/commands.md:398"
+            },
+            {
+              "text": "`content/commands.md:398` says \"Same-session re-arm heartbeats\" — true for `session:start` re-arm, easy to misread as \"active work keeps the lease\". [reading: content/commands.md]",
+              "artifact_path": "content/commands.md"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        },
+        {
+          "id": 17,
+          "text": "[footnote] Assist-scratch early-return also skips the occupancy gate (`dispatcher.ts:816–842` → allow `write-assist-scratch-ready` before `:881`). Not the incident class; do not expand v1 to scratch. Note it so A is not marketed as \"every PreToolUse write\".",
+          "artifact_path": "dispatcher.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 18,
+          "text": "[footnote] `OCCUPANCY_JOIN_PROTOCOLS` includes `heartbeat-file` / `parent-message` (`occupancy.ts:31`) but join remains out of scope. Do not revive join protocol as this story's vehicle; keep A/B as lease touch, not join negotiation.",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 19,
+          "text": "Spawn tools skip occupancy evaluation (`dispatcher.ts:881–882` allow stub). Parent/worktree holder must renew; child Edit in the *same* tree needs the holder id in env or is denied. Cohort worktrees with their own leases are fine.",
+          "artifact_path": "dispatcher.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 20,
+          "text": "B — discoverable `occupancy:heartbeat` (or documented equivalent Shell/agents can run) — required, not optional, given `dispatcher.ts:1268–1273`.",
+          "artifact_path": "dispatcher.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 21,
+          "text": "C — honest `commands.md` refresh path; no live `occupancy:request` implication.",
+          "artifact_path": "commands.md",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 22,
+          "text": "*SHA: `522643763423b57d4ca7e9ddb551785d3a2bfb84` (`origin/master` at synthesis; critic named the same tip).",
+          "artifact_path": "origin/master",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 23,
+          "text": "*My scope-widening comments (17:26, 17:29) contradict the disposition. Triage said \"ready as one story… Do not decompose children.\" I then argued two failure modes and split one to #3604. I defer to the one-story disposition for THIS issue. To be clear about #3604: it is an adjacent defect, not a decomposition of this story — it covers leases never being released at all (`releaseOccupancy` has two callers: a stress harness and `releaseSwarmOccupancy` at `swarm/complete-cohort.ts:637`), which the triage did not cover and which no part of A/B/C addresses. If the maintainers would rather fold it in or close it as out of scope, that is fine by me.",
+          "artifact_path": "swarm/complete-cohort.ts:637",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "*My scope-widening comments (17:26, 17:29) contradict the disposition. Triage said \"ready as one story… Do not decompose children.\" I then argued two failure modes and split one to #3604. I defer to the one-story disposition for THIS issue. To be clear about #3604: it is an adjacent defect, not a decomposition of this story — it covers leases never being released at all (`releaseOccupancy` has two callers: a stress harness and `releaseSwarmOccupancy` at `swarm/complete-cohort.ts:637`), which the triage did not cover and which no part of A/B/C addresses. If the maintainers would rather fold it in or close it as out of scope, that is fine by me. [reading: swarm/complete-cohort.ts:637]",
+              "artifact_path": "swarm/complete-cohort.ts:637"
+            },
+            {
+              "text": "*My scope-widening comments (17:26, 17:29) contradict the disposition. Triage said \"ready as one story… Do not decompose children.\" I then argued two failure modes and split one to #3604. I defer to the one-story disposition for THIS issue. To be clear about #3604: it is an adjacent defect, not a decomposition of this story — it covers leases never being released at all (`releaseOccupancy` has two callers: a stress harness and `releaseSwarmOccupancy` at `swarm/complete-cohort.ts:637`), which the triage did not cover and which no part of A/B/C addresses. If the maintainers would rather fold it in or close it as out of scope, that is fine by me. [reading: swarm/complete-cohort.ts]",
+              "artifact_path": "swarm/complete-cohort.ts"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        },
+        {
+          "id": 24,
+          "text": "Debounce. My proposal omitted it. Re-stamping on every product write hammers `.deft/occupancy.json`; gating on age > a fraction of `OCCUPANCY_TTL_MS` is required, not optional.",
+          "artifact_path": ".deft/occupancy.json",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 25,
+          "text": "The lease found at session start was 21 hours past its `heartbeat_at` (`2026-08-24T23:14:37Z`, session `b71f5825`), against `OCCUPANCY_TTL_MS = 20 * 60 * 1000` (`occupancy.ts:28`).",
+          "artifact_path": "occupancy.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 26,
+          "text": "Confirmed by grep that no occupancy heartbeat caller exists in `packages/core/src` or `packages/cli/src` -- every `heartbeat` hit belongs to the sub-agent monitor (#1365), a separate mechanism.",
+          "artifact_path": "packages/core/src",
+          "ambiguous": true,
+          "readings": [
+            {
+              "text": "Confirmed by grep that no occupancy heartbeat caller exists in `packages/core/src` or `packages/cli/src` -- every `heartbeat` hit belongs to the sub-agent monitor (#1365), a separate mechanism. [reading: packages/core/src]",
+              "artifact_path": "packages/core/src"
+            },
+            {
+              "text": "Confirmed by grep that no occupancy heartbeat caller exists in `packages/core/src` or `packages/cli/src` -- every `heartbeat` hit belongs to the sub-agent monitor (#1365), a separate mechanism. [reading: packages/cli/src]",
+              "artifact_path": "packages/cli/src"
+            }
+          ],
+          "chosen_reading": 0,
+          "provenance": "statement"
+        }
+      ]
+    }
+  }
+}

--- a/xbrief/proposed/2026-08-25-3718-bugswarm-swarmlaunch-is-unreachable-for-a-freshly-triaged-st.xbrief.json
+++ b/xbrief/proposed/2026-08-25-3718-bugswarm-swarmlaunch-is-unreachable-for-a-freshly-triaged-st.xbrief.json
@@ -1,0 +1,166 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3718"
+  },
+  "plan": {
+    "title": "bug(swarm): swarm:launch is unreachable for a freshly-triaged story -- readiness needs 15 hand-authored fields and file_scope collides with the provenance gate",
+    "status": "proposed",
+    "narratives": {
+      "Description": "bug(swarm): swarm:launch is unreachable for a freshly-triaged story -- readiness needs 15 hand-authored fields and file_scope collides with the provenance gate",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3718",
+      "Overview": "## Problem\n\n`swarm:launch` cannot accept a freshly-triaged story. The artifact `triage:accept` produces is rejected by `swarm:readiness` on fifteen fields, no verb or skill bridges the gap, and the one field that would bridge it — `file_scope` — triggers a separate enforced gate that demands a prior merged PR and a human TTY.\n\nThe result is that the sanctioned batch-launch path is unreachable for exactly the work most likely to need it: a cohort of newly-accepted issues.\n\n## Reproduction, tonight, six stories\n\nIssues #3666, #3673, #3679, #3690, #3712, #3713. All accepted via `triage:accept`, promoted, and activated.\n\n**First failure** — `swarm:launch --stories …` against `pending/`:\n\n```\nError: could not resolve every cohort member:\n  - #3666: no active story references this issue.\n```\n\n`swarm:launch` requires `active/`, not `pending/`. Nothing says so before you run it.\n\n**Second failure** — after `scope:activate` on all six:\n\n```\nError: story '…3666…' is not launch-ready -- swarm:readiness gate failed:\nMissing fields: plan.metadata.kind=story, plan.id, plan.narratives.ImplementationPlan,\nplan.narratives.UserStory, plan.items[].narrative.Acceptance,\nplan.metadata.swarm.readiness=ready for concurrent allocation,\nplan.metadata.swarm.parallel_safe, plan.metadata.swarm.file_scope,\nplan.metadata.swarm.verify_commands, plan.metadata.swarm.expected_outputs,\nplan.metadata.swarm.depends_on, plan.metadata.swarm.conflict_group,\nplan.metadata.swarm.size, plan.metadata.swarm.file_scope_confidence,\nplan.metadata.swarm.model_tier, Traces or missing_traces_justification\n```\n\nEvery story, all fifteen fields. Meanwhile `task xbrief:preflight` exits **0** on the same artifacts — \"ready for implementation.\"\n\nSo two gates disagree about whether the same brief is buildable, and the one that says yes is the one the intent gate uses.\n\n## Nothing produces the metadata\n\nThe shape is documented — `content/vbrief/vbrief.md` § Swarm-Ready Story Contract gives the full `plan.metadata.swarm` block. What is missing is anything that writes it for a story-sized issue:\n\n- `triage:accept` emits narratives, items, and acceptance clauses, and no `swarm` block at all.\n- `deft-directive-refinement` covers ingest, evaluate, reconcile, promote/demote, prioritize, and prompts for `effort` on accept (#1581). It never touches `plan.metadata.swarm`.\n- `deft-directive-decompose` is scoped to \"a specification, Phase 4 implementation scope, or epic xBRIEF … too broad for direct concurrent swarm work.\" A one-sentence documentation fix is not too broad. `packages/core/src/scope/decompose.ts` only *validates* `file_scope` quality (`BROAD_FILE_SCOPE_ROOTS`); it does not generate the block.\n- There is no `swarm:*` scaffolding verb in the CLI help.\n\nThe only path is hand-authoring fifteen fields per story, and nothing in the flow tells an operator that is the expectation.\n\n## The `file_scope` requirement collides with an enforced gate\n\nThis is the part that makes hand-authoring insufficient rather than merely tedious.\n\n`swarm:readiness` **requires** a non-empty `file_scope`. But `verify:scope-provenance` — which runs in the required merge gate via `task check:merge` (`Taskfile.yml:435`, `ci.yml:119`/`:388`) — fails closed on a declared non-empty `file_scope` with no base-committed approval. Recording that approval requires a separate merged PR *and* `scope:record-approved-scope`, which needs a real TTY and refuses agent shells.\n\nSo satisfying `swarm:readiness` obligates, per story: author the block, mint approval at a human terminal, land an approval-only PR, then launch. For a six-story cohort that is six mints and an approval PR before any work starts.\n\nThe corpus shows nobody does this. Of 1309 completed briefs, 616 declare a `file_scope` and **4** approval records exist. Empty `file_scope` soft-warns past the provenance gate — which `content/docs/scope-provenance.md:136` names as the anti-pattern that removes the fence — but it also fails `swarm:readiness`. There is no value of `file_scope` that satisfies both gates without the two-PR bootstrap.\n\n## Why it matters\n\nAGENTS.md (#3032) requires through-merge story work to be dispatched via the swarm or solo-worker launch path, cohort size 1 included. When `swarm:launch` is unreachable, every operator falls back to hand-rolled worktrees — which is what happened tonight for all six stories, and what happened earlier for #3708. The sanctioned path is the one nobody can use, so the unsanctioned one becomes the norm and its correctness is re-derived by each operator.\n\n## Candidate directions\n\nNot selecting one.\n\n- A scaffolding verb that fills the swarm block from an accepted brief, leaving the operator to correct it.\n- Relax `swarm:readiness` where a field is not load-bearing for the launch it is gating, rather than requiring all fifteen for a solo cohort.\n- Reconcile the `file_scope` requirement with the provenance gate so the two are jointly satisfiable without a per-story two-PR bootstrap.\n- Make `swarm:launch` accept `pending/` and activate as part of launch, or say plainly at the point of failure that activation comes first.\n- Decide that hand-authoring is intended, and put that expectation somewhere an operator meets before the second failed command.\n\n## Related\n\n- **#3666** — a sequential story has no launchable configuration; adjacent, currently in build. This issue is the freshly-triaged-story case rather than the sequential-vs-parallel one.\n- **#3715** — the fence engages for 4 of 600 declared scopes. The `file_scope` half of this issue is a concrete instance of why declaration is avoided.\n- **#3714** — surfacing the approval obligation before implementation.\n- **#3717** — recut issues leave scaffolds stale; same scaffold, different defect.\n\n## Acceptance\n\n- [ ] A freshly-accepted story can reach `swarm:launch` without hand-authoring fifteen fields, or the requirement to do so is stated where the operator meets it\n- [ ] `swarm:readiness` and `verify:scope-provenance` are jointly satisfiable without a per-story approval PR and TTY mint\n- [ ] `swarm:launch` failing on a `pending/` brief says activation is the prerequisite\n- [ ] `xbrief:preflight` and `swarm:readiness` no longer disagree silently about the same artifact, or the difference is explained where both are used\n- [ ] No gate weakened purely to make launch succeed (#3156)\n- [ ] CHANGELOG `[Unreleased]` entry\n\nRefs #3032, #3145, #3205.\n\n",
+      "Labels": "bug, agent-experience, process"
+    },
+    "items": [
+      {
+        "title": "A freshly-accepted story can reach `swarm:launch` without hand-authoring fifteen fields, or the requirement to do so is stated where the operator meets it",
+        "status": "proposed"
+      },
+      {
+        "title": "`swarm:readiness` and `verify:scope-provenance` are jointly satisfiable without a per-story approval PR and TTY mint",
+        "status": "proposed"
+      },
+      {
+        "title": "`swarm:launch` failing on a `pending/` brief says activation is the prerequisite",
+        "status": "proposed"
+      },
+      {
+        "title": "`xbrief:preflight` and `swarm:readiness` no longer disagree silently about the same artifact, or the difference is explained where both are used",
+        "status": "proposed"
+      },
+      {
+        "title": "No gate weakened purely to make launch succeed (#3156)",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG `[Unreleased]` entry",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "process"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3718",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3718: bug(swarm): swarm:launch is unreachable for a freshly-triaged story -- readiness needs 15 hand-authored fields and file_scope collides with the provenance gate"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3032",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3032"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [
+        {
+          "command": "- #3666: no active story references this issue",
+          "reason": "first token \"-\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L15"
+        },
+        {
+          "command": "plan.narratives.UserStory, plan.items[].narrative.Acceptance,",
+          "reason": "first token \"plan.narratives.userstory,\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "plan.metadata.swarm.readiness=ready for concurrent allocation,",
+          "reason": "first token \"plan.metadata.swarm.readiness=ready\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "plan.metadata.swarm.parallel_safe, plan.metadata.swarm.file_scope,",
+          "reason": "first token \"plan.metadata.swarm.parallel_safe,\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "plan.metadata.swarm.verify_commands, plan.metadata.swarm.expected_outputs,",
+          "reason": "first token \"plan.metadata.swarm.verify_commands,\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "plan.metadata.swarm.depends_on, plan.metadata.swarm.conflict_group,",
+          "reason": "first token \"plan.metadata.swarm.depends_on,\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "plan.metadata.swarm.size, plan.metadata.swarm.file_scope_confidence,",
+          "reason": "first token \"plan.metadata.swarm.size,\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "plan.metadata.swarm.model_tier, Traces or missing_traces_justification",
+          "reason": "first token \"plan.metadata.swarm.model_tier,\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L24"
+        },
+        {
+          "command": "task check:merge",
+          "reason": "wrapper subcommand must be check|doctor|verify:*|help|--version (scope/policy/swarm/scm/merge and other ambient-authority verbs denied)",
+          "sourceSpan": "inline@L55"
+        }
+      ],
+      "swarm": {},
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 6 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "A freshly-accepted story can reach `swarm:launch` without hand-authoring fifteen fields, or the requirement to do so is stated where the operator meets it",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "`swarm:readiness` and `verify:scope-provenance` are jointly satisfiable without a per-story approval PR and TTY mint",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "`swarm:launch` failing on a `pending/` brief says activation is the prerequisite",
+          "artifact_path": "pending/",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "`xbrief:preflight` and `swarm:readiness` no longer disagree silently about the same artifact, or the difference is explained where both are used",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "No gate weakened purely to make launch succeed (#3156)",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "CHANGELOG `[Unreleased]` entry",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    }
+  }
+}

--- a/xbrief/proposed/2026-08-25-3729-bugsession-the-occupancy-lease-is-exclusion-only-an-agent-th.xbrief.json
+++ b/xbrief/proposed/2026-08-25-3729-bugsession-the-occupancy-lease-is-exclusion-only-an-agent-th.xbrief.json
@@ -1,0 +1,117 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3729"
+  },
+  "plan": {
+    "title": "bug(session): the occupancy lease is exclusion-only -- an agent that never claims is never gated",
+    "status": "proposed",
+    "narratives": {
+      "Description": "bug(session): the occupancy lease is exclusion-only -- an agent that never claims is never gated",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3729",
+      "Overview": "## Problem\n\nThe worktree occupancy lease is **exclusion-only**. It blocks you if someone *else* holds a live lease. Nothing requires a mutating actor to hold one. An agent that never claims is never blocked, never blocks anyone, and is invisible to the mechanism.\n\nCombined with #3599, the protection is self-disabling: after 20 minutes no lease is live, so the gate permits everything from everyone.\n\n## Root cause\n\n`packages/core/src/session/occupancy.ts:394-415`:\n\n```ts\nconst live = liveOccupant(projectRoot, now);\nif (live === null) return { allow: true, message: null, occupant: null };\n```\n\n`liveOccupant` (`:130-138`) returns `null` when the record is absent **or expired**, and `OCCUPANCY_TTL_MS = 20 * 60 * 1000` (`:28`). So the gate has exactly two failure-open paths — nobody ever claimed, or the claim aged out — and both resolve to `allow: true` for any actor.\n\nThere is no counterpart check anywhere: nothing asks \"is *this* actor holding a lease before it mutates.\" Claiming happens only inside `session:start` / `session:ready`, which an agent reaches only by entering the mutation ceremony deliberately. Skipping the ceremony skips the claim, and skipping the claim costs nothing.\n\n## Measured\n\nThis session, on `C:\\Repos\\deft\\directive`:\n\n- The parent ran roughly **14 hours** of mutation work — merges, force-pushes, rebases, issue writes, ~14 agent dispatches — **without ever claiming a lease**. It never ran `session:start`.\n- The lease file held a **21-hour-old** record from a different session (`b71f5825`, heartbeat `2026-08-24T23:14:37Z`). Long expired, so `liveOccupant` returned `null` and every write was permitted.\n- **Six of seven** subagent worktrees have no `.deft/occupancy.json` at all. Only `b3666` claimed one. Nothing in the dispatch envelope asked them to, and one did it anyway — so the capability is reachable and its use is incidental.\n- `plan.policy.hostHooks` is `{\"cursor\": true, ...}`, so the write gate **was active the whole time**. It had nothing to enforce against.\n\nUp to six concurrent mutating workers plus the parent is precisely the shape #3433 exists to guard. Nothing collided, but only because each worker had its own worktree and the parent serialised merges by hand. That is construction, not enforcement.\n\n## Relationship to #3599\n\nSame function, different half, and the remedies do not overlap.\n\n- **#3599** is the *owner-side* defect: a session that correctly claimed has its heartbeat go stale during active work and gets legitimately stolen. Its fix is to refresh `heartbeat_at` on owner writes.\n- **This issue** is the *non-claimant* case: an actor that never claimed is never gated. #3599's fix does not touch it — refreshing a heartbeat that was never written changes nothing, and the six unclaimed worktrees here would behave identically after #3599 lands.\n\nThey compound. #3599 guarantees leases go stale; this issue guarantees staleness means no protection rather than a warning.\n\n## What is genuinely open\n\nNot selecting a direction.\n\n- Should mutation without a held lease be **denied**, or **warned**? Denying is a new fail-closed gate on every product write and would have blocked this entire session; that may be correct or may be intolerable.\n- Should workers claim leases on their own worktrees at all? Worktree isolation already prevents collision in the common case. If the lease is only meaningful for shared trees, say so and stop implying broader coverage.\n- Should the dispatch envelope require it? Nothing in `agent-prompt-preamble.md` mentions occupancy, which is why six of seven workers skipped it.\n- Is a 20-minute TTL right for agent sessions that routinely run for hours? The TTL was presumably sized for human sessions.\n\n## Constraint\n\nDo not make this a fail-closed gate on every product-path write without weighing the cost. A gate that denies writes whenever a lease is missing would have stopped every piece of work in this session, including the work that fixed other gates. If the answer is enforcement, it needs a migration posture, not a flag flip (#3156).\n\n## Acceptance\n\n- [ ] An agent mutating a worktree without holding its lease is detectable — denied or warned, decided deliberately\n- [ ] The dispatch path tells workers whether they are expected to claim, and they do so consistently\n- [ ] The TTL is justified against how long agent sessions actually run, or made configurable\n- [ ] Documentation stops implying the lease protects a worktree when it protects only against live claimants\n- [ ] Whatever lands is coherent with #3599's owner-side fix rather than duplicating it\n- [ ] CHANGELOG `[Unreleased]` entry\n\nRefs #3433, #3599, #954.\n\n",
+      "Labels": "bug, agent-experience, process"
+    },
+    "items": [
+      {
+        "title": "An agent mutating a worktree without holding its lease is detectable — denied or warned, decided deliberately",
+        "status": "proposed"
+      },
+      {
+        "title": "The dispatch path tells workers whether they are expected to claim, and they do so consistently",
+        "status": "proposed"
+      },
+      {
+        "title": "The TTL is justified against how long agent sessions actually run, or made configurable",
+        "status": "proposed"
+      },
+      {
+        "title": "Documentation stops implying the lease protects a worktree when it protects only against live claimants",
+        "status": "proposed"
+      },
+      {
+        "title": "Whatever lands is coherent with #3599's owner-side fix rather than duplicating it",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG `[Unreleased]` entry",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "process"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3729",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3729: bug(session): the occupancy lease is exclusion-only -- an agent that never claims is never gated"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3433",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3433"
+      }
+    ],
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 6 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "An agent mutating a worktree without holding its lease is detectable — denied or warned, decided deliberately",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "The dispatch path tells workers whether they are expected to claim, and they do so consistently",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "The TTL is justified against how long agent sessions actually run, or made configurable",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "Documentation stops implying the lease protects a worktree when it protects only against live claimants",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "Whatever lands is coherent with #3599's owner-side fix rather than duplicating it",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "CHANGELOG `[Unreleased]` entry",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "metadata": {
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    }
+  }
+}

--- a/xbrief/proposed/2026-08-25-3736-perfhooks-every-write-re-runs-the-full-gated-ritual-11s-and.xbrief.json
+++ b/xbrief/proposed/2026-08-25-3736-perfhooks-every-write-re-runs-the-full-gated-ritual-11s-and.xbrief.json
@@ -1,0 +1,50 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3736"
+  },
+  "plan": {
+    "title": "perf(hooks): every write re-runs the full gated ritual (~11s), and a merge makes the next write time out and fail closed",
+    "status": "proposed",
+    "narratives": {
+      "Description": "perf(hooks): every write re-runs the full gated ritual (~11s), and a merge makes the next write time out and fail closed",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3736",
+      "Overview": "## Summary\n\nEvery write and every spawn re-runs the **full gated session ritual** inside the `tool.before` hook. Measured cost is **~11 seconds per write** on the happy path, against a 30-second fail-closed timeout. After anything that moves git HEAD -- a merge, a rebase, a pull -- the ritual goes stale and the next write inherits the **cold ceremony path, measured at 48-57s**, which blows the timeout. Because the matcher is `failClosed: true`, the timeout is delivered to the agent as a denial.\n\nThis is not a maintainer-only concern. Consumers run the same deposit with the same timeout.\n\n## Measurements\n\nAll on `origin/master` `71bf8216`, Windows, warm cache, ritual green.\n\n| Probe | Latency | Verdict |\n|---|---|---|\n| `tool.before` with a **Write** payload | **11.2s / 11.2s / 11.3s** | `allow` / `write-ready` |\n| `tool.before` with a **Task/spawn** payload | **9.3s** | `allow` / `spawn-ready` |\n| `tool.before` with a **Shell** payload | **0.5s / 0.5s** | `allow` / `shell-op-unclassifiable` |\n| `verify:session-ritual -- --tier=gated` alone | **8.9s / 8.8s** | exit 0 |\n| `session:ready` (cold path) | **48s**, **57s** | -- |\n\nThe ritual accounts for essentially all of the write cost. Shell short-circuits **before** the ritual, which is why it is fast -- and why it is the only escape hatch when the gate misbehaves.\n\n## Cause\n\n`packages/core/src/hooks/dispatcher.ts` re-runs the gated ritual on every matched call, and deliberately refuses to trust a cached pass:\n\n```ts\n// Mutation dispatch is a live gated boundary: active verification reruns\n// non-cacheable agent-hook readiness instead of trusting persisted success.\nritual = verifySessionRitual(projectRoot, {\n  tier: \"gated\", posture: \"mutation\", bypass: false,\n});\n```\n\nThe non-cacheable part live-probes all four host hook registrations on **every** write. The timeout was sized against this: the deposit comment says Cursor's `tool.before` timeout sits *\"above the gated-ritual / live agent-hook readiness budget\"* (`CURSOR_TOOL_BEFORE_TIMEOUT_SECONDS`, #3246). That sizing holds for the warm path at 11s. It does not hold for the cold path at 48-57s.\n\n## The failure I hit\n\nTurned hooks on in this repo. Worked for about ten minutes, then an ordinary file write returned:\n\n```\nTool blocked because this hook is configured to fail closed.\nHook \"deft-hook --host cursor --event tool.before\" timed out after 30s.\n```\n\nI had just merged two PRs and pulled master. HEAD moved discontinuously, the ritual staled (`\"stale because git HEAD changed discontinuously ... full cold ceremony required\"`), and the next write inherited the cold evaluation.\n\n**The gate is incompatible with the merge step of the workflow it governs.** Merging is ordinary agent work, it is the one action guaranteed to move HEAD, and it reliably poisons the following write. A `drive-to: merge-ready` worker does exactly this by design.\n\n## Consumer cost\n\nAt ~11.2s of pure gate latency per write, with no caching between calls:\n\n| Writes in a session | Added clock time |\n|---|---|\n| 20 | ~3.7 min |\n| 50 | ~9.3 min |\n| 100 | ~19 min |\n| 200 | ~37 min |\n\nThat is wall time the consumer pays and cannot see the reason for. The matcher covers `Edit`, `Write`, `WriteFile`, `CreateFile`, `MultiEdit`, `NotebookEdit`, `StrReplace`, `SearchReplace`, `Delete`, `DeleteFile`, `ApplyPatch`, `apply_patch` -- i.e. essentially all file authoring.\n\n## Two distinct defects\n\n1. **Cost.** An unbounded readiness computation sits on the synchronous path of every write, uncached by design. Even when it succeeds it is a ~11s tax per edit.\n2. **Correctness of the failure mode.** `failClosed: true` renders a *timeout* indistinguishable from a *policy refusal*. A timeout is not a policy decision. An agent cannot tell \"you are not allowed to write\" from \"the check did not finish\", and neither can a consumer reading the message.\n\n## Directions (not a design)\n\n- Cache the ritual verdict for the session and invalidate on the events that actually matter (HEAD change, compact, policy edit) rather than re-deriving per call.\n- Or evaluate at `sessionStart` only, and keep `tool.before` to the cheap policy checks -- occupancy, scope, intent ceiling -- that do not require probing host registrations.\n- Or separate the two failure modes: fail **open** on timeout with a loud warning, keep fail-closed for genuine denials. A gate that cannot answer in time has not decided anything.\n- If the live agent-hook probe must stay non-cacheable, bound it explicitly and report which sub-check exceeded its budget.\n\n## Notes\n\nRecovery when it fires: the hook config is already loaded by the host, so deleting `.cursor/hooks.json` does **not** disable it mid-session -- it makes things worse, because the ritual's `agent_hooks` step then fails and every write is denied for a new reason. The way out is to re-deposit through the shell and re-run the ritual. Shell being ungated is load-bearing for recovery and appears incidental.\n\nRelated: #3732 (where this surfaced, and which should keep the doctor-vs-ritual reconciliation question), #3246 (timeout sizing), #3611.\n\n"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3736",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3736: perf(hooks): every write re-runs the full gated ritual (~11s), and a merge makes the next write time out and fail closed"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [
+        {
+          "command": "Hook \"deft-hook --host cursor --event tool.before\" timed out after 30s",
+          "reason": "first token \"hook\" is not in the literal-AC allowlist",
+          "sourceSpan": "fence@L41"
+        },
+        {
+          "command": "verify:session-ritual -- --tier=gated",
+          "reason": "inline backtick in prose is a mention, not a stated acceptance command (#3721)",
+          "sourceSpan": "inline@L18"
+        }
+      ],
+      "swarm": {},
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "project_floor",
+      "derived_reason": "no shell acceptance commands stated in task text; floor until agent derives AC (#3284 ladder)"
+    }
+  }
+}

--- a/xbrief/proposed/2026-08-25-3739-bughooks-nested-hosts-get-a-5s-budget-the-framework-itself-c.xbrief.json
+++ b/xbrief/proposed/2026-08-25-3739-bughooks-nested-hosts-get-a-5s-budget-the-framework-itself-c.xbrief.json
@@ -1,0 +1,60 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3739"
+  },
+  "plan": {
+    "title": "bug(hooks): nested hosts get a 5s budget the framework itself calls too small, and a killed hook renders identically to an allow",
+    "status": "proposed",
+    "narratives": {
+      "Description": "bug(hooks): nested hosts get a 5s budget the framework itself calls too small, and a killed hook renders identically to an allow",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3739",
+      "Overview": "## Summary\n\nNested hosts (Claude, Grok, Codex) get a **5-second** hook timeout. The framework's own source says 5s is below the work's ceiling, and says so while raising *Cursor* to 30s for exactly that reason. The nested deposits were left at 5.\n\nBecause a nested **allow renders as an empty string** and a deny requires structured JSON, a hook killed at 5s emits nothing — which is byte-identical to an allow. The gate cannot deliver a deny it never printed.\n\nSplit from #3736 after an N=3 design-critique panel.\n\n## The asymmetry, in the framework's own words\n\n```ts\n// packages/core/src/init-deposit/agent-hooks.ts\n/**\n * Mutation tool.before runs `inspectMutationGates` -> gated `verifySessionRitual`,\n * which re-runs non-cacheable agent-hook readiness on every boundary. Live\n * readiness alone has a multi-host fixture ceiling of ~24s\n * (`content/contracts/agent-hook-readiness.md`); the historical deposit default\n * of 5s was below that budget. ...\n */\nexport const CURSOR_TOOL_BEFORE_TIMEOUT_SECONDS = 30;\n\n/** Nested Claude/Grok/Codex command-hook default timeout (seconds). */\nexport const NESTED_HOOK_TIMEOUT_SECONDS = 5;\n```\n\nThe diagnosis is correct and the remedy was applied to one host of four. `failClosed: true` likewise appears only in the Cursor block.\n\n## Why a nested deny cannot be emitted\n\n`renderHostDecision` returns an empty string for an allow on the nested hosts, and this is pinned by test:\n\n```ts\n// packages/core/src/hooks/dispatcher.test.ts:2110\nexpect(renderHostDecision(\"claude\", allow)).toBe(\"\");\nexpect(renderHostDecision(\"grok\",   allow)).toBe(\"\");\nexpect(renderHostDecision(\"codex\",  allow)).toBe(\"\");\n```\n\nA deny, by contrast, requires emitting structured JSON (`hookSpecificOutput.permissionDecision: \"deny\"` for Claude/Codex, `{decision: \"deny\"}` for Grok). If the host kills the process at 5s, nothing is written. **The framework cannot deliver a verdict it never printed**, whatever the host then does with the silence.\n\n## Measured work exceeds the budget routinely\n\nSame machine, same SHA, four independent observers, with the live probe **skipped** (maintainer checkout):\n\n| Observer | `tool.before`, Write payload |\n|---|---|\n| critic B | 6.379s |\n| critic A | 5.9 / 7.7 / 9.6s |\n| critic C | 8.1 / 12.7s |\n| parent | 6.3 / 7.0s quiet; 11.2-11.6s under load |\n\nEvery one of these exceeds 5s. On a consumer where the live probe actually runs, the published ceiling is ~24s. And with the `cache_fresh` drift probe armed (#3738) a single call was measured at ~115s.\n\nSo the nested budget is not marginal. It is exceeded on the happy path, by a factor of at least one and sometimes twenty.\n\n## What is verified and what is not\n\n**Verified in-repo:** the 5s constant; the 24s ceiling and the comment conceding 5s is too small; allow renders empty on nested hosts, pinned by test; deny requires structured output; measured work of 5-12s baseline.\n\n**Not verified:** what each host *does* with a killed hook. If a host treats silence as permission granted, this is a silent authorization bypass on three of four hosts. If it treats a kill as an error, it is instead an opaque breakage. Either way the gate does not render its verdict, but the severity differs and someone should confirm per host.\n\nNote that a related question is open for Grok specifically — its deposit may not be loaded at all (separate issue), which would make the timeout question moot on that host.\n\n## Acceptance\n\n- The nested deposit budget is sized against the same measured work the Cursor budget was sized against, or the work is moved off the synchronous path so a small budget is honest.\n- A nested host that cannot complete in budget produces a **distinguishable** outcome — not an empty string that is indistinguishable from allow.\n- Whatever the choice, it is stated per host rather than inherited by default.\n\nSplit from #3736. Related: #3738 (the drift read that makes the overrun routine), #3732 (agent-hook boundary), #3246 (Cursor timeout sizing).\n\n"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3739",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3739: bug(hooks): nested hosts get a 5s budget the framework itself calls too small, and a killed hook renders identically to an allow"
+      }
+    ],
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 3 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "The nested deposit budget is sized against the same measured work the Cursor budget was sized against, or the work is moved off the synchronous path so a small budget is honest.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "A nested host that cannot complete in budget produces a distinguishable outcome — not an empty string that is indistinguishable from allow.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "implementation"
+        },
+        {
+          "id": 3,
+          "text": "Whatever the choice, it is stated per host rather than inherited by default.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "metadata": {
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
Tracks six proposed briefs generated by `triage:accept` today, plus a policy decision record from 2026-08-24. The repo already tracks 26 briefs in `xbrief/proposed/`, so these were the outliers rather than the convention.

**Queued, not started:** #3598, #3718, #3736, #3739.
**Occupancy cluster, owned separately under #3613:** #3599, #3729.
**Decision record:** `minGreptileConfidence` stays at 5, do not lower.

No lifecycle transition -- all six remain in `proposed/`. Committing them so the v0.107.0 release preflight sees a clean tree rather than needing `--allow-dirty`.