### PR TITLE
fix(contracts): pin the #3755 changelog entry by content, not by section (#3930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **A content contract no longer pins its changelog line to the `[Unreleased]` section (#3930).** A release cut moves an entry into the section it cut, so the v0.108.0 cut emptied the bounded slice and left `task check` red on master for every branch, independent of what that branch changed. The occupancy membership case now requires exactly one entry anywhere in the changelog carrying both of its tokens. The changelog is append-only across cuts, so that holds for every future release with no section parsing and no new release machinery. Closes #3930. Refs #3755, #3156.
 
 ### Removed
 

--- a/packages/core/src/content-contracts/standards/occupancy_membership_docs.test.ts
+++ b/packages/core/src/content-contracts/standards/occupancy_membership_docs.test.ts
@@ -36,11 +36,15 @@ describe("occupancy boundary naming (#3755)", () => {
     expect(text).not.toContain("Join (`occupancy:request`) is named in remediation only");
   });
 
-  it("carries one Unreleased changelog line for the membership change", () => {
+  // Searched over the whole file, not the Unreleased section: a release cut
+  // moves the entry into the cut section, so a section-bounded search is a
+  // scheduled failure. The changelog is append-only, so exactly-one holds
+  // wherever the entry lives (#3930).
+  it("carries exactly one changelog entry for the membership change", () => {
     const changelog = readText("CHANGELOG.md");
-    const unreleased = changelog.split("## [Unreleased]")[1]?.split("\n## ")[0] ?? "";
-    const mentions = unreleased.split("\n").filter((line) => line.includes("Closes #3755"));
-    expect(mentions).toHaveLength(1);
-    expect(mentions[0]).toContain("occupancy:grant");
+    const entries = changelog
+      .split("\n")
+      .filter((line) => line.includes("Closes #3755") && line.includes("occupancy:grant"));
+    expect(entries).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

`task check` has been red on `origin/master` since the v0.108.0 cut. One content-contract case bounded its changelog search to the `## [Unreleased]` section:

```ts
const unreleased = changelog.split("## [Unreleased]")[1]?.split("\n## ")[0] ?? "";
const mentions = unreleased.split("\n").filter((line) => line.includes("Closes #3755"));
expect(mentions).toHaveLength(1);
```

The cut moved that entry into `## [0.108.0] - 2026-08-29`, which is what a cut is supposed to do, so the bounded slice went empty. The assertion encoded a false invariant -- the entry's section is transient, the entry is not -- and it blocked the `Merge gate (task check)` required check on every PR branched from master, independent of what the branch changed.

The case now searches the whole file and requires exactly one entry carrying both of its tokens:

```ts
const entries = changelog
  .split("\n")
  .filter((line) => line.includes("Closes #3755") && line.includes("occupancy:grant"));
expect(entries).toHaveLength(1);
```

The changelog is append-only across cuts, so exactly-one holds wherever the entry lives -- no section parsing, no new release machinery.

## Remedy provenance

Design-critique bound: accepted lean 5466430201, critic 5466425900, verified-claims table 5466430284. This is the critic's fourth option, which the issue body did not name. The three options in the body were each rejected: option 1 ("Unreleased or the most recent released section") is a one-cut grace period that also needs latest-section logic not exposed today; option 2 (drop the case) weakens the gate, since the two sibling cases pin occupancy behaviour and operator documentation while this third case independently pins release-note discoverability; option 3 (post-cut release obligation) is prose rather than a control.

The class premise was refuted by measurement (denominator 1): of 15 candidate test files containing both `CHANGELOG.md` and `Unreleased`, 13 use literals, mocked seams, or temp-root changelogs, 2 read the repository CHANGELOG, and only this one bounded its assertion to the Unreleased section. `standing_residual_floor_3448.test.ts` is the other repository reader but is not section-bounded, so it is untouched here and still passes.

## Gate integrity (#3156)

This edits a currently-failing gate, which is normally forbidden. It is authorized because the arc bound this specific repair and the assertion encoded a false invariant. The guarantee is preserved, not relaxed: still exactly one, still both tokens.

## Evidence

Mutation proofs against the repository CHANGELOG, each mutation applied by index and reverted (changelog restored byte-identical):

| Mutation | Expected | Observed |
|---|---|---|
| Entry line removed | fail | fail -- `expected [] to have a length of 1 but got +0` |
| Entry line duplicated | fail | fail -- `expected [ ...(2) ] to have a length of 1 but got 2` |
| `occupancy:grant` dropped from the entry | fail | fail -- length 0 |
| `Closes #3755` dropped from the entry | fail | fail -- length 0 |
| Synthetic pre-cut: entry moved under `[Unreleased]` | pass | pass |
| Synthetic post-cut: two later release sections inserted above the entry | pass | pass |

The last two demonstrate section-independence against synthetic changelogs rather than by assertion: a future cut that moves the entry again cannot break the case.

## Review fix batch

Greptile raised one P1 (inline, not counted in the rolling summary): the scope xBRIEF was tracked under `xbrief/active/` with `plan.status: running`, and its only `github-issue` reference is #3930 -- which this PR closes on merge. That is exactly the `verify:orphan-active` shipped signature, so master would have gone red again on a different gate the moment the issue closed.

The finding is valid. `collectGithubRefs` (`packages/core/src/orphan-active/refs.ts`) collects only `github-issue`-typed references, so the `x-xbrief/refs` entries for #3755 and #3156 are not collected and the brief resolves to #3930 alone; the unscoped sweep then returns `shipped("all referenced issues are closed")`.

Verified against the real evaluator with a stubbed post-merge GitHub state (#3930 closed, #3785 open), on two synthetic roots that both actually run the sweep:

| Tree | `verify:orphan-active` |
|---|---|
| WITH the #3930 active brief (what the first push shipped) | **exit 1** -- "1 active/running xBRIEF look shipped but still consume WIP" |
| WITHOUT it (what this branch ships) | **exit 0** -- "no orphaned active/running xBRIEFs (scanned 1 running brief in active/)" |

Fix: the brief is no longer tracked in this PR. It stays `running` locally so the worker keeps its lifecycle, and lands as a stamped `completed/` artifact after merge via `scope:complete` -- which #3476 requires regardless. Master therefore has no orphan exposure at any point, rather than a red window that a follow-up lifecycle PR would have had to close.

## Related Issues

Closes #3930. Refs #3755, #3156, #3448.

## Checklist

- [x] `/deft:change <name>` — N/A (2 files, not cross-cutting)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally — full `task check` green

## Post-Merge

- [ ] **Verify issue auto-close**: after squash merge, confirm #3930 closed; #3755 must stay closed and must not be re-referenced by a closing keyword.
- [ ] `scope:complete` + land the completed xBRIEF (`verify:orphan-active` / `verify:completed-tracked` both exit 0).