### PR TITLE
chore(xbrief): land completed-tracked artifact for #3850

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Land completed-tracked artifact for #3850 (#3264 / #1358).** The #3850 xBRIEF stayed in `active/` after squash of PR 3856. Moved to `xbrief/completed/` via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land completed-tracked artifact for #3831 (#3264 / #1358).** The #3831 xBRIEF stayed in `active/` after squash of PR 3834. Moved to `xbrief/completed/` via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land completed-tracked artifact for #3826 (#3264 / #1358).** The #3826 xBRIEF stayed in `active/` after squash of PR 3840. Moved to `xbrief/completed/` via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Consumer package-manager override and Windows shim hardening (#3610 / #3814).** `package.json#packageManager` is now authoritative over `DEFT_PACKAGE_MANAGER`; conflicting overrides fail closed. Windows npm/pnpm probes transport the resolved shim path through a cleared child-environment variable so paths containing `%` cannot be expanded or substituted by `cmd.exe`. CI runs `deft toolchain-check --consumer` against an npm-pinned consumer deposit fixture. Refs #3814.

--- a/xbrief/completed/2026-08-28-3850-bugdesigncritique-the-panel-deposit-guards-are-inconsistent.xbrief.json
+++ b/xbrief/completed/2026-08-28-3850-bugdesigncritique-the-panel-deposit-guards-are-inconsistent.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF for GitHub issue #3850",
-    "updated": "2026-08-28T16:25:23Z"
+    "updated": "2026-08-28T17:07:51Z"
   },
   "plan": {
     "title": "bug(design-critique): the panel-deposit guards are inconsistent prose, and panel completeness has no executable consumer",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Reconcile the seven bind-guard loci in content/contracts/design-critique.md onto the deposit-independent sibling-completeness phrasing that already exists, and state plainly that panel completeness is behavioural.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3850 (body recut 2026-08-28 to the bound contract; synthesis comment 5454966234, successor lean 5454472108)",
@@ -16,7 +16,7 @@
     "items": [
       {
         "title": "All seven bind guards in the contract read \"no unposted same-round siblings remain\" or \"same-round siblings remain unposted\", the deposit-independent wording that already existed",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/content-contracts/standards/design_critique_contract.test.ts",
@@ -26,7 +26,7 @@
       },
       {
         "title": "The contract states \"Panel completeness is behavioural.\" and that \"nothing machine-checks it\", so no reader infers a gate that is not there",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/content-contracts/standards/design_critique_contract.test.ts",
@@ -36,7 +36,7 @@
       },
       {
         "title": "The content-contract test pins \"no unposted same-round siblings remain\" and \"Panel completeness is locked as contract text only\", and introduces no new predicate",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/content-contracts/standards/design_critique_contract.test.ts",
@@ -46,7 +46,7 @@
       },
       {
         "title": "No gate anywhere reads panel-deposit contents",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "review",
           "pointer": "https://github.com/deftai/directive/pull/3856",
@@ -56,7 +56,7 @@
       },
       {
         "title": "CHANGELOG [Unreleased] entry: the contract now \"guards sibling completeness the same way in all seven places\"",
-        "status": "proposed",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "CHANGELOG.md",
@@ -135,8 +135,33 @@
         "schema": "deft.scope.intended_placement.v1",
         "files": [],
         "module_boundary": ""
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3856,
+        "prBase": null,
+        "mergeCommit": "52a5fddc99092cd52727c0be6deb4f84a72b370c",
+        "deliveryBranch": "master",
+        "deliveryCommit": "52a5fddc99092cd52727c0be6deb4f84a72b370c",
+        "verifiedAt": "2026-08-28T17:07:51Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "0d640257-5e7f-4f80-8965-b9c2f41c5cf8"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-28T17:07:51Z"
+      },
+      "completedAt": "2026-08-28T17:07:51Z",
+      "completedSessionId": "0d640257-5e7f-4f80-8965-b9c2f41c5cf8",
+      "capacityBucket": "new-capability"
     },
-    "updated": "2026-08-28T16:25:17Z"
+    "updated": "2026-08-28T17:07:51Z"
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle-only. The #3850 xBRIEF rode into master in its `active/` state on PR #3856; `scope:complete` has now moved it to `xbrief/completed/` with the merge commit `52a5fddc` recorded as delivery evidence. This lands that move so `verify:completed-tracked -- --issue 3850` passes on `origin/master` (#3476).

No product change. Does not reopen or recut #3850.

## Related Issues

Refs #3850, #2321, #3476, #3264.

## Checklist

- [x] `/deft:change` — N/A. Two files, lifecycle bookkeeping only.
- [x] `CHANGELOG.md` — entry added under `[Unreleased]`.
- [x] `ROADMAP.md` — N/A.
- [x] Tests pass locally — no code change; the brief validates under `vbrief:validate` and `verify:ac`.

## Post-Merge

- [ ] `task verify:completed-tracked -- --issue 3850` exit 0 on `origin/master`.
