### PR TITLE
Claim occupancy before creating swarm launch worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Claim occupancy before creating swarm worktrees (#3649).** `swarm:launch` takes the occupancy lease before resolving or creating trees from `--worktree-map`. A foreign live occupant creates zero worktrees. If this launch newly claimed the lease and a later step fails, it releases that lease so close-out is not left with a stranded occupant. Does not change reuse of already-registered worktrees. Closes #3649.
 
 - **Release Step 3 no longer issues one sequential `gh api` call per anchored issue (#3752).** Pre-flight vBRIEF lifecycle sync now loads the complete open-issue inventory in one paginated REST subprocess and treats anchors absent from that set as non-open, with fail-closed handling for truncated or malformed inventory. Step 3 reports anchor counts up front; `task release` usage documents `--allow-vbrief-drift`.
 

--- a/packages/core/src/swarm/launch.test.ts
+++ b/packages/core/src/swarm/launch.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import {
   type GhRunner,
 } from "../intake/github-auth-modes.js";
 import type { CompletedProcess } from "../scm/call.js";
+import { applyWorktreeOccupancy, occupancyPath, readOccupancy } from "../session/occupancy.js";
 import {
   buildManifest,
   formatDispatchAuthEnvelope,
@@ -465,6 +466,117 @@ describe("swarmLaunch identity-bound injection (#1351)", () => {
     expect(result.stderr).toMatch(/BLOCKED/i);
     expect(result.stderr).toMatch(/installation|#3693/i);
     expect(result.stdout).not.toContain(FAKE_TOKEN);
+  });
+});
+
+describe("swarmLaunch occupancy-before-create (#3649)", () => {
+  const savedRouting = process.env.DEFT_ROUTING_PATH;
+  const cleanups: string[] = [];
+  afterEach(() => {
+    if (savedRouting === undefined) {
+      delete process.env.DEFT_ROUTING_PATH;
+    } else {
+      process.env.DEFT_ROUTING_PATH = savedRouting;
+    }
+    while (cleanups.length > 0) {
+      const dir = cleanups.pop();
+      if (dir !== undefined) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  function launchProject(): string {
+    const project = mkdtempSync(join(tmpdir(), "launch-occ-"));
+    cleanups.push(project);
+    writeReadyStory(project, "story-a", 3649);
+    const routePath = join(project, "routing.local.json");
+    writeFileSync(
+      routePath,
+      JSON.stringify({
+        cursor: { "leaf-implementation": { model: "composer-2.5-fast", mode: "pinned" } },
+      }),
+    );
+    process.env.DEFT_ROUTING_PATH = routePath;
+    return project;
+  }
+
+  it("denies a foreign occupant before creating a mapped worktree", () => {
+    const project = launchProject();
+    applyWorktreeOccupancy(project, { sessionId: "foreign-owner", intent: "swarm" });
+    const missing = join(project, "wt-missing");
+    const mapPath = join(project, "worktree-map.json");
+    writeFileSync(
+      mapPath,
+      JSON.stringify([
+        {
+          story_id: "story-a",
+          worktree_path: missing.replace(/\\/g, "/"),
+          base_branch: "master",
+        },
+      ]),
+    );
+    let resolverCalls = 0;
+    const result = swarmLaunch({
+      stories: ["3649"],
+      projectRoot: project,
+      autonomous: true,
+      worktreeMap: mapPath,
+      baseBranch: "master",
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["local-unsandboxed", "host-gh"],
+      worktreeResolver: () => {
+        resolverCalls += 1;
+        throw new Error("worktree resolver must not run after occupancy deny");
+      },
+      environ: { CURSOR_AGENT: "1" },
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/occupied|occupancy/i);
+    expect(resolverCalls).toBe(0);
+    expect(existsSync(missing)).toBe(false);
+    expect(readOccupancy(project)?.sessionId).toBe("foreign-owner");
+  });
+
+  it("releases a newly claimed lease when a later step fails", () => {
+    const project = launchProject();
+    const mapPath = join(project, "worktree-map.json");
+    writeFileSync(mapPath, "{}\n");
+    const result = swarmLaunch({
+      stories: ["3649"],
+      projectRoot: project,
+      autonomous: true,
+      worktreeMap: mapPath,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["local-unsandboxed", "host-gh"],
+      environ: { CURSOR_AGENT: "1" },
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/worktree-map|JSON array/i);
+    expect(existsSync(occupancyPath(project))).toBe(false);
+    expect(readOccupancy(project)).toBeNull();
+  });
+
+  it("does not release a heartbeat on an existing owner after a later failure", () => {
+    const project = launchProject();
+    applyWorktreeOccupancy(project, { sessionId: "owner", intent: "mutation" });
+    const mapPath = join(project, "worktree-map.json");
+    writeFileSync(mapPath, "{}\n");
+    const result = swarmLaunch({
+      stories: ["3649"],
+      projectRoot: project,
+      autonomous: true,
+      worktreeMap: mapPath,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["local-unsandboxed", "host-gh"],
+      environ: { CURSOR_AGENT: "1", DEFT_SESSION_ID: "owner" },
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(readOccupancy(project)?.sessionId).toBe("owner");
+    expect(existsSync(occupancyPath(project))).toBe(true);
   });
 });
 

--- a/packages/core/src/swarm/launch.test.ts
+++ b/packages/core/src/swarm/launch.test.ts
@@ -559,6 +559,29 @@ describe("swarmLaunch occupancy-before-create (#3649)", () => {
     expect(readOccupancy(project)).toBeNull();
   });
 
+  it("keeps the original later-step error when occupancy release throws", () => {
+    const project = launchProject();
+    const mapPath = join(project, "worktree-map.json");
+    writeFileSync(mapPath, "{}\n");
+    const result = swarmLaunch({
+      stories: ["3649"],
+      projectRoot: project,
+      autonomous: true,
+      worktreeMap: mapPath,
+      preflightGate: () => ({ exitCode: 0, message: "" }),
+      readinessGate: () => ({ exitCode: 0, report: "" }),
+      runtimeAuthProbe: () => ["local-unsandboxed", "host-gh"],
+      releaseOccupancyFn: () => {
+        throw new Error("lock compromised: occupancy session changed before release");
+      },
+      environ: { CURSOR_AGENT: "1" },
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/worktree-map|JSON array/i);
+    expect(result.stderr).not.toMatch(/lock compromised/);
+    expect(existsSync(occupancyPath(project))).toBe(true);
+  });
+
   it("does not release a heartbeat on an existing owner after a later failure", () => {
     const project = launchProject();
     applyWorktreeOccupancy(project, { sessionId: "owner", intent: "mutation" });

--- a/packages/core/src/swarm/launch.test.ts
+++ b/packages/core/src/swarm/launch.test.ts
@@ -578,7 +578,8 @@ describe("swarmLaunch occupancy-before-create (#3649)", () => {
     });
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toMatch(/worktree-map|JSON array/i);
-    expect(result.stderr).not.toMatch(/lock compromised/);
+    expect(result.stderr).toMatch(/occupancy:steal --confirm/);
+    expect(result.stderr).toMatch(/lock compromised/);
     expect(existsSync(occupancyPath(project))).toBe(true);
   });
 

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -61,6 +61,7 @@ export type WorktreeResolverFn = (
   options?: { repoRoot?: string },
 ) => WorktreeRecord[];
 export type RuntimeAuthProbeFn = () => [string, string];
+export type OccupancyReleaseFn = typeof releaseOccupancy;
 
 export const defaultPreflightGate: PreflightGateFn = (vbriefPath) => {
   const result = preflightEvaluate(vbriefPath);
@@ -955,6 +956,8 @@ export interface LaunchArgs {
   readinessGate?: ReadinessGateFn;
   worktreeResolver?: WorktreeResolverFn;
   runtimeAuthProbe?: RuntimeAuthProbeFn;
+  /** Test seam: override occupancy release after a newly minted claim fails. */
+  releaseOccupancyFn?: OccupancyReleaseFn;
   /**
    * Injection seam for the routing-provider environment lookup, mirroring
    * `resolveRoutingPath`'s `environ` parameter (#1877 Greptile follow-up).
@@ -1093,10 +1096,16 @@ export function swarmLaunch(args: LaunchArgs): {
     stderr: string,
   ): { exitCode: number; stdout: string; stderr: string } => {
     if (newlyClaimed) {
-      releaseOccupancy(projectRoot, {
-        sessionId: occupancy.sessionId,
-        env: args.environ ?? process.env,
-      });
+      try {
+        const release = args.releaseOccupancyFn ?? releaseOccupancy;
+        release(projectRoot, {
+          sessionId: occupancy.sessionId,
+          env: args.environ ?? process.env,
+        });
+      } catch {
+        // Best-effort: a throw here must not replace the original launch error
+        // or skip the structured return (#3649 Greptile P1).
+      }
     }
     return { exitCode, stdout: "", stderr };
   };

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -1096,15 +1096,22 @@ export function swarmLaunch(args: LaunchArgs): {
     stderr: string,
   ): { exitCode: number; stdout: string; stderr: string } => {
     if (newlyClaimed) {
+      const recovery =
+        "Occupancy release failed after this launch error; the lease may still be live. " +
+        "The occupant may release (occupancy:release / session:end), or steal (occupancy:steal --confirm).";
       try {
         const release = args.releaseOccupancyFn ?? releaseOccupancy;
-        release(projectRoot, {
+        const decision = release(projectRoot, {
           sessionId: occupancy.sessionId,
           env: args.environ ?? process.env,
         });
-      } catch {
-        // Best-effort: a throw here must not replace the original launch error
-        // or skip the structured return (#3649 Greptile P1).
+        if (decision.code !== 0) {
+          stderr = `${stderr}\n${recovery} ${decision.message}\n`;
+        }
+      } catch (exc: unknown) {
+        // Do not replace the original structured launch error; tell the operator
+        // the lease may still deny later sessions (#3649 Greptile P1).
+        stderr = `${stderr}\n${recovery} ${String(exc)}\n`;
       }
     }
     return { exitCode, stdout: "", stderr };

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -20,7 +20,7 @@ import {
   stripArtifactSuffix,
 } from "../layout/resolve.js";
 import { evaluate as preflightEvaluate } from "../preflight/evaluate.js";
-import { applyWorktreeOccupancy } from "../session/occupancy.js";
+import { applyWorktreeOccupancy, releaseOccupancy } from "../session/occupancy.js";
 import { issueNumbersFromPlan, scopeMetadataRank } from "../triage/queue/scope-walk.js";
 import { selectionOrderingKey } from "../triage/queue/selection.js";
 import {
@@ -1074,17 +1074,43 @@ export function swarmLaunch(args: LaunchArgs): {
     args.operatorApproval ??
     `task swarm:launch (${args.autonomous ? "autonomous" : "interactive"})`;
 
+  const occupancy = applyWorktreeOccupancy(projectRoot, {
+    env: args.environ ?? process.env,
+    intent: "swarm",
+  });
+  if (occupancy.code !== 0) {
+    return {
+      exitCode: EXIT_GATE_FAILED,
+      stdout: "",
+      stderr: `${occupancy.message}\n`,
+    };
+  }
+  // Heartbeat on an existing owner is not a new claim -- only release a lease
+  // this process just minted (#3649 paired failure clause).
+  const newlyClaimed = occupancy.action === "claimed";
+  const failAfterClaim = (
+    exitCode: number,
+    stderr: string,
+  ): { exitCode: number; stdout: string; stderr: string } => {
+    if (newlyClaimed) {
+      releaseOccupancy(projectRoot, {
+        sessionId: occupancy.sessionId,
+        env: args.environ ?? process.env,
+      });
+    }
+    return { exitCode, stdout: "", stderr };
+  };
+
   let worktreeRecordMap = new Map<string, WorktreeRecord>();
   if (args.worktreeMap !== undefined && args.worktreeMap !== null) {
     const resolver = args.worktreeResolver ?? resolveWorktreeMap;
     try {
       const payload = JSON.parse(readFileSync(args.worktreeMap, "utf8")) as unknown;
       if (!Array.isArray(payload)) {
-        return {
-          exitCode: EXIT_CONFIG_ERROR,
-          stdout: "",
-          stderr: `Error: --worktree-map ${args.worktreeMap} must contain a JSON array of records.\n`,
-        };
+        return failAfterClaim(
+          EXIT_CONFIG_ERROR,
+          `Error: --worktree-map ${args.worktreeMap} must contain a JSON array of records.\n`,
+        );
       }
       const records = resolver(
         payload as Record<string, unknown>[],
@@ -1096,11 +1122,10 @@ export function swarmLaunch(args: LaunchArgs): {
       );
       worktreeRecordMap = new Map(records.map((r) => [r.story_id, r]));
     } catch (exc: unknown) {
-      return {
-        exitCode: EXIT_CONFIG_ERROR,
-        stdout: "",
-        stderr: `Error: worktree map resolution failed: ${String(exc)}\n`,
-      };
+      return failAfterClaim(
+        EXIT_CONFIG_ERROR,
+        `Error: worktree map resolution failed: ${String(exc)}\n`,
+      );
     }
   }
 
@@ -1110,7 +1135,7 @@ export function swarmLaunch(args: LaunchArgs): {
     const probe = args.runtimeAuthProbe ?? defaultRuntimeAuthProbe;
     [runtimeMode, githubAuthMode] = probe();
   } catch (exc: unknown) {
-    return { exitCode: EXIT_CONFIG_ERROR, stdout: "", stderr: `Error: ${String(exc)}\n` };
+    return failAfterClaim(EXIT_CONFIG_ERROR, `Error: ${String(exc)}\n`);
   }
 
   let resolvedModel: string | null = null;
@@ -1124,11 +1149,10 @@ export function swarmLaunch(args: LaunchArgs): {
     // would emit an exit-0 manifest with no model and no error to follow. Match
     // verify:routing, which treats the same state as a config error (#1739).
     if (route.source === "invalid") {
-      return {
-        exitCode: EXIT_CONFIG_ERROR,
-        stdout: "",
-        stderr: `Error: routing gate misconfigured: ${route.error ?? "invalid routing decision"}\n`,
-      };
+      return failAfterClaim(
+        EXIT_CONFIG_ERROR,
+        `Error: routing gate misconfigured: ${route.error ?? "invalid routing decision"}\n`,
+      );
     }
     if (route.decided) {
       resolvedModel = route.model;
@@ -1143,18 +1167,6 @@ export function swarmLaunch(args: LaunchArgs): {
         ? dispatchProviderFor(backend.backend_id)
         : null;
   const workerRoleValue = routingFile !== null || backend !== null ? LEAF_CODING_WORKER_ROLE : null;
-
-  const occupancy = applyWorktreeOccupancy(projectRoot, {
-    env: args.environ ?? process.env,
-    intent: "swarm",
-  });
-  if (occupancy.code !== 0) {
-    return {
-      exitCode: EXIT_GATE_FAILED,
-      stdout: "",
-      stderr: `${occupancy.message}\n`,
-    };
-  }
 
   const launchEnviron = args.environ ?? process.env;
   let expectedGithubLogin: string | null = null;
@@ -1173,11 +1185,7 @@ export function swarmLaunch(args: LaunchArgs): {
       cwd: projectRoot,
     });
     if (!injection.ok) {
-      return {
-        exitCode: EXIT_GATE_FAILED,
-        stdout: "",
-        stderr: `${injection.detail}\n${injection.remedy}\n`,
-      };
+      return failAfterClaim(EXIT_GATE_FAILED, `${injection.detail}\n${injection.remedy}\n`);
     }
     if (injection.injected) {
       expectedGithubLogin = injection.expectedLogin;
@@ -1223,11 +1231,10 @@ export function swarmLaunch(args: LaunchArgs): {
       cohort_key: cohortKey,
     });
   } catch (exc: unknown) {
-    return {
-      exitCode: EXIT_CONFIG_ERROR,
-      stdout: "",
-      stderr: `Error: could not persist launch occupancy_session_id: ${String(exc)}\n`,
-    };
+    return failAfterClaim(
+      EXIT_CONFIG_ERROR,
+      `Error: could not persist launch occupancy_session_id: ${String(exc)}\n`,
+    );
   }
 
   if (args.output !== undefined && args.output !== null) {


### PR DESCRIPTION
## Summary

swarm:launch claimed the occupancy lease after it resolved and created worktrees from --worktree-map. A foreign live occupant then denied the launch with trees already on disk and no teardown path.

This PR claims occupancy first. On deny, nothing is created. If this launch newly claimed the lease (claimed, not a heartbeat on an existing owner) and a later step fails (map parse/create, auth probe, routing, credential injection, persist), it releases that lease so close-out is not left with a stranded occupant.

HEAD-match reuse of already-registered worktrees is out of scope (#3756). This does not add a shared git worktree remove helper.

## Related Issues

Closes #3649

## Checklist

- [x] /deft:change <name> — N/A (3 files, same occupancy-before-create story)
- [x] CHANGELOG.md — added entry under [Unreleased]
- [x] ROADMAP.md — N/A
- [x] Tests pass locally — occupancy-before-create suite (21 in launch.test.ts) plus biome lint; full 	ask check verify:* preflight passed

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed
- [ ] Enable branch protection on master requiring CI status check (one-time setup, see #57)
