### PR TITLE
chore(lifecycle): land completed-tracked xBRIEF for #3828 to clear master

### DIFF
--- a/xbrief/completed/2026-08-28-3828-buglifecycle-the-d12-stale-origin-gate-denies-its-own-named.xbrief.json
+++ b/xbrief/completed/2026-08-28-3828-buglifecycle-the-d12-stale-origin-gate-denies-its-own-named.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF for GitHub issue #3828",
-    "updated": "2026-08-28T17:08:07Z"
+    "updated": "2026-08-28T18:26:20Z"
   },
   "plan": {
     "title": "bug(lifecycle): the D12 stale-origin gate denies its own named remedy and blocks every linked worktree",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Make three printed strings honest: the xbrief:preflight origin-freshness recovery, the interim bump path it must name, and the dest-form coverage hint.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3828",
@@ -16,7 +16,7 @@
     "items": [
       {
         "title": "xbrief:preflight's recovery names a path that succeeds from the printed state, and links #3857",
-        "status": "pending",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/preflight/evaluate.test.ts::origin-freshness recovery (#3828) > prints a recovery the brief's own state can execute",
@@ -26,7 +26,7 @@
       },
       {
         "title": "scope:activate no longer appears in that recovery",
-        "status": "pending",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/preflight/evaluate.test.ts::origin-freshness recovery (#3828) > does not offer the stamp as a cure for an unreachable origin",
@@ -36,7 +36,7 @@
       },
       {
         "title": "The dest-form coverage hint reflects the policy actually in force",
-        "status": "pending",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/hooks/dispatcher.test.ts::states the Shell coverage the policy in force actually provides (#3828)",
@@ -46,7 +46,7 @@
       },
       {
         "title": "Tests pin the recovery text against the states it is printed in",
-        "status": "pending",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "test",
           "pointer": "packages/core/src/preflight/evaluate.test.ts::origin-freshness recovery (#3828) > keeps the activate hint on rejects where activating is the right move",
@@ -56,7 +56,7 @@
       },
       {
         "title": "CHANGELOG `[Unreleased]` line",
-        "status": "pending",
+        "status": "completed",
         "x-directive/evidence": {
           "kind": "observed_behavior",
           "pointer": "CHANGELOG.md [Unreleased] > Fixed: \"The stale-origin refusal now names a recovery that works from the state it prints in (#3828)\"",
@@ -167,8 +167,32 @@
         "module_boundary": "packages/core/src (preflight recovery text + hooks deny text)",
         "cohesion_exemption": "Message-text edits inside existing modules. dispatcher.ts and its test are already over the review trigger; this scope edits one helper (scopeNotReadyCoverageHint) and adds cases rather than adding placement. Splitting either file is #3794/#3438 work, not this scope."
       },
-      "capacityBucket": "defect-repair"
+      "capacityBucket": "defect-repair",
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3868,
+        "prBase": null,
+        "mergeCommit": "c40da8b1b8cb2dbe633944a22e5b9baaed3f8406",
+        "deliveryBranch": "master",
+        "deliveryCommit": "c40da8b1b8cb2dbe633944a22e5b9baaed3f8406",
+        "verifiedAt": "2026-08-28T18:26:20Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "667f1173-0b35-4ef6-a111-3361cbd6ce6f"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-28T18:26:20Z"
+      },
+      "completedAt": "2026-08-28T18:26:20Z",
+      "completedSessionId": "667f1173-0b35-4ef6-a111-3361cbd6ce6f"
     },
-    "updated": "2026-08-28T17:08:07Z"
+    "updated": "2026-08-28T18:26:20Z"
   }
 }


### PR DESCRIPTION
## Why

Master is red. PR #3868 merged the #3828 fix and closed the issue, but did not run `scope:complete`, so the brief stayed in `xbrief/active/` on master. `verify:orphan-active` fails closed inside `check:framework-source`, which fails `check:merge`, which turns the merge gate red.

This is the #2321 / #3429 post-merge lifecycle obligation: a worker scoped `stop-at: pr-open` does not own `scope:complete`, so the orchestrator must run it after merge. That step was missed when the original builder was terminated mid-flight.

## What

`scope:complete` with the merge evidence from PR #3868 (merge commit `c40da8b1`), moving the brief to `xbrief/completed/`. No product code changes.

## Verification

- `verify:orphan-active` exits 0 locally (was exit 1 on master)
- `verify:ac` passed at rung=derived: 1 verified, 7 unverifiable, 0 failed
- Literal acceptance command re-run verbatim: `pnpm exec vitest run packages/core/src/preflight/evaluate.test.ts packages/core/src/hooks/dispatcher.test.ts` exit 0
