### PR TITLE
chore(xbrief): point #3599 acceptance evidence at the test names that exist

### DIFF
--- a/xbrief/completed/2026-08-26-3599-fixsession-occupancy-lease-never-heartbeats-during-active-wo.xbrief.json
+++ b/xbrief/completed/2026-08-26-3599-fixsession-occupancy-lease-never-heartbeats-during-active-wo.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #3599",
-    "updated": "2026-08-27T03:35:44Z"
+    "updated": "2026-08-27T04:05:17Z"
   },
   "plan": {
     "title": "fix(session): occupancy lease never heartbeats during active work, so a working session gets stolen (#3433)",
@@ -20,7 +20,7 @@
         "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
-          "pointer": "packages/core/src/session/occupancy.test.ts \"write-gate refresh keeps a working owner's lease alive past the TTL (#3599)\" + \"write-gate refresh is off by default and floored to avoid amplification (#3599)\"; packages/core/src/hooks/dispatcher.test.ts \"an allowed write renews the owner's lease and warns when it went stale (#3599)\"",
+          "pointer": "packages/core/src/session/occupancy.test.ts \"write-gate refresh keeps a working owner's lease alive past the TTL (#3599)\" + \"write-gate refresh is off by default and floored to avoid amplification (#3599)\"; packages/core/src/hooks/dispatcher.test.ts \"an allowed write renews the owner's lease instead of warning about it (#3599)\"",
           "recorded_at": "2026-08-27T03:35:14Z",
           "recorded_by": "leaf-worker/3599"
         }
@@ -70,7 +70,7 @@
         "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
-          "pointer": "packages/core/src/session/occupancy.test.ts \"the absolute age cap expires a lease that never stops refreshing (#3599)\" + \"a lease past the cap reads as capped even once its heartbeat also lapses (#3599)\" + \"the refresh verb tells a capped holder to re-claim, not to beat harder (#3599)\"",
+          "pointer": "packages/core/src/session/occupancy.test.ts \"the absolute age cap expires a lease that never stops refreshing (#3599)\" + \"a lease past the cap reads as capped even once its heartbeat also lapses (#3599)\" + \"the refresh verb tells a capped holder to re-claim, not to beat harder (#3599)\"; packages/core/src/hooks/dispatcher.test.ts \"denies a capped holder's write but not the release it is told to run (#3599)\"",
           "recorded_at": "2026-08-27T03:35:14Z",
           "recorded_by": "leaf-worker/3599"
         }
@@ -262,6 +262,6 @@
         }
       ]
     },
-    "updated": "2026-08-27T03:35:44Z"
+    "updated": "2026-08-27T04:05:17Z"
   }
 }


### PR DESCRIPTION
Corrects the one inaccurate acceptance-evidence pointer Greptile flagged on PR #3795 (4/5).

Item 0 cited the dispatcher regression test by its pre-rename name. The test was
renamed when its assertion inverted -- it now pins that a successful re-stamp
stays quiet, so `and warns when it went stale` became `instead of warning about
it` -- and the pointer kept the old name.

The test exists and does pin the behavior, so nothing about the attestation was
false. But a pointer that resolves to nothing cannot be checked by the next
reader, and being checkable is the whole purpose of an evidence pointer under
 #3240 / #3305.

## Every pointer is now verified

Rather than fix only the flagged line, all eight pointers were checked
mechanically: each quoted test name must appear in the file its pointer names.
One was broken (item 0); the rest resolve. They now all do.

## Also

Cites the capped-holder dispatcher test under the age-cap item, which is where
the cap's load-bearing behavior is pinned -- a capped holder is denied its writes
while the `occupancy:release` it is told to run still goes through. That was the
deadlock risk called out during review of #3776, and it deserves a pointer in the
audit trail.
