### PR TITLE
fix(release): fetch open-issue inventory once for Step 3 (#3752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release Step 3 no longer issues one sequential `gh api` call per anchored issue (#3752).** Pre-flight vBRIEF lifecycle sync now loads the complete open-issue inventory in one paginated REST subprocess and treats anchors absent from that set as non-open, with fail-closed handling for truncated or malformed inventory. Step 3 reports anchor counts up front; `task release` usage documents `--allow-vbrief-drift`.
+
 ### Removed
 
 ## [0.107.0] - 2026-08-26

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -738,7 +738,7 @@ tasks:
   #                    tests/cli/test_release_e2e.py
   # Refs #74, #233, #642, #635, #709, #710, #716, #718.
   release:
-    desc: "Automate the v0.X.Y release flow (#74) -- task release -- <version> [--dry-run] [--skip-tag] [--skip-release] [--no-draft]"
+    desc: "Automate the v0.X.Y release flow (#74) -- task release -- <version> [--dry-run] [--skip-tag] [--skip-release] [--no-draft] [--allow-vbrief-drift]"
     deps: [ts:build]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:

--- a/packages/core/src/content-contracts/standards/taskfile_release_names.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_release_names.test.ts
@@ -65,6 +65,21 @@ describe("test_taskfile_release_names.py", () => {
     },
   );
 
+  it.skipIf(!taskAvailable)("test_release_task_desc_documents_allow_vbrief_drift (#3752)", () => {
+    const out = execFileSync(
+      "task",
+      ["-t", join(repoRoot(), "Taskfile.yml"), "--list-all", "--json"],
+      {
+        cwd: repoRoot(),
+        encoding: "utf8",
+        env: { ...process.env, PYTHONUTF8: "1" },
+      },
+    );
+    const parsed = JSON.parse(out) as { tasks?: Array<{ task?: string; desc?: string }> };
+    const release = (parsed.tasks ?? []).find((entry) => entry.task === "release");
+    expect(release?.desc ?? "").toContain("--allow-vbrief-drift");
+  });
+
   it.skipIf(!taskAvailable)(
     "test_task_release_summary_with_apostrophe_does_not_shell_parse_fail (#2547)",
     () => {

--- a/packages/core/src/release/issue-state-fetch.test.ts
+++ b/packages/core/src/release/issue-state-fetch.test.ts
@@ -16,6 +16,16 @@ function completed(stdout = "", stderr = "", returncode = 0): CompletedProcess {
 const RATE_LIMIT_STDERR =
   "gh: API rate limit exceeded for user (HTTP 403)\nX-RateLimit-Reset: 2000000300\n";
 
+const OPEN_INVENTORY_ENDPOINT = "repos/deftai/directive/issues?state=open&per_page=100";
+
+function inventoryCall(args: readonly string[] | null): boolean {
+  return (
+    args?.includes("--paginate") === true &&
+    args?.includes("--slurp") === true &&
+    args?.includes(OPEN_INVENTORY_ENDPOINT) === true
+  );
+}
+
 describe("issue-state-fetch", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -68,7 +78,7 @@ describe("issue-state-fetch", () => {
   it("fetchIssueStatesForRelease retries once after rate-limit sleep", () => {
     const sleep = vi.fn();
     const now = vi.fn().mockReturnValue(2_000_000_000);
-    let issueCalls = 0;
+    let inventoryCalls = 0;
     const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[] | null) => {
       if (args?.[0] === "rate_limit") {
         return completed(
@@ -80,11 +90,14 @@ describe("issue-state-fetch", () => {
           }),
         );
       }
-      issueCalls += 1;
-      if (issueCalls === 1) {
-        return completed("", RATE_LIMIT_STDERR, 1);
+      if (inventoryCall(args)) {
+        inventoryCalls += 1;
+        if (inventoryCalls === 1) {
+          return completed("", RATE_LIMIT_STDERR, 1);
+        }
+        return completed(JSON.stringify([{ number: 206, state: "open" }]));
       }
-      return completed(JSON.stringify({ state: "open", state_reason: null }));
+      throw new Error(`unexpected REST args: ${String(args?.join(" "))}`);
     });
 
     const result = fetchIssueStatesForRelease("deftai/directive", new Set([206]), {
@@ -98,7 +111,7 @@ describe("issue-state-fetch", () => {
       expect(result.states.get(206)?.value).toBe("OPEN");
     }
     expect(sleep).toHaveBeenCalledTimes(1);
-    expect(issueCalls).toBe(2);
+    expect(inventoryCalls).toBe(2);
   });
 
   it("fetchIssueStatesForRelease emits actionable failure after retry still rate-limited", () => {
@@ -115,7 +128,10 @@ describe("issue-state-fetch", () => {
           }),
         );
       }
-      return completed("", RATE_LIMIT_STDERR, 1);
+      if (inventoryCall(args)) {
+        return completed("", RATE_LIMIT_STDERR, 1);
+      }
+      throw new Error(`unexpected REST args: ${String(args?.join(" "))}`);
     });
 
     const result = fetchIssueStatesForRelease("deftai/directive", new Set([206]), {
@@ -138,7 +154,13 @@ describe("issue-state-fetch", () => {
   it("fetchIssueStatesForRelease does not probe rate_limit on non-rate-limit failures", () => {
     const sleep = vi.fn();
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    const scmCall = vi.fn().mockReturnValue(completed("", "auth failed", 1));
+    const scmCall = vi.fn((...callArgs: unknown[]) => {
+      const args = callArgs[2] as readonly string[] | null;
+      if (inventoryCall(args)) {
+        return completed("", "auth failed", 1);
+      }
+      return completed("", "auth failed", 1);
+    });
     const result = fetchIssueStatesForRelease("deftai/directive", new Set([1]), {
       scmCall,
       sleep,
@@ -153,7 +175,13 @@ describe("issue-state-fetch", () => {
 
   it("fetchIssueStatesForRelease does not retry on non-rate-limit failures", () => {
     const sleep = vi.fn();
-    const scmCall = vi.fn().mockReturnValue(completed("", "auth failed", 1));
+    const scmCall = vi.fn((...callArgs: unknown[]) => {
+      const args = callArgs[2] as readonly string[] | null;
+      if (inventoryCall(args)) {
+        return completed("", "auth failed", 1);
+      }
+      return completed("", "auth failed", 1);
+    });
     const result = fetchIssueStatesForRelease("deftai/directive", new Set([1]), {
       scmCall,
       sleep,
@@ -165,20 +193,40 @@ describe("issue-state-fetch", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it("fetchIssueStatesForRelease succeeds without retry when first fetch works", () => {
+  it("fetchIssueStatesForRelease maps open inventory to OPEN and absent anchors to NOT_FOUND", () => {
     const sleep = vi.fn();
-    const scmCall = vi
-      .fn()
-      .mockReturnValue(completed(JSON.stringify({ state: "closed", state_reason: "completed" })));
-    const result = fetchIssueStatesForRelease("deftai/directive", new Set([11]), {
+    const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[] | null) => {
+      if (inventoryCall(args)) {
+        return completed(
+          JSON.stringify([
+            { number: 11, state: "open" },
+            { number: 401, state: "open", pull_request: { url: "https://github.com/o/r/pull/401" } },
+          ]),
+        );
+      }
+      throw new Error(`unexpected REST args: ${String(args?.join(" "))}`);
+    });
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([11, 99]), {
       scmCall,
       sleep,
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.states.get(11)).toEqual(new IssueState("CLOSED", "COMPLETED"));
+      expect(result.states.get(11)).toEqual(new IssueState("OPEN"));
+      expect(result.states.get(99)).toEqual(new IssueState("NOT_FOUND"));
     }
     expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("fetchIssueStatesForRelease fails closed on non-array inventory JSON", () => {
+    const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[] | null) => {
+      if (inventoryCall(args)) {
+        return completed(JSON.stringify({ not: "an array" }));
+      }
+      throw new Error(`unexpected REST args: ${String(args?.join(" "))}`);
+    });
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([1]), { scmCall });
+    expect(result.ok).toBe(false);
   });
 
   it("probeGithubRateLimit fails open on throw, non-zero, empty, and bad JSON (#2952)", () => {
@@ -221,7 +269,6 @@ describe("issue-state-fetch", () => {
         ),
       ),
     ).toBeNull();
-    // Missing remaining fields yield nulls (not NaN).
     expect(
       probeGithubRateLimit(
         vi
@@ -236,7 +283,6 @@ describe("issue-state-fetch", () => {
   it("computeRateLimitSleepSeconds uses probe reset when header absent (#2952)", () => {
     const nowSec = 1_000;
     const probe = { coreRemaining: 0, coreResetUnix: nowSec + 30, graphqlRemaining: 1 };
-    // detectRateLimit must see a rate-limit stderr shape without X-RateLimit-Reset.
     const sleepS = computeRateLimitSleepSeconds(
       "gh: API rate limit exceeded for user (HTTP 403)",
       probe,

--- a/packages/core/src/release/issue-state-fetch.test.ts
+++ b/packages/core/src/release/issue-state-fetch.test.ts
@@ -200,7 +200,11 @@ describe("issue-state-fetch", () => {
         return completed(
           JSON.stringify([
             { number: 11, state: "open" },
-            { number: 401, state: "open", pull_request: { url: "https://github.com/o/r/pull/401" } },
+            {
+              number: 401,
+              state: "open",
+              pull_request: { url: "https://github.com/o/r/pull/401" },
+            },
           ]),
         );
       }

--- a/packages/core/src/release/issue-state-fetch.ts
+++ b/packages/core/src/release/issue-state-fetch.ts
@@ -1,8 +1,10 @@
 /**
  * Release Step 3 issue-state fetch with capped rate-limit retry (#2577).
+ * Open-issue inventory via one paginated REST subprocess (#3752).
  */
 import { detectRateLimit } from "../cache/fetch.js";
-import { type FetchIssueStatesOptions, fetchIssueStates } from "../intake/reconcile-issues.js";
+import { IssueState } from "../intake/reconcile-issues.js";
+import { type RunGhApiFn, GhRestError, restIssueListOpenInventory } from "../scm/gh-rest.js";
 import { type CallOptions, type CompletedProcess, call } from "../scm/call.js";
 
 export type ScmCallFn = (
@@ -25,7 +27,9 @@ export interface RateLimitProbe {
   readonly graphqlRemaining: number | null;
 }
 
-export interface FetchIssueStatesForReleaseOptions extends FetchIssueStatesOptions {
+export interface FetchIssueStatesForReleaseOptions {
+  readonly cwd?: string;
+  readonly scmCall?: ScmCallFn;
   readonly sleep?: SleepFn;
   readonly now?: () => number;
 }
@@ -33,7 +37,7 @@ export interface FetchIssueStatesForReleaseOptions extends FetchIssueStatesOptio
 export type FetchIssueStatesForReleaseResult =
   | {
       readonly ok: true;
-      readonly states: Map<number, import("../intake/reconcile-issues.js").IssueState>;
+      readonly states: Map<number, IssueState>;
     }
   | { readonly ok: false; readonly reason: string };
 
@@ -44,6 +48,87 @@ function defaultSleep(seconds: number): void {
   }
   const shared = new Int32Array(new SharedArrayBuffer(4));
   Atomics.wait(shared, 0, 0, ms);
+}
+
+function scmCallToRunGhApi(scmCall: ScmCallFn, cwd?: string): RunGhApiFn {
+  return (args, options) => {
+    const result = scmCall("github-issue", "api", args, {
+      timeout: options?.timeout ?? 120,
+      cwd,
+    });
+    return {
+      returncode: result.returncode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  };
+}
+
+function buildStatesFromOpenInventory(
+  issueNumbers: ReadonlySet<number>,
+  openInventory: readonly Record<string, unknown>[],
+): Map<number, IssueState> {
+  const openNumbers = new Set<number>();
+  for (const row of openInventory) {
+    const n = row.number;
+    if (typeof n === "number" && Number.isInteger(n)) {
+      openNumbers.add(n);
+    }
+  }
+  const states = new Map<number, IssueState>();
+  for (const n of [...issueNumbers].sort((a, b) => a - b)) {
+    states.set(n, openNumbers.has(n) ? new IssueState("OPEN") : new IssueState("NOT_FOUND"));
+  }
+  return states;
+}
+
+interface OpenInventoryAttempt {
+  readonly inventory: Record<string, unknown>[] | null;
+  readonly sawRateLimit: boolean;
+  readonly rateLimitStderr: string;
+  readonly failureReason: string | null;
+}
+
+function fetchOpenInventoryAttempt(
+  repo: string,
+  runGhApiFn: RunGhApiFn,
+): OpenInventoryAttempt {
+  let sawRateLimit = false;
+  let rateLimitStderr = "";
+  const trackingFn: RunGhApiFn = (args, options) => {
+    const result = runGhApiFn(args, options);
+    if (result.returncode !== 0 && detectRateLimit(result.stderr)[0]) {
+      sawRateLimit = true;
+      rateLimitStderr = result.stderr;
+    }
+    return result;
+  };
+  try {
+    return {
+      inventory: restIssueListOpenInventory(repo, { runGhApiFn: trackingFn }),
+      sawRateLimit,
+      rateLimitStderr,
+      failureReason: null,
+    };
+  } catch (err) {
+    const stderr = err instanceof GhRestError ? err.stderr : "";
+    if (stderr.length > 0 && detectRateLimit(stderr)[0]) {
+      sawRateLimit = true;
+      rateLimitStderr = stderr;
+    }
+    const reason =
+      err instanceof GhRestError
+        ? `open-issue inventory fetch failed: ${err.message}`
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return {
+      inventory: null,
+      sawRateLimit,
+      rateLimitStderr,
+      failureReason: reason,
+    };
+  }
 }
 
 function parseRateLimitProbe(stdout: string): RateLimitProbe | null {
@@ -155,43 +240,48 @@ export function fetchIssueStatesForRelease(
   issueNumbers: ReadonlySet<number>,
   options: FetchIssueStatesForReleaseOptions = {},
 ): FetchIssueStatesForReleaseResult {
+  if (issueNumbers.size === 0) {
+    return { ok: true, states: new Map() };
+  }
+
+  process.stderr.write(
+    `[release Step 3] checking ${issueNumbers.size} unique anchored issue(s) via open-issue inventory\n`,
+  );
+
   const sleepFn = options.sleep ?? defaultSleep;
   const nowFn = options.now ?? (() => Math.floor(Date.now() / 1000));
   const baseScmCall = options.scmCall ?? call;
   const cwd = options.cwd ?? undefined;
-  let sawRateLimit = false;
-  let lastRateLimitStderr = "";
+  const runGhApiFn = scmCallToRunGhApi(baseScmCall, cwd);
 
-  const trackingScmCall: ScmCallFn = (source, verb, args, callOptions) => {
-    const result = baseScmCall(source, verb, args, callOptions);
-    if (result.returncode !== 0 && detectRateLimit(result.stderr)[0]) {
-      sawRateLimit = true;
-      lastRateLimitStderr = result.stderr;
-    }
-    return result;
+  const finishSuccess = (
+    inventory: readonly Record<string, unknown>[],
+  ): FetchIssueStatesForReleaseResult => {
+    process.stderr.write(
+      `[release Step 3] open-issue inventory: ${inventory.length} open issue(s)\n`,
+    );
+    return { ok: true, states: buildStatesFromOpenInventory(issueNumbers, inventory) };
   };
 
-  let states = fetchIssueStates(repo, issueNumbers, { ...options, scmCall: trackingScmCall });
-  if (states !== null) {
-    return { ok: true, states };
+  let attempt = fetchOpenInventoryAttempt(repo, runGhApiFn);
+  if (attempt.inventory !== null) {
+    return finishSuccess(attempt.inventory);
   }
 
-  if (sawRateLimit) {
+  if (attempt.sawRateLimit) {
     const probe = probeGithubRateLimit(baseScmCall, cwd);
-    const sleepS = computeRateLimitSleepSeconds(lastRateLimitStderr, probe, nowFn());
+    const sleepS = computeRateLimitSleepSeconds(attempt.rateLimitStderr, probe, nowFn());
     process.stderr.write(
       `[release Step 3] GitHub REST rate limit hit; sleeping ${sleepS}s before one retry\n`,
     );
     sleepFn(sleepS);
-    sawRateLimit = false;
-    lastRateLimitStderr = "";
-    states = fetchIssueStates(repo, issueNumbers, { ...options, scmCall: trackingScmCall });
-    if (states !== null) {
-      return { ok: true, states };
+    attempt = fetchOpenInventoryAttempt(repo, runGhApiFn);
+    if (attempt.inventory !== null) {
+      return finishSuccess(attempt.inventory);
     }
   }
 
-  const rateLimitRelated = sawRateLimit || lastRateLimitStderr.length > 0;
+  const rateLimitRelated = attempt.sawRateLimit || attempt.rateLimitStderr.length > 0;
   if (rateLimitRelated) {
     const probe = probeGithubRateLimit(baseScmCall, cwd);
     const details = formatRateLimitFailureDetails(probe, true);
@@ -201,5 +291,7 @@ export function fetchIssueStatesForRelease(
       reason: "GitHub REST rate limit exhausted (see stderr for recovery steps)",
     };
   }
+
+  process.stderr.write(`${attempt.failureReason ?? "open-issue inventory fetch failed"}\n`);
   return { ok: false, reason: "failed to fetch issue states from gh" };
 }

--- a/packages/core/src/release/issue-state-fetch.ts
+++ b/packages/core/src/release/issue-state-fetch.ts
@@ -4,8 +4,8 @@
  */
 import { detectRateLimit } from "../cache/fetch.js";
 import { IssueState } from "../intake/reconcile-issues.js";
-import { type RunGhApiFn, GhRestError, restIssueListOpenInventory } from "../scm/gh-rest.js";
 import { type CallOptions, type CompletedProcess, call } from "../scm/call.js";
+import { GhRestError, type RunGhApiFn, restIssueListOpenInventory } from "../scm/gh-rest.js";
 
 export type ScmCallFn = (
   source: string,
@@ -89,10 +89,7 @@ interface OpenInventoryAttempt {
   readonly failureReason: string | null;
 }
 
-function fetchOpenInventoryAttempt(
-  repo: string,
-  runGhApiFn: RunGhApiFn,
-): OpenInventoryAttempt {
+function fetchOpenInventoryAttempt(repo: string, runGhApiFn: RunGhApiFn): OpenInventoryAttempt {
   let sawRateLimit = false;
   let rateLimitStderr = "";
   const trackingFn: RunGhApiFn = (args, options) => {

--- a/packages/core/src/release/native-steps.ts
+++ b/packages/core/src/release/native-steps.ts
@@ -60,6 +60,9 @@ export function checkVbriefLifecycleSyncNative(
         anchorIssueNumbers.add(num);
       }
     }
+    process.stderr.write(
+      `[release Step 3] ${anchors.length} lifecycle anchor(s), ${anchorIssueNumbers.size} unique issue number(s) to evaluate\n`,
+    );
     const fetchResult = fetchIssueStatesForRelease(repo, anchorIssueNumbers, {
       cwd: projectRoot,
     });

--- a/packages/core/src/scm/gh-rest.test.ts
+++ b/packages/core/src/scm/gh-rest.test.ts
@@ -4,6 +4,7 @@ import {
   InvalidRepoError,
   type RunGhApiFn,
   restIssueList,
+  restIssueListOpenInventory,
   restIssueView,
   splitRepo,
 } from "./gh-rest.js";
@@ -86,5 +87,60 @@ describe("restIssueList", () => {
       stderr: "",
     });
     expect(() => restIssueList("deftai/directive", {}, { runGhApiFn })).toThrow(GhRestError);
+  });
+});
+
+describe("restIssueListOpenInventory", () => {
+  const endpoint = "repos/deftai/directive/issues?state=open&per_page=100";
+
+  it("uses one paginate+slurp subprocess and filters pull requests", () => {
+    const runGhApiFn: RunGhApiFn = (args) => {
+      expect(args).toEqual(["--paginate", "--slurp", endpoint]);
+      return {
+        returncode: 0,
+        stdout: JSON.stringify([
+          { number: 1, state: "open" },
+          { number: 2, state: "open", pull_request: { url: "https://github.com/o/r/pull/2" } },
+        ]),
+        stderr: "",
+      };
+    };
+    expect(restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toEqual([
+      { number: 1, state: "open" },
+    ]);
+  });
+
+  it("returns empty list for empty stdout", () => {
+    const runGhApiFn: RunGhApiFn = () => ({ returncode: 0, stdout: "", stderr: "" });
+    expect(restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toEqual([]);
+  });
+
+  it("raises GhRestError on command failure", () => {
+    const runGhApiFn: RunGhApiFn = () => ({ returncode: 1, stdout: "", stderr: "auth failed" });
+    expect(() => restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toThrow(
+      GhRestError,
+    );
+  });
+
+  it("raises GhRestError on non-array JSON", () => {
+    const runGhApiFn: RunGhApiFn = () => ({
+      returncode: 0,
+      stdout: JSON.stringify({ not: "array" }),
+      stderr: "",
+    });
+    expect(() => restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toThrow(
+      GhRestError,
+    );
+  });
+
+  it("raises GhRestError when a row is not an object", () => {
+    const runGhApiFn: RunGhApiFn = () => ({
+      returncode: 0,
+      stdout: JSON.stringify([null]),
+      stderr: "",
+    });
+    expect(() => restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toThrow(
+      GhRestError,
+    );
   });
 });

--- a/packages/core/src/scm/gh-rest.test.ts
+++ b/packages/core/src/scm/gh-rest.test.ts
@@ -110,6 +110,24 @@ describe("restIssueListOpenInventory", () => {
     ]);
   });
 
+  it("flattens slurped page arrays from gh paginate output", () => {
+    const runGhApiFn: RunGhApiFn = () => ({
+      returncode: 0,
+      stdout: JSON.stringify([
+        [
+          { number: 10, state: "open" },
+          { number: 11, state: "open", pull_request: { url: "https://github.com/o/r/pull/11" } },
+        ],
+        [{ number: 12, state: "open" }],
+      ]),
+      stderr: "",
+    });
+    expect(restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toEqual([
+      { number: 10, state: "open" },
+      { number: 12, state: "open" },
+    ]);
+  });
+
   it("returns empty list for empty stdout", () => {
     const runGhApiFn: RunGhApiFn = () => ({ returncode: 0, stdout: "", stderr: "" });
     expect(restIssueListOpenInventory("deftai/directive", { runGhApiFn })).toEqual([]);

--- a/packages/core/src/scm/gh-rest.ts
+++ b/packages/core/src/scm/gh-rest.ts
@@ -474,6 +474,51 @@ export interface RestIssueListPaginatedOptions extends RestIssueListOptions {
 
 const OPEN_INVENTORY_MAX_ISSUES = REST_PAGINATION_MAX_PAGES * REST_MAX_PER_PAGE;
 
+function issueRowOrThrow(item: unknown, endpoint: string): Record<string, unknown> {
+  if (typeof item !== "object" || item === null || Array.isArray(item)) {
+    throw new GhRestError({
+      stderr: "open-issue inventory row is not an object",
+      exitCode: 0,
+      endpoint,
+      payload: null,
+      hint: "REST issue list rows must be objects",
+    });
+  }
+  return item as Record<string, unknown>;
+}
+
+/** Flatten `gh api --paginate --slurp` issue-list output (pages or single page). */
+export function flattenOpenInventoryPayload(parsed: unknown[], endpoint: string): Record<string, unknown>[] {
+  if (parsed.length === 0) {
+    return [];
+  }
+  const out: Record<string, unknown>[] = [];
+  const allPages = parsed.every((item) => Array.isArray(item));
+  if (allPages) {
+    for (const page of parsed) {
+      if (!Array.isArray(page)) {
+        continue;
+      }
+      for (const item of page) {
+        const row = issueRowOrThrow(item, endpoint);
+        if ("pull_request" in row) {
+          continue;
+        }
+        out.push(row);
+      }
+    }
+    return out;
+  }
+  for (const item of parsed) {
+    const row = issueRowOrThrow(item, endpoint);
+    if ("pull_request" in row) {
+      continue;
+    }
+    out.push(row);
+  }
+  return out;
+}
+
 /**
  * Complete open-issue inventory in one `gh api --paginate --slurp` subprocess (#3752).
  * Fail-closed on command failure, non-array JSON, buffer exhaustion, or cap hit.
@@ -522,23 +567,7 @@ export function restIssueListOpenInventory(
       hint: "open-issue inventory must be a JSON array",
     });
   }
-  const out: Record<string, unknown>[] = [];
-  for (const item of parsed) {
-    if (typeof item !== "object" || item === null || Array.isArray(item)) {
-      throw new GhRestError({
-        stderr: "open-issue inventory row is not an object",
-        exitCode: 0,
-        endpoint,
-        payload: null,
-        hint: "REST issue list rows must be objects",
-      });
-    }
-    const row = item as Record<string, unknown>;
-    if ("pull_request" in row) {
-      continue;
-    }
-    out.push(row);
-  }
+  const out = flattenOpenInventoryPayload(parsed, endpoint);
   if (out.length >= OPEN_INVENTORY_MAX_ISSUES) {
     throw new GhRestError({
       stderr: `open-issue inventory reached cap ${OPEN_INVENTORY_MAX_ISSUES}; pagination may be incomplete`,

--- a/packages/core/src/scm/gh-rest.ts
+++ b/packages/core/src/scm/gh-rest.ts
@@ -241,6 +241,7 @@ export const PUBLIC_HELPERS = [
   "restPrView",
   "restIssueList",
   "restIssueListPaginated",
+  "restIssueListOpenInventory",
 ] as const;
 
 function writeJsonPayload(payload: Record<string, unknown>): { path: string; dir: string } {
@@ -469,6 +470,85 @@ export function restPrView(
 export interface RestIssueListPaginatedOptions extends RestIssueListOptions {
   readonly limit?: number | null;
   readonly excludePulls?: boolean;
+}
+
+const OPEN_INVENTORY_MAX_ISSUES = REST_PAGINATION_MAX_PAGES * REST_MAX_PER_PAGE;
+
+/**
+ * Complete open-issue inventory in one `gh api --paginate --slurp` subprocess (#3752).
+ * Fail-closed on command failure, non-array JSON, buffer exhaustion, or cap hit.
+ * Pull-request rows are excluded.
+ */
+export function restIssueListOpenInventory(
+  repo: string,
+  seams: GhRestSeams = {},
+): Record<string, unknown>[] {
+  const [owner, name] = splitRepo(repo);
+  const endpoint = `repos/${owner}/${name}/issues?state=open&per_page=${REST_MAX_PER_PAGE}`;
+  const runner = seams.runGhApiFn ?? runGhApi;
+  const result = runner(["--paginate", "--slurp", endpoint], { timeout: 120 });
+  if (result.returncode !== 0) {
+    throw new GhRestError({
+      stderr: result.stderr.trim(),
+      exitCode: result.returncode,
+      endpoint,
+      payload: null,
+      hint: "verify gh auth and core REST quota; open-issue inventory must be complete",
+    });
+  }
+  const stdout = result.stdout.trim();
+  if (stdout.length === 0) {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (exc: unknown) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    throw new GhRestError({
+      stderr: `non-JSON open-issue inventory: ${message}`,
+      exitCode: 0,
+      endpoint,
+      payload: null,
+      hint: "gh api --paginate --slurp must return a JSON array",
+    });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new GhRestError({
+      stderr: `unexpected top-level type ${typeof parsed}`,
+      exitCode: 0,
+      endpoint,
+      payload: null,
+      hint: "open-issue inventory must be a JSON array",
+    });
+  }
+  const out: Record<string, unknown>[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new GhRestError({
+        stderr: "open-issue inventory row is not an object",
+        exitCode: 0,
+        endpoint,
+        payload: null,
+        hint: "REST issue list rows must be objects",
+      });
+    }
+    const row = item as Record<string, unknown>;
+    if ("pull_request" in row) {
+      continue;
+    }
+    out.push(row);
+  }
+  if (out.length >= OPEN_INVENTORY_MAX_ISSUES) {
+    throw new GhRestError({
+      stderr: `open-issue inventory reached cap ${OPEN_INVENTORY_MAX_ISSUES}; pagination may be incomplete`,
+      exitCode: 0,
+      endpoint,
+      payload: null,
+      hint: "repo may exceed supported open-issue count; fail closed rather than truncate",
+    });
+  }
+  return out;
 }
 
 export function restIssueListPaginated(

--- a/packages/core/src/scm/gh-rest.ts
+++ b/packages/core/src/scm/gh-rest.ts
@@ -488,7 +488,10 @@ function issueRowOrThrow(item: unknown, endpoint: string): Record<string, unknow
 }
 
 /** Flatten `gh api --paginate --slurp` issue-list output (pages or single page). */
-export function flattenOpenInventoryPayload(parsed: unknown[], endpoint: string): Record<string, unknown>[] {
+export function flattenOpenInventoryPayload(
+  parsed: unknown[],
+  endpoint: string,
+): Record<string, unknown>[] {
   if (parsed.length === 0) {
     return [];
   }


### PR DESCRIPTION
## Summary

- Release Step 3 (`Pre-flight vBRIEF lifecycle sync`) now gathers issue state via one fail-closed `gh api --paginate --slurp` open-issue inventory instead of 1,156 sequential per-anchor calls.
- Anchors absent from the complete open set are treated as non-open; PR rows are filtered; malformed/truncated inventory fails closed.
- Step 3 reports lifecycle anchor and unique-issue counts up front; `task release` usage documents `--allow-vbrief-drift`.

## Test plan

- [x] `vitest run packages/core/src/release/issue-state-fetch.test.ts`
- [x] `vitest run packages/core/src/scm/gh-rest.test.ts`
- [x] `vitest run packages/core/src/release/native-steps.test.ts`
- [x] Taskfile desc includes `--allow-vbrief-drift`

Closes #3752
