### PR TITLE
chore(3781): land leftover completed-tracked artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Land leftover completed-tracked artifact for #3781 (#3264 / #1358).** The #3781 xBRIEF stayed in active/ after squash of PR 3802. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
+
 - **A PR can no longer merge while closing an issue whose brief is left running and unattested.** New `task verify:pr-closeout-attestable -- --pr N` fails closed when the PR's closing references name an issue whose brief is still `running` in `xbrief/active/` with acceptance criteria carrying neither evidence nor disposition, and `pr:wait-mergeable-and-merge` now runs it as the last gate before the merge call. The trigger is the closing reference, not the branch diff: CI runs before the merge and the issue closes on it, so a diff-keyed gate can never fail the PR that creates the orphan. Matching is repository-qualified and case-insensitive on the owner/repo slug (GitHub slugs are case-insensitive), so a same-numbered issue in another repository cannot block, a mixed-case slug for this repository still matches, a bare tracking number still reads as this repository, and an unresolvable OWNER/REPO is exit 2 rather than a pass. The refusal names each unattested criterion and the exact shape it needs, including which evidence kinds its axis allows. Reuses `evaluateAcceptanceEvidenceGate`, the same rule `scope:complete` enforces. Closes #3781. Refs #3609, #3598, #3611, #3240.
 
 - **Land leftover completed-tracked artifact for #3767 (#3264 / #1358).** The #3767 xBRIEF stayed in active/ after squash of PR 3789. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-08-27-3781-buglifecycle-a-pr-can-merge-while-closing-an-issue-whose-bri.xbrief.json
+++ b/xbrief/completed/2026-08-27-3781-buglifecycle-a-pr-can-merge-while-closing-an-issue-whose-bri.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #3781",
-    "updated": "2026-08-27T03:58:35Z"
+    "updated": "2026-08-27T16:01:42Z"
   },
   "plan": {
     "title": "bug(lifecycle): a PR can merge while closing an issue whose brief is left running and unattested",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(lifecycle): a PR can merge while closing an issue whose brief is left running and unattested",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3781",
@@ -17,7 +17,7 @@
     "items": [
       {
         "title": "A PR that closes issue `N` and leaves `N`'s brief `running` in `active/` with unattested items fails a merge-time check",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/pr-wait-mergeable/cascade.test.ts::waitMergeableAndMerge > closeout attestability gate before merge (#3781) > refuses the merge when the PR closes an issue whose brief is unattested",
@@ -27,7 +27,7 @@
       },
       {
         "title": "The trigger is the PR's closing reference, **not** the branch diff",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/pr-closeout-attestable/evaluate.test.ts::#3598 shape (brief predates the closing branch) > fires on the closing reference even though the brief is absent from the branch diff -- asserts the branch diff is exactly [src.ts] while the gate still fires",
@@ -37,7 +37,7 @@
       },
       {
         "title": "The failure names each unattested item and the exact shape it needs (`{kind, pointer, recorded_at, recorded_by}` or `{disposition, reason, provenance, recorded_at}`)",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/pr-closeout-attestable/evaluate.test.ts::pr-closeout-attestable failure message > names every unattested criterion and the shape it needs",
@@ -47,7 +47,7 @@
       },
       {
         "title": "A PR that leaves an unattested brief **without** closing its issue is unaffected",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/pr-closeout-attestable/evaluate.test.ts::pr-closeout-attestable evaluate > leaves an unattested brief alone when the PR does not close its issue",
@@ -57,7 +57,7 @@
       },
       {
         "title": "The check reuses `evaluateAcceptanceEvidenceGate` rather than reimplementing the rule, so the two cannot drift",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "task verify:ac clause 5 (#3323) -- anchor \"evaluateAcceptanceEvidenceGate\" verified present in packages/core/src/pr-closeout-attestable/evaluate.ts; the gate calls it rather than restating the rule",
@@ -67,7 +67,7 @@
       },
       {
         "title": "Regression fixture reproducing #3609: PR closes the issue, brief has five unattested items, gate fails",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/pr-closeout-attestable/evaluate.test.ts::pr-closeout-attestable evaluate > fails closed when the PR closes an issue whose running brief is unattested -- five bare items, exit 1",
@@ -77,7 +77,7 @@
       },
       {
         "title": "Regression fixture for the #3598 shape: brief already on master well before the closing PR, gate still fires on the closing reference",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/pr-closeout-attestable/evaluate.test.ts::pr-closeout-attestable #3598 shape (brief predates the closing branch) -- brief committed to master before the branch, gate still fires",
@@ -87,7 +87,7 @@
       },
       {
         "title": "CHANGELOG `[Unreleased]` entry",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "task verify:ac clause 8 (#3323) -- anchor \"verify:pr-closeout-attestable\" verified present in the CHANGELOG.md [Unreleased] Added section",
@@ -135,7 +135,32 @@
         "schema": "deft.scope.intended_placement.v1",
         "files": [],
         "module_boundary": ""
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3802,
+        "prBase": null,
+        "mergeCommit": "0c4cc490bf27b51ac86fc8ed3f4e2997f480463e",
+        "deliveryBranch": "master",
+        "deliveryCommit": "0c4cc490bf27b51ac86fc8ed3f4e2997f480463e",
+        "verifiedAt": "2026-08-27T16:01:42Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "5cbf87b3-27ed-48af-b925-239b746d70da"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-27T16:01:42Z"
+      },
+      "completedAt": "2026-08-27T16:01:42Z",
+      "completedSessionId": "5cbf87b3-27ed-48af-b925-239b746d70da",
+      "capacityBucket": "new-capability"
     },
     "acceptance": {
       "commands": [],
@@ -202,6 +227,6 @@
       ],
       "ambiguity_attestation": "none_found"
     },
-    "updated": "2026-08-27T03:58:35Z"
+    "updated": "2026-08-27T16:01:42Z"
   }
 }


### PR DESCRIPTION
## What this does

Land leftover completed-tracked artifact for #3781 after squash of PR 3802.

scope:complete already moved the brief locally. This PR is the delivery-tip land so erify:completed-tracked -- --issue 3781 can pass on origin/master.

Refs #3781, #2321, #3476, #3264.

Lifecycle-only (completed xBRIEF + CHANGELOG leftover). Not a product story envelope.
