### PR TITLE
chore(lifecycle): land completed-tracked xBRIEF for #3831 (#3264 / #1358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Land completed-tracked artifact for #3831 (#3264 / #1358).** The #3831 xBRIEF stayed in `active/` after squash of PR 3834. Moved to `xbrief/completed/` via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land completed-tracked artifact for #3826 (#3264 / #1358).** The #3826 xBRIEF stayed in `active/` after squash of PR 3840. Moved to `xbrief/completed/` via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Consumer package-manager override and Windows shim hardening (#3610 / #3814).** `package.json#packageManager` is now authoritative over `DEFT_PACKAGE_MANAGER`; conflicting overrides fail closed. Windows npm/pnpm probes transport the resolved shim path through a cleared child-environment variable so paths containing `%` cannot be expanded or substituted by `cmd.exe`. CI runs `deft toolchain-check --consumer` against an npm-pinned consumer deposit fixture. Refs #3814.
 - **Land leftover completed-tracked artifact for #3774 (#3264 / #1358).** The #3774 xBRIEF stayed untracked after squash of PR 3808. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-08-28-3831-bugdesign-critique-the-completed-arc-citation-grammar-is-unp.xbrief.json
+++ b/xbrief/completed/2026-08-28-3831-bugdesign-critique-the-completed-arc-citation-grammar-is-unp.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #3831",
-    "updated": "2026-08-28T02:47:04Z"
+    "updated": "2026-08-28T15:27:56Z"
   },
   "plan": {
     "title": "bug(design-critique): the completed-arc citation grammar is unpublished, too narrow and too wide at once, and split across two parsers",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(design-critique): the completed-arc citation grammar is unpublished, too narrow and too wide at once, and split across two parsers",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3831",
@@ -17,7 +17,7 @@
     "items": [
       {
         "title": "The contract publishes the closed set of accepted citation forms",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/content-contracts/standards/design_critique_contract.test.ts :: \"publishes the closed citation grammar with a position predicate (#3831)\" locks the `## Citation grammar` section of content/contracts/design-critique.md, including all six accepted forms, the refused-position list, and the two narrowing conditions added in review batches 4-5",
@@ -27,7 +27,7 @@
       },
       {
         "title": "A synthesis citing `` successor lean `NNNNNNNN` `` parses; #3796's original synthesis parses without being rewritten",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/citation-grammar.test.ts :: \"reads a balanced single-backtick id -- the form that blocked #3796\"; end-to-end through the ingest predicate at packages/core/src/design-critique/completed-arc-record.test.ts :: \"completes a synthesis whose ids sit in code spans\"",
@@ -37,7 +37,7 @@
       },
       {
         "title": "Blockquoted, fenced, struck-through, and negated occurrences do **not** clear",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/citation-grammar.test.ts :: describe \"scanCitations position predicate (#3831)\" -- fenced (plain, indented one to three spaces, tilde, mismatched closer, closer carrying an info string, permalink), inline-code (single, double-backtick, opened on an earlier line, unbalanced run), blockquote (marked, lazy continuation, blockquoted fence), strikethrough (same line, across a newline), and negation (including the determiner `that`, the cleft `that`, and a denial complement whose negation follows the citation)",
@@ -47,7 +47,7 @@
       },
       {
         "title": "Citation extraction and table-claim detection share one parser; mixed-form matrices assert the typed `citedTableId`",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/completed-arc-record.test.ts :: \"resolves the typed table id across mixed-form matrices\" and \"no longer waives the table requirement when the table id is decorated\"; both read the single scanCitations parse",
@@ -57,7 +57,7 @@
       },
       {
         "title": "Citing the superseded lean before the bound contract does not block",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/completed-arc-record.test.ts :: \"clears on set membership, so citing the superseded lean first does not block\"",
@@ -67,7 +67,7 @@
       },
       {
         "title": "The `missing-record` detail does not assert a recut that did not occur",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/completed-arc-record.test.ts :: \"does not assert a recut when a record cites only the superseded lean\"",
@@ -77,7 +77,7 @@
       },
       {
         "title": "Fixtures cover decorated ids, bolded keywords, and each negative position class",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/citation-grammar.test.ts :: \"reads an emphasised keyword, which is the mandated house style\" for the bolded keyword; describe \"scanCitations closed set -- decorations outside it do not cite (#3831)\" for the thirteen decorated id shapes; describe \"scanCitations position predicate (#3831)\" for each negative position class",
@@ -87,7 +87,7 @@
       },
       {
         "title": "No regression: a genuinely uncited synthesis still blocks",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/design-critique/completed-arc-record.test.ts :: \"says so plainly when the body carries no id at all\"",
@@ -97,7 +97,7 @@
       },
       {
         "title": "CHANGELOG `[Unreleased]` entry",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "observed_behavior",
           "pointer": "CHANGELOG.md line 40, under \"## [Unreleased]\" > \"### Fixed\": the entry beginning \"A design-critique synthesis written in the house style now clears ingest, and mixed formatting no longer waives the verified-claims-table requirement (#3831).\"",
@@ -203,8 +203,33 @@
         "schema": "deft.scope.intended_placement.v1",
         "files": [],
         "module_boundary": ""
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3834,
+        "prBase": "master",
+        "mergeCommit": "348ce76498e16d37c9dd65902e1bb360c874a8fe",
+        "deliveryBranch": "master",
+        "deliveryCommit": "348ce76498e16d37c9dd65902e1bb360c874a8fe",
+        "verifiedAt": "2026-08-28T15:27:56Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "3828cd85-8b23-4b4b-8b33-d3779db4b9b2"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-28T15:27:56Z"
+      },
+      "completedAt": "2026-08-28T15:27:56Z",
+      "completedSessionId": "3828cd85-8b23-4b4b-8b33-d3779db4b9b2",
+      "capacityBucket": "new-capability"
     },
-    "updated": "2026-08-28T02:47:04Z"
+    "updated": "2026-08-28T15:27:56Z"
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle-only follow-up to [#3834](https://github.com/deftai/directive/pull/3834), which merged as `348ce764` and closed #3831.

`scope:complete` is filesystem-only and runs after the merge, so the #3831 xBRIEF was still sitting in `xbrief/active/` on master. `task verify:completed-tracked -- --issue 3831` fails closed until the completed artifact is tracked on `origin/master`, and this PR is that land.

- Moves the brief to `xbrief/completed/` via `task scope:complete`, with `--merge-commit 348ce76498e16d37c9dd65902e1bb360c874a8fe --pr 3834 --pr-base master` as delivery evidence.
- Adds the matching `[Unreleased]` CHANGELOG entry, same shape as the #3826 and #3774 lands already in this section.

No product code changes. Does not reopen or recut #3831.

## Test plan

- [x] `task scope:complete` exit 0; brief moved `active/` → `completed/`
- [x] `task verify:orphan-active -- --issue 3831` exit 0 on this branch
- [ ] `task verify:completed-tracked -- --issue 3831` exit 0 against `origin/master` after this merges

Refs #2321, #3264, #3476, #1358.
