### PR TITLE
chore(lifecycle): land the completed #3929 xBRIEF (#3264 / #1358)

### DIFF
--- a/xbrief/completed/2026-08-30-3929-design-critique-arc-summary-legibility.xbrief.json
+++ b/xbrief/completed/2026-08-30-3929-design-critique-arc-summary-legibility.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF for GitHub issue #3929 (design-critique bound over two arcs; builds the bound design, not the body original proposal)",
-    "updated": "2026-08-30T04:24:21Z"
+    "updated": "2026-08-30T05:25:47Z"
   },
   "plan": {
     "title": "docs(design-critique): plain-language summary on both operator-facing artifacts, with a per-artifact reserved line-start matrix",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Two artifacts in the design-critique motion are operator-facing and neither states its own conclusion in plain language. The synthesis terminates in a sentence that is identical on every arc by construction. The successor lean is the consent gate and carries a per-heading take map that never says what confirming would assert. This scope lands the plain-language summary on both, under a fixed placement-only heading token, with a per-artifact prohibition over three reserved line-start families and an express statement that nothing observes any of it at runtime.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3929",
@@ -245,8 +245,33 @@
         ],
         "module_boundary": "content/contracts",
         "cohesion_exemption": "CHANGELOG.md is a chronological append-only release log; this slice appends one [Unreleased] entry and edits nothing else in the file. The two test files are the locking surfaces the contract change names."
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3943,
+        "prBase": null,
+        "mergeCommit": "02c2c9733ea6fe8fe33a696618ab29d6ff882757",
+        "deliveryBranch": "master",
+        "deliveryCommit": "02c2c9733ea6fe8fe33a696618ab29d6ff882757",
+        "verifiedAt": "2026-08-30T05:25:47Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "72cb74d6-2178-48e5-b3be-2d3c601dde20"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-30T05:25:47Z"
+      },
+      "completedAt": "2026-08-30T05:25:47Z",
+      "completedSessionId": "72cb74d6-2178-48e5-b3be-2d3c601dde20",
+      "capacityBucket": "new-capability"
     },
-    "updated": "2026-08-30T04:24:21Z"
+    "updated": "2026-08-30T05:25:47Z"
   }
 }

--- a/xbrief/decisions/2026-08-30-mark-the-design-critique-plain-language-summary-non-normative-fo.decision.json
+++ b/xbrief/decisions/2026-08-30-mark-the-design-critique-plain-language-summary-non-normative-fo.decision.json
@@ -18,7 +18,7 @@
   "whyWinner": "A plain-language summary cannot itself be closed-form, and a bounded instruction is still an instruction in the parent authoritative voice inside the comment ingest clearance always cites; marking both summaries non-normative and mandating no forward-instruction field removes the injection surface without removing the legibility the issue exists for",
   "confidence": "high",
   "activeScopeRefs": [
-    "xbrief/active/2026-08-30-3929-design-critique-arc-summary-legibility.xbrief.json"
+    "xbrief/completed/2026-08-30-3929-design-critique-arc-summary-legibility.xbrief.json"
   ],
   "timestamp": "2026-08-30T04:44:01Z",
   "revisitTrigger": "If ingest gains a real quarantine for composed comment text, or a downstream consumer needs a machine-readable next step, revisit and consider a typed field",


### PR DESCRIPTION
## Summary

Lifecycle-only. The #3929 scope xBRIEF stayed in `xbrief/active/` after the squash merge of #3943; `scope:complete` moved it to `xbrief/completed/` with merge evidence (`--merge-commit 02c2c9733ea6fe8fe33a696618ab29d6ff882757 --pr 3943`). No product change, no reopen, no recut.

Unblocks `deft verify:orphan-active -- --issue 3929` and `deft verify:completed-tracked -- --issue 3929` on `origin/master`.

## Related Issues

Refs #3929, #2321, #3476, #3264, #1358

## Checklist

- [x] `/deft:change <name>` — N/A: one lifecycle file move
- [x] `CHANGELOG.md` — N/A: lifecycle-only, the product entry landed in #3943
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally — no code change; brief validates (`task vbrief:validate`)

## Post-Merge

- [x] #3929 already closed by #3943