### PR TITLE
fix(agents): point consumer Skills Index at packs:slice (#3601)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=a30278786c69 refreshed=2026-08-28T20:45:11Z session=e1673d5b25f8 -->
+<!-- deft:managed-section v3 sha=795181f9abba refreshed=2026-08-30T16:02:08Z session=311ea6792b8f -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -228,7 +228,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Skills
 
-! **Skills Index** (Level-0) in `.deft/core/REFERENCES.md` — scan before improvising; read `SKILL.md` only on index match. `welcome` / `onboard triage` → `deft triage:welcome --onboard` (N3 / #1143); lessons → packs:slice.
+! **Skills Index** (Level-0): `npx deft packs:slice skills list` (text, not `--json`; local also `.\node_modules\.bin\deft`) — scan before improvising; read `SKILL.md` on match. `welcome` / `onboard triage` → `deft triage:welcome --onboard`.
 ## Skill pin policy (#2508)
 
 ! Process-critical skills with false-negative risk MUST be named in AGENTS.md (always-pin tier) — tier definitions: `.deft/core/docs/skill-pin-policy.md` (#2508).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Consumer Skills Index no longer points at a file npm never deposits (#3601).** The managed AGENTS.md card now names `npx deft packs:slice skills list` (text form, not `--json`; local also `.\node_modules\.bin\deft`) instead of `.deft/core/REFERENCES.md`. Root `REFERENCES.md` stays bucket `repo-dev`. C1 declared deposit closure checks required paths against staged pack output and fails on a mutated tree. `plan.policy.agentsMdBudget.absoluteMaxBytes` 16530→16547 for the pointer. Closes #3601. Refs #3899, #2501.
 - **Land completed-tracked artifact for #3873 (#3264 / #1358).** The #3873 xBRIEF stayed in `active/` after squash of PR 3948 (`41331dea`). Moved to `xbrief/completed/` via scope:complete. #3873 stays open for measured residue; this does not close or recut it. Refs #2321, #3476.
 - **Land completed-tracked artifact for #3932 (#3264 / #1358).** The #3932 xBRIEF stayed in `active/` after squash of PR 3950 (`ba3d6a8f`). Moved to `xbrief/completed/` via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land completed-tracked artifact for #3934 (#3264 / #1358).** The #3934 xBRIEF rode into master under `active/` with PR 3941, so completing it needs a second landing. Moved to `xbrief/completed/` via scope:complete. #3934 stays open for the operator's label and title decisions; this does not close or recut it. Refs #2321, #3476.

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -336,7 +336,7 @@ The npm engine (`npm i -g @deftai/directive`) remains the canonical runtime hand
 
 **Default install tier:** **daily-core** (setup, sync, build, pre-pr, review-cycle, triage) — the sync script and `deft-tiers.json` `defaultInstallTier` select this unless you override with `--tier all`, `--tier standard`, or `--tier advanced`. **Standard** covers operational workflows; **advanced** (release, swarm, debug, article-review) stays deferred. Full lists: `packaging/openpackage/deft-tiers.json`. Detail: [`packaging/openpackage/deft-directive-skills/README.md`](../packaging/openpackage/deft-directive-skills/README.md).
 
-Consumer AGENTS.md stays pointer-thin — scan `.deft/core/REFERENCES.md` Skills Index; do not enumerate skills in the managed section.
+Consumer AGENTS.md stays pointer-thin — scan `npx deft packs:slice skills list` Skills Index; do not enumerate skills in the managed section.
 
 ### Always-on bootstrap budget (DD-3, #2463)
 

--- a/content/contracts/deposit-required-paths.json
+++ b/content/contracts/deposit-required-paths.json
@@ -1,0 +1,26 @@
+{
+  "schema": "deft.deposit-required-paths.v1",
+  "description": "Closed typed declaration of deposit paths a consumer agent is mandated to read (#3601 / #3899 C1). Not extracted from AGENTS.md prose.",
+  "paths": [
+    ".deft/core/main.md",
+    ".deft/core/commands.md",
+    ".deft/core/docs/deft-directive-disable.md",
+    ".deft/core/docs/hook-runtime-unavailable.md",
+    ".deft/core/docs/skill-pin-policy.md",
+    ".deft/core/docs/writing-ste100.md",
+    ".deft/core/docs/decision-log.md",
+    ".deft/core/docs/gate-integrity.md",
+    ".deft/core/contracts/deterministic-questions.md",
+    ".deft/core/contracts/intent-ceiling.md",
+    ".deft/core/contracts/deposit-required-paths.json",
+    ".deft/core/templates/agent-prompt-preamble.md",
+    ".deft/core/scm/github.md",
+    ".deft/core/swarm/swarm.md",
+    ".deft/core/meta/security.md",
+    ".deft/core/.agents/skills/deft-directive-build/SKILL.md",
+    ".deft/core/.agents/skills/deft-directive-pre-pr/SKILL.md",
+    ".deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md",
+    ".deft/core/.agents/skills/deft-directive-swarm/SKILL.md",
+    ".deft/core/.agents/skills/deft-directive-feedback/SKILL.md"
+  ]
+}

--- a/content/contracts/host-lifecycle-duties.md
+++ b/content/contracts/host-lifecycle-duties.md
@@ -26,7 +26,7 @@ session routing in AGENTS.md (#2176), cold-start algorithm orientation (#609).
 
 | Moment | Duty |
 |--------|------|
-| **Session start** | Resolve **project root** (WSL / dual-path SoT when applicable). Know how to reach the **Skills Index** (consumer: `.deft/core/REFERENCES.md`; framework: `content/REFERENCES.md` or root `REFERENCES.md`). Optional session ritual when mutation intent applies (`session:start` / `#1149`). Confirm Deft alignment when USER.md is present (#2176). |
+| **Session start** | Resolve **project root** (WSL / dual-path SoT when applicable). Know how to reach the **Skills Index** (consumer: `npx deft packs:slice skills list` text form, not `--json`; framework: root `REFERENCES.md`). Optional session ritual when mutation intent applies (`session:start` / `#1149`). Confirm Deft alignment when USER.md is present (#2176). |
 | **Deft-shaped user intent** | Route via **Skills Index / skill trigger path before freestyle host tools**. Prefer **pinned Directive skills** over same-named host skills (e.g. Cursor `/review` or host “review” ≠ `deft-directive-article-review` / `deft-directive-review-cycle`). |
 | **Tool boundary** (optional) | Classifier hook / write-intent path when installed (#2967 A2 class). Graph append when installed (#2966 A1 class). Not required for this first cut. |
 | **Turn / session end** (optional) | Evidence flush / MEMORY note of which skill path ran, for APE continuity. |

--- a/content/conventions/content-manifest.json
+++ b/content/conventions/content-manifest.json
@@ -363,7 +363,7 @@
     {
       "path": "REFERENCES.md",
       "bucket": "repo-dev",
-      "note": "Repo-level references index for maintainers (harness-entry-adjacent; stays at root)."
+      "note": "Maintainer-only Skills Index and lazy-load guide. Audience boundary (bucket repo-dev). Consumers use npx deft packs:slice skills list (#3601 / #3899). Do not reclassify as content."
     },
     {
       "path": "ROADMAP.md",

--- a/content/docs/skill-pin-policy.md
+++ b/content/docs/skill-pin-policy.md
@@ -13,7 +13,7 @@ Pins are for **false-negative-sensitive process gates**, not for copying entire 
 | Tier | Meaning | How the agent discovers it |
 |---|---|---|
 | **always-pin** | Named in AGENTS.md (managed or consumer unmanaged header) as a required `SKILL.md` load when a matching work type starts | Always-loaded AGENTS.md |
-| **on-demand** | Routed via Skills Index triggers in `REFERENCES.md` — scan Level-0, read Level-1 on match | Skills Index → `SKILL.md` |
+| **on-demand** | Routed via Skills Index triggers (consumer: `npx deft packs:slice skills list`; maintainer: `REFERENCES.md`) — scan Level-0, read Level-1 on match | Skills Index → `SKILL.md` |
 | **reference-only** | External, rare, or maintainer-only corpora; no standing trigger routing | Explicit doc pointer only |
 
 ### Criteria for always-pin

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -66,7 +66,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Skills
 
-! **Skills Index** (Level-0) in `.deft/core/REFERENCES.md` — scan before improvising; read `SKILL.md` only on index match. `welcome` / `onboard triage` → `deft triage:welcome --onboard` (N3 / #1143); lessons → packs:slice.
+! **Skills Index** (Level-0): `npx deft packs:slice skills list` (text, not `--json`; local also `.\node_modules\.bin\deft`) — scan before improvising; read `SKILL.md` on match. `welcome` / `onboard triage` → `deft triage:welcome --onboard`.
 ## Skill pin policy (#2508)
 
 ! Process-critical skills with false-negative risk MUST be named in AGENTS.md (always-pin tier) — tier definitions: `.deft/core/docs/skill-pin-policy.md` (#2508).

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -6,6 +6,10 @@ import { resolveContentPackageRoot } from "@deftai/directive-core/dist/content-r
 import { parseDoctorFlags } from "@deftai/directive-core/dist/doctor/flags.js";
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
 import { findPackageAbsentDepositPathsSync } from "@deftai/directive-core/dist/init-deposit/hygiene.js";
+import {
+  evaluateInstalledDepositClosure,
+  renderDeclaredDepositClosureLine,
+} from "@deftai/directive-core/dist/validate-content/deposit-required.js";
 import { renderPrecutoverLine } from "@deftai/directive-core/dist/vbrief-validate/precutover.js";
 import {
   renderStaleHeaderLine,
@@ -82,7 +86,12 @@ export function run(argv: string[]): number {
     process.stdout.write(`${renderXbriefMigrationLine(projectRoot)}\n`);
     process.stdout.write(`${renderStaleHeaderLine(projectRoot)}\n`);
     process.stdout.write(`${renderDepositFileSetHygieneLine(projectRoot, depositResult)}\n`);
+    const closure = evaluateInstalledDepositClosure(projectRoot);
+    process.stdout.write(`${renderDeclaredDepositClosureLine(closure)}\n`);
     if (flags.full && !depositResult.skipped && depositResult.absent.length > 0) {
+      depositHygieneExit = 1;
+    }
+    if (flags.full && !closure.skipped && closure.missing.length > 0) {
       depositHygieneExit = 1;
     }
   }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -91,7 +91,7 @@ export function run(argv: string[]): number {
     if (flags.full && !depositResult.skipped && depositResult.absent.length > 0) {
       depositHygieneExit = 1;
     }
-    if (flags.full && !closure.skipped && closure.missing.length > 0) {
+    if (flags.full && !closure.skipped && (closure.missing.length > 0 || closure.error !== null)) {
       depositHygieneExit = 1;
     }
   }

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -199,7 +199,7 @@ const PROPAGATION_ACTION_VERBS = [
   "start agent",
 ] as const;
 
-const SKILLS_POINTER_MARKERS = ["## Skills", "Skills Index", "REFERENCES.md"] as const;
+const SKILLS_POINTER_MARKERS = ["## Skills", "Skills Index", "packs:slice skills list"] as const;
 
 const INDEXED_SKILL_IDS = [
   "deft-directive-setup",
@@ -577,9 +577,9 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     id: "skills-index-2501",
     shape: "doc",
     header: "Skills",
-    canonicalHome: "REFERENCES.md",
-    pointerHints: ["Skills Index", "REFERENCES.md", "SKILL.md", "Level-0"],
-    canonicalBodyMarkers: ["Skills Index", "Level 0", "SKILL.md"],
+    canonicalHome: "packs/skills/skills-pack-0.1.json",
+    pointerHints: ["Skills Index", "packs:slice skills list", "SKILL.md", "Level-0"],
+    canonicalBodyMarkers: ["skills-pack-0.1", "deft-directive-build", "triggers"],
     retiredFullTextMarkers: [
       "Skill routing (which skill answers which trigger) is not a table",
       "unified with the framework doc routing so you consult one place",
@@ -741,7 +741,7 @@ function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
   }
   if (
     spec.shape === "doc" &&
-    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|docs\/[\w.-]+\.md|\.deft\/core\/contracts\/|\.deft\/core\/docs\/|REFERENCES\.md|templates\/agent-prompt-preamble\.md/.test(
+    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|docs\/[\w.-]+\.md|\.deft\/core\/contracts\/|\.deft\/core\/docs\/|REFERENCES\.md|templates\/agent-prompt-preamble\.md|packs:slice/.test(
       section,
     )
   ) {

--- a/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
@@ -124,11 +124,13 @@ describe("test_agents_md_session_start", () => {
   // via the propagation command markers in agents_entry_contract.test.ts.
   it("skill_routing_table_replaced_with_pointer", () => {
     expect(agentsMdText).not.toContain("## Skill Routing");
-    const skills = extractSection(agentsMdText, "Skills");
-    expect(skills).toBeTruthy();
-    expect(skills).toContain("Skills Index");
-    expect(skills).toContain("REFERENCES.md");
-    expect(skills).toContain("task triage:welcome --onboard");
+    const maintainerSkills = extractSection(agentsMdText, "Skills");
+    expect(maintainerSkills).toBeTruthy();
+    expect(maintainerSkills).toContain("Skills Index");
+    expect(maintainerSkills).toContain("REFERENCES.md");
+    expect(maintainerSkills).toContain("task triage:welcome --onboard");
+    const consumerSkills = extractSection(extractManagedSection(agentsMdText), "Skills");
+    expect(consumerSkills).toContain("packs:slice skills list");
   });
 
   it("pre_start_agent_gate_stack_in_commands_canonical_home", () => {

--- a/packages/core/src/content-contracts/standards/deposit_required_closure.test.ts
+++ b/packages/core/src/content-contracts/standards/deposit_required_closure.test.ts
@@ -1,6 +1,6 @@
-import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   evaluateDepositClosure,
@@ -66,5 +66,22 @@ describe("declared deposit closure against staged pack (#3601 C1)", () => {
     expect(skills).toContain("npx deft");
     expect(skills).toContain("--json");
     expect(skills).toContain("node_modules");
+  });
+
+  it("declared paths follow the content-package prepack mapping", () => {
+    const root = repoRoot();
+    const pkg = readFileSync(join(root, "packages", "content", "package.json"), "utf8");
+    expect(pkg).toContain("content");
+    expect(pkg).toContain("main.md");
+    const declaration = loadDepositRequiredDeclaration(resolveDeclarationFile(root) as string);
+    const contentNeedle = join("content", "x").slice(0, -1);
+    for (const declared of declaration.paths) {
+      const rel = packRelativeFromDepositPath(declared);
+      if (rel === "main.md" || rel === "SKILL.md") {
+        continue;
+      }
+      expect(sourcePathForPackRelative(root, rel)).toContain(contentNeedle);
+    }
+    expect(sep).toBeTruthy();
   });
 });

--- a/packages/core/src/content-contracts/standards/deposit_required_closure.test.ts
+++ b/packages/core/src/content-contracts/standards/deposit_required_closure.test.ts
@@ -1,6 +1,7 @@
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, sep } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   evaluateDepositClosure,
@@ -20,35 +21,64 @@ afterEach(() => {
   }
 });
 
+function readPrepackScript(root: string): string {
+  const manifest = JSON.parse(
+    readFileSync(join(root, "packages", "content", "package.json"), "utf8"),
+  ) as { scripts?: { prepack?: string } };
+  const prepack = manifest.scripts?.prepack;
+  if (typeof prepack !== "string" || prepack.length === 0) {
+    throw new Error("packages/content/package.json has no prepack script");
+  }
+  const first = prepack.indexOf('"');
+  const last = prepack.lastIndexOf('"');
+  if (first === -1 || last <= first) {
+    throw new Error("could not parse prepack script body");
+  }
+  return prepack.slice(first + 1, last);
+}
+
 function stageDeclaredPack(root: string): string {
   const declarationPath = resolveDeclarationFile(root);
   expect(declarationPath, "C1 declaration must exist in the source tree").toBeTruthy();
   const declaration = loadDepositRequiredDeclaration(declarationPath as string);
-  const pack = mkdtempSync(join(tmpdir(), "deft-c1-stage-"));
-  staged.push(pack);
+  const tmp = mkdtempSync(join(tmpdir(), "deft-c1-prepack-"));
+  staged.push(tmp);
+  const pkgDir = join(tmp, "packages", "content");
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify({ name: "@deftai/directive-content", version: "0.0.0" }),
+    "utf8",
+  );
+  mkdirSync(join(tmp, "content"), { recursive: true });
   for (const declared of declaration.paths) {
     const rel = packRelativeFromDepositPath(declared);
     const from = sourcePathForPackRelative(root, rel);
-    const to = join(pack, ...rel.split("/"));
+    const destRel =
+      rel === "main.md" || rel === "SKILL.md" ? rel : join("content", ...rel.split("/"));
+    const to = join(tmp, destRel);
     mkdirSync(dirname(to), { recursive: true });
     cpSync(from, to);
   }
-  return pack;
+  const ran = spawnSync("node", ["--input-type=module", "-e", readPrepackScript(root)], {
+    cwd: pkgDir,
+    encoding: "utf8",
+  });
+  expect(ran.status, ran.stderr || ran.stdout || "").toBe(0);
+  return pkgDir;
 }
 
 describe("declared deposit closure against staged pack (#3601 C1)", () => {
-  it("every declared required path exists in the prepack-mapped staged tree", () => {
+  it("every declared required path exists after running content-package prepack", () => {
     const root = repoRoot();
-    const declarationPath = resolveDeclarationFile(root);
-    expect(declarationPath).toBeTruthy();
-    const declaration = loadDepositRequiredDeclaration(declarationPath as string);
+    const declaration = loadDepositRequiredDeclaration(resolveDeclarationFile(root) as string);
     expect(declaration.paths.length).toBeGreaterThan(0);
     const pack = stageDeclaredPack(root);
     const result = evaluateDepositClosure({ packRoot: pack, paths: declaration.paths });
     expect(result.ok, result.missing.join(", ")).toBe(true);
   });
 
-  it("fails when a declared file is deleted from the staged tree", () => {
+  it("fails when a declared file is deleted from the staged pack output", () => {
     const root = repoRoot();
     const declaration = loadDepositRequiredDeclaration(resolveDeclarationFile(root) as string);
     const pack = stageDeclaredPack(root);
@@ -66,22 +96,5 @@ describe("declared deposit closure against staged pack (#3601 C1)", () => {
     expect(skills).toContain("npx deft");
     expect(skills).toContain("--json");
     expect(skills).toContain("node_modules");
-  });
-
-  it("declared paths follow the content-package prepack mapping", () => {
-    const root = repoRoot();
-    const pkg = readFileSync(join(root, "packages", "content", "package.json"), "utf8");
-    expect(pkg).toContain("content");
-    expect(pkg).toContain("main.md");
-    const declaration = loadDepositRequiredDeclaration(resolveDeclarationFile(root) as string);
-    const contentNeedle = join("content", "x").slice(0, -1);
-    for (const declared of declaration.paths) {
-      const rel = packRelativeFromDepositPath(declared);
-      if (rel === "main.md" || rel === "SKILL.md") {
-        continue;
-      }
-      expect(sourcePathForPackRelative(root, rel)).toContain(contentNeedle);
-    }
-    expect(sep).toBeTruthy();
   });
 });

--- a/packages/core/src/content-contracts/standards/deposit_required_closure.test.ts
+++ b/packages/core/src/content-contracts/standards/deposit_required_closure.test.ts
@@ -1,0 +1,70 @@
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  evaluateDepositClosure,
+  loadDepositRequiredDeclaration,
+  packRelativeFromDepositPath,
+  resolveDeclarationFile,
+  sourcePathForPackRelative,
+} from "../../validate-content/deposit-required.js";
+import { readText, repoRoot } from "./_helpers.js";
+
+const staged: string[] = [];
+
+afterEach(() => {
+  while (staged.length > 0) {
+    const root = staged.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function stageDeclaredPack(root: string): string {
+  const declarationPath = resolveDeclarationFile(root);
+  expect(declarationPath, "C1 declaration must exist in the source tree").toBeTruthy();
+  const declaration = loadDepositRequiredDeclaration(declarationPath as string);
+  const pack = mkdtempSync(join(tmpdir(), "deft-c1-stage-"));
+  staged.push(pack);
+  for (const declared of declaration.paths) {
+    const rel = packRelativeFromDepositPath(declared);
+    const from = sourcePathForPackRelative(root, rel);
+    const to = join(pack, ...rel.split("/"));
+    mkdirSync(dirname(to), { recursive: true });
+    cpSync(from, to);
+  }
+  return pack;
+}
+
+describe("declared deposit closure against staged pack (#3601 C1)", () => {
+  it("every declared required path exists in the prepack-mapped staged tree", () => {
+    const root = repoRoot();
+    const declarationPath = resolveDeclarationFile(root);
+    expect(declarationPath).toBeTruthy();
+    const declaration = loadDepositRequiredDeclaration(declarationPath as string);
+    expect(declaration.paths.length).toBeGreaterThan(0);
+    const pack = stageDeclaredPack(root);
+    const result = evaluateDepositClosure({ packRoot: pack, paths: declaration.paths });
+    expect(result.ok, result.missing.join(", ")).toBe(true);
+  });
+
+  it("fails when a declared file is deleted from the staged tree", () => {
+    const root = repoRoot();
+    const declaration = loadDepositRequiredDeclaration(resolveDeclarationFile(root) as string);
+    const pack = stageDeclaredPack(root);
+    rmSync(join(pack, "main.md"));
+    const mutated = evaluateDepositClosure({ packRoot: pack, paths: declaration.paths });
+    expect(mutated.ok).toBe(false);
+    expect(mutated.missing).toContain(".deft/core/main.md");
+  });
+
+  it("consumer template no longer mandates .deft/core/REFERENCES.md and names the pack-slice text form", () => {
+    const template = readText("templates/agents-entry.md");
+    const skills = template.split("## Skills")[1]?.split("## ")[0] ?? "";
+    expect(skills).not.toContain(".deft/core/REFERENCES.md");
+    expect(skills).toContain("packs:slice skills list");
+    expect(skills).toContain("npx deft");
+    expect(skills).toContain("--json");
+    expect(skills).toContain("node_modules");
+  });
+});

--- a/packages/core/src/validate-content/deposit-required.test.ts
+++ b/packages/core/src/validate-content/deposit-required.test.ts
@@ -155,7 +155,12 @@ describe("prepack mapping", () => {
 describe("renderDeclaredDepositClosureLine", () => {
   it("skips when no declaration is present", () => {
     expect(
-      renderDeclaredDepositClosureLine({ skipped: true, missing: [], declarationPath: null }),
+      renderDeclaredDepositClosureLine({
+        skipped: true,
+        missing: [],
+        declarationPath: null,
+        error: null,
+      }),
     ).toContain("skip");
   });
 
@@ -165,6 +170,7 @@ describe("renderDeclaredDepositClosureLine", () => {
         skipped: false,
         missing: [],
         declarationPath: "contracts/deposit-required-paths.json",
+        error: null,
       }),
     ).toContain("ok");
     expect(
@@ -172,6 +178,7 @@ describe("renderDeclaredDepositClosureLine", () => {
         skipped: false,
         missing: [".deft/core/main.md"],
         declarationPath: "contracts/deposit-required-paths.json",
+        error: null,
       }),
     ).toContain("fail");
   });
@@ -201,5 +208,17 @@ describe("evaluateInstalledDepositClosure", () => {
     const result = evaluateInstalledDepositClosure(root);
     expect(result.skipped).toBe(false);
     expect(result.missing).toEqual([".deft/core/commands.md"]);
+  });
+
+  it("rejects null JSON and does not throw from evaluateInstalledDepositClosure", () => {
+    expect(() => parseDepositRequiredDeclaration("null")).toThrow(/expected an object/);
+    const root = tempRoot();
+    const deft = join(root, ".deft", "core");
+    mkdirSync(join(deft, "contracts"), { recursive: true });
+    writeFileSync(join(deft, "contracts", "deposit-required-paths.json"), "null\n", "utf8");
+    const result = evaluateInstalledDepositClosure(root);
+    expect(result.skipped).toBe(false);
+    expect(result.error).toMatch(/expected an object/);
+    expect(renderDeclaredDepositClosureLine(result)).toContain("fail");
   });
 });

--- a/packages/core/src/validate-content/deposit-required.test.ts
+++ b/packages/core/src/validate-content/deposit-required.test.ts
@@ -1,0 +1,205 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEPOSIT_PREFIX,
+  DEPOSIT_REQUIRED_SCHEMA,
+  evaluateDepositClosure,
+  evaluateInstalledDepositClosure,
+  extractDepositRequiredComments,
+  packRelativeFromDepositPath,
+  parseDepositRequiredDeclaration,
+  renderDeclaredDepositClosureLine,
+  sourcePathForPackRelative,
+} from "./deposit-required.js";
+
+const roots: string[] = [];
+
+function tempRoot(prefix = "deft-c1-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/** Naive ! + .deft/core/ scan -- the extractor C1 must not be. */
+function naiveProseExtractor(source: string): string[] {
+  const out: string[] = [];
+  const pathRe = /\.deft\/core\/[^\s`]+/g;
+  for (const line of source.split("\n")) {
+    if (!line.trimStart().startsWith("!")) continue;
+    let match = pathRe.exec(line);
+    while (match !== null) {
+      out.push(match[0].replace(/[.,;:]+$/, ""));
+      match = pathRe.exec(line);
+    }
+  }
+  return out;
+}
+
+const PROSE_FIXTURE = [
+  "! Full guidelines: .deft/core/main.md <!-- deposit-required: .deft/core/main.md -->",
+  "! load USER.md and xbrief/PROJECT-DEFINITION.xbrief.json",
+  "! If skills cannot be read, read .deft/core/QUICK-START.md",
+  "! Historical: scripts/preflight_implementation.py was removed in #2022",
+  "! Do not ship .deft/core/REFERENCES.md (repo-dev audience boundary)",
+  "\u2297 never `.deft/core/` for cold-start (#2273)",
+].join("\n");
+
+describe("extractDepositRequiredComments (#3601 C1)", () => {
+  it("extracts only parser-visible deposit-required fields", () => {
+    expect(extractDepositRequiredComments(PROSE_FIXTURE)).toEqual([".deft/core/main.md"]);
+  });
+
+  it("does not misclassify consumer-owned, conditional, historical, or prohibited paths", () => {
+    const extracted = extractDepositRequiredComments(PROSE_FIXTURE);
+    expect(extracted).not.toContain("USER.md");
+    expect(extracted).not.toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(extracted).not.toContain(".deft/core/QUICK-START.md");
+    expect(extracted).not.toContain("scripts/preflight_implementation.py");
+    expect(extracted).not.toContain(".deft/core/REFERENCES.md");
+    expect(extracted).not.toContain(".deft/core/");
+  });
+
+  it("differs from a regex over ! prose, which misclassifies the same fixture", () => {
+    const naive = naiveProseExtractor(PROSE_FIXTURE);
+    expect(naive).toEqual(
+      expect.arrayContaining([
+        ".deft/core/main.md",
+        ".deft/core/QUICK-START.md",
+        ".deft/core/REFERENCES.md",
+      ]),
+    );
+    expect(extractDepositRequiredComments(PROSE_FIXTURE)).toEqual([".deft/core/main.md"]);
+  });
+
+  it("returns empty on prose with no typed field", () => {
+    expect(extractDepositRequiredComments("! read .deft/core/commands.md")).toEqual([]);
+  });
+});
+
+describe("parseDepositRequiredDeclaration", () => {
+  it("accepts a closed v1 declaration", () => {
+    const parsed = parseDepositRequiredDeclaration(
+      JSON.stringify({ schema: DEPOSIT_REQUIRED_SCHEMA, paths: [".deft/core/main.md"] }),
+    );
+    expect(parsed.paths).toEqual([".deft/core/main.md"]);
+  });
+
+  it("rejects a missing schema, empty paths, and non-deposit paths", () => {
+    expect(() => parseDepositRequiredDeclaration("{}")).toThrow(/expected schema/);
+    expect(() =>
+      parseDepositRequiredDeclaration(
+        JSON.stringify({ schema: DEPOSIT_REQUIRED_SCHEMA, paths: [] }),
+      ),
+    ).toThrow(/non-empty/);
+    expect(() =>
+      parseDepositRequiredDeclaration(
+        JSON.stringify({ schema: DEPOSIT_REQUIRED_SCHEMA, paths: ["USER.md"] }),
+      ),
+    ).toThrow(/invalid path/);
+    expect(() =>
+      parseDepositRequiredDeclaration(
+        JSON.stringify({ schema: DEPOSIT_REQUIRED_SCHEMA, paths: [".deft/core/../etc/passwd"] }),
+      ),
+    ).toThrow(/invalid path/);
+  });
+});
+
+describe("evaluateDepositClosure mutation (#3601 C1 non-vacuous)", () => {
+  it("passes when every declared path exists in the staged pack, and fails after a delete", () => {
+    const pack = tempRoot();
+    mkdirSync(join(pack, "docs"), { recursive: true });
+    writeFileSync(join(pack, "main.md"), "# main\n", "utf8");
+    writeFileSync(join(pack, "docs", "gate-integrity.md"), "# gate\n", "utf8");
+    const paths = [".deft/core/main.md", ".deft/core/docs/gate-integrity.md"];
+    const ok = evaluateDepositClosure({ packRoot: pack, paths });
+    expect(ok).toEqual({ ok: true, missing: [], checked: 2 });
+
+    rmSync(join(pack, "main.md"));
+    const mutated = evaluateDepositClosure({ packRoot: pack, paths });
+    expect(mutated.ok).toBe(false);
+    expect(mutated.missing).toEqual([".deft/core/main.md"]);
+  });
+
+  it("does not treat a source-checkout-only file as present in the pack", () => {
+    const pack = tempRoot();
+    writeFileSync(join(pack, "main.md"), "# main\n", "utf8");
+    const result = evaluateDepositClosure({
+      packRoot: pack,
+      paths: [".deft/core/main.md", ".deft/core/REFERENCES.md"],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual([".deft/core/REFERENCES.md"]);
+  });
+});
+
+describe("prepack mapping", () => {
+  it("maps harness entries to repo root and other paths under content/", () => {
+    expect(packRelativeFromDepositPath(".deft/core/main.md")).toBe("main.md");
+    expect(sourcePathForPackRelative(join("repo"), "main.md")).toBe(join("repo", "main.md"));
+    expect(sourcePathForPackRelative(join("repo"), "commands.md")).toBe(
+      join("repo", "content", "commands.md"),
+    );
+    expect(DEPOSIT_PREFIX).toBe(".deft/core/");
+  });
+});
+
+describe("renderDeclaredDepositClosureLine", () => {
+  it("skips when no declaration is present", () => {
+    expect(
+      renderDeclaredDepositClosureLine({ skipped: true, missing: [], declarationPath: null }),
+    ).toContain("skip");
+  });
+
+  it("reports ok and fail", () => {
+    expect(
+      renderDeclaredDepositClosureLine({
+        skipped: false,
+        missing: [],
+        declarationPath: "contracts/deposit-required-paths.json",
+      }),
+    ).toContain("ok");
+    expect(
+      renderDeclaredDepositClosureLine({
+        skipped: false,
+        missing: [".deft/core/main.md"],
+        declarationPath: "contracts/deposit-required-paths.json",
+      }),
+    ).toContain("fail");
+  });
+});
+
+describe("evaluateInstalledDepositClosure", () => {
+  it("skips when the declaration is absent", () => {
+    const root = tempRoot();
+    const result = evaluateInstalledDepositClosure(root);
+    expect(result.skipped).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it("reports missing declared paths in an installed deposit", () => {
+    const root = tempRoot();
+    const deft = join(root, ".deft", "core");
+    mkdirSync(join(deft, "contracts"), { recursive: true });
+    writeFileSync(
+      join(deft, "contracts", "deposit-required-paths.json"),
+      JSON.stringify({
+        schema: DEPOSIT_REQUIRED_SCHEMA,
+        paths: [".deft/core/main.md", ".deft/core/commands.md"],
+      }),
+      "utf8",
+    );
+    writeFileSync(join(deft, "main.md"), "# main\n", "utf8");
+    const result = evaluateInstalledDepositClosure(root);
+    expect(result.skipped).toBe(false);
+    expect(result.missing).toEqual([".deft/core/commands.md"]);
+  });
+});

--- a/packages/core/src/validate-content/deposit-required.ts
+++ b/packages/core/src/validate-content/deposit-required.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * C1 declared deposit closure (#3601 / #3899).
+ *
+ * Required consumer-deposit paths are a closed typed declaration, not a
+ * regex over AGENTS.md RFC2119 prose. Existence checks reuse existsSync
+ * the same way validate-links.ts does, against a staged pack root (the
+ * prepack flatten), not the source checkout.
+ */
+
+export const DEPOSIT_REQUIRED_SCHEMA = "deft.deposit-required-paths.v1" as const;
+export const DEPOSIT_REQUIRED_REL = "contracts/deposit-required-paths.json";
+export const DEPOSIT_PREFIX = ".deft/core/";
+
+export interface DepositRequiredDeclaration {
+  readonly schema: typeof DEPOSIT_REQUIRED_SCHEMA;
+  readonly paths: readonly string[];
+}
+
+export interface DepositClosureResult {
+  readonly ok: boolean;
+  readonly missing: readonly string[];
+  readonly checked: number;
+}
+
+/** Parser-visible field. Not a scan of ! / backtick paths. */
+const DEPOSIT_REQUIRED_COMMENT = /<!--\s*deposit-required:\s+(\S+)\s*-->/g;
+
+export function extractDepositRequiredComments(source: string): string[] {
+  const out: string[] = [];
+  const re = new RegExp(DEPOSIT_REQUIRED_COMMENT.source, "g");
+  let match: RegExpExecArray | null = re.exec(source);
+  while (match !== null) {
+    const path = match[1];
+    if (path !== undefined) {
+      out.push(path);
+    }
+    match = re.exec(source);
+  }
+  return out;
+}
+
+export function parseDepositRequiredDeclaration(jsonText: string): DepositRequiredDeclaration {
+  let data: { schema?: unknown; paths?: unknown };
+  try {
+    data = JSON.parse(jsonText) as { schema?: unknown; paths?: unknown };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`deposit-required: invalid JSON (${reason})`);
+  }
+  if (data.schema !== DEPOSIT_REQUIRED_SCHEMA) {
+    throw new Error(
+      "deposit-required: expected schema " +
+        DEPOSIT_REQUIRED_SCHEMA +
+        ", got " +
+        String(data.schema),
+    );
+  }
+  if (!Array.isArray(data.paths) || data.paths.length === 0) {
+    throw new Error("deposit-required: paths must be a non-empty array of strings");
+  }
+  const paths: string[] = [];
+  for (const item of data.paths) {
+    if (
+      typeof item !== "string" ||
+      !item.startsWith(DEPOSIT_PREFIX) ||
+      item.includes("\\") ||
+      item.includes("..")
+    ) {
+      throw new Error(`deposit-required: invalid path ${String(item)}`);
+    }
+    paths.push(item);
+  }
+  return { schema: DEPOSIT_REQUIRED_SCHEMA, paths };
+}
+
+export function packRelativeFromDepositPath(declared: string): string {
+  if (!declared.startsWith(DEPOSIT_PREFIX)) {
+    throw new Error(`deposit-required: not a deposit path: ${declared}`);
+  }
+  return declared.slice(DEPOSIT_PREFIX.length);
+}
+
+/** Prepack mapping used by @deftai/directive-content. */
+export function sourcePathForPackRelative(repoRoot: string, packRelative: string): string {
+  const rel = packRelative.replace(/\\/g, "/");
+  if (
+    rel === "main.md" ||
+    rel === "SKILL.md" ||
+    rel === "Taskfile.yml" ||
+    rel.startsWith("tasks/") ||
+    rel.startsWith(".githooks/")
+  ) {
+    return join(repoRoot, ...rel.split("/"));
+  }
+  return join(repoRoot, "content", ...rel.split("/"));
+}
+
+export function evaluateDepositClosure(options: {
+  readonly packRoot: string;
+  readonly paths: readonly string[];
+}): DepositClosureResult {
+  const missing: string[] = [];
+  for (const declared of options.paths) {
+    const rel = packRelativeFromDepositPath(declared);
+    const target = join(options.packRoot, ...rel.split("/"));
+    if (!existsSync(target)) {
+      missing.push(declared);
+    }
+  }
+  return { ok: missing.length === 0, missing, checked: options.paths.length };
+}
+
+export function loadDepositRequiredDeclaration(filePath: string): DepositRequiredDeclaration {
+  return parseDepositRequiredDeclaration(readFileSync(filePath, "utf8"));
+}
+
+export function resolveDeclarationFile(root: string): string | null {
+  const underContent = join(root, "content", DEPOSIT_REQUIRED_REL);
+  if (existsSync(underContent)) {
+    return underContent;
+  }
+  const underRoot = join(root, DEPOSIT_REQUIRED_REL);
+  if (existsSync(underRoot)) {
+    return underRoot;
+  }
+  return null;
+}
+
+export function evaluateInstalledDepositClosure(projectRoot: string): {
+  readonly skipped: boolean;
+  readonly missing: readonly string[];
+  readonly declarationPath: string | null;
+} {
+  const deftDir = join(projectRoot, ".deft", "core");
+  const declarationPath = resolveDeclarationFile(deftDir) ?? resolveDeclarationFile(projectRoot);
+  if (declarationPath === null) {
+    return { skipped: true, missing: [], declarationPath: null };
+  }
+  if (!existsSync(deftDir)) {
+    return { skipped: true, missing: [], declarationPath };
+  }
+  const declaration = loadDepositRequiredDeclaration(declarationPath);
+  const result = evaluateDepositClosure({ packRoot: deftDir, paths: declaration.paths });
+  return { skipped: false, missing: result.missing, declarationPath };
+}
+
+export function renderDeclaredDepositClosureLine(
+  result: ReturnType<typeof evaluateInstalledDepositClosure>,
+): string {
+  if (result.skipped) {
+    return "Deposit required-paths: skip -- no C1 declaration in this tree.";
+  }
+  if (result.missing.length === 0) {
+    return "Deposit required-paths: ok -- declared C1 paths exist in .deft/core.";
+  }
+  const sample = result.missing.slice(0, 5).join(", ");
+  const extra = result.missing.length > 5 ? ` (+${String(result.missing.length - 5)} more)` : "";
+  return (
+    "Deposit required-paths: fail -- " +
+    String(result.missing.length) +
+    " declared path(s) missing from .deft/core. Examples: " +
+    sample +
+    extra +
+    ". Run directive update to refresh the deposit (#3601 C1)."
+  );
+}

--- a/packages/core/src/validate-content/deposit-required.ts
+++ b/packages/core/src/validate-content/deposit-required.ts
@@ -43,13 +43,18 @@ export function extractDepositRequiredComments(source: string): string[] {
 }
 
 export function parseDepositRequiredDeclaration(jsonText: string): DepositRequiredDeclaration {
-  let data: { schema?: unknown; paths?: unknown };
+  let _data: { schema?: unknown; paths?: unknown };
+  let parsed: unknown;
   try {
-    data = JSON.parse(jsonText) as { schema?: unknown; paths?: unknown };
+    parsed = JSON.parse(jsonText) as unknown;
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(`deposit-required: invalid JSON (${reason})`);
   }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("deposit-required: expected an object");
+  }
+  const data = parsed as { schema?: unknown; paths?: unknown };
   if (data.schema !== DEPOSIT_REQUIRED_SCHEMA) {
     throw new Error(
       "deposit-required: expected schema " +
@@ -133,18 +138,24 @@ export function evaluateInstalledDepositClosure(projectRoot: string): {
   readonly skipped: boolean;
   readonly missing: readonly string[];
   readonly declarationPath: string | null;
+  readonly error: string | null;
 } {
   const deftDir = join(projectRoot, ".deft", "core");
   const declarationPath = resolveDeclarationFile(deftDir) ?? resolveDeclarationFile(projectRoot);
   if (declarationPath === null) {
-    return { skipped: true, missing: [], declarationPath: null };
+    return { skipped: true, missing: [], declarationPath: null, error: null };
   }
   if (!existsSync(deftDir)) {
-    return { skipped: true, missing: [], declarationPath };
+    return { skipped: true, missing: [], declarationPath, error: null };
   }
-  const declaration = loadDepositRequiredDeclaration(declarationPath);
-  const result = evaluateDepositClosure({ packRoot: deftDir, paths: declaration.paths });
-  return { skipped: false, missing: result.missing, declarationPath };
+  try {
+    const declaration = loadDepositRequiredDeclaration(declarationPath);
+    const result = evaluateDepositClosure({ packRoot: deftDir, paths: declaration.paths });
+    return { skipped: false, missing: result.missing, declarationPath, error: null };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { skipped: false, missing: [], declarationPath, error: reason };
+  }
 }
 
 export function renderDeclaredDepositClosureLine(
@@ -152,6 +163,13 @@ export function renderDeclaredDepositClosureLine(
 ): string {
   if (result.skipped) {
     return "Deposit required-paths: skip -- no C1 declaration in this tree.";
+  }
+  if (result.error) {
+    return (
+      "Deposit required-paths: fail -- could not read C1 declaration (" +
+      result.error +
+      "). Run directive update to refresh the deposit (#3601 C1)."
+    );
   }
   if (result.missing.length === 0) {
     return "Deposit required-paths: ok -- declared C1 paths exist in .deft/core.";

--- a/packages/core/src/validate-content/index.ts
+++ b/packages/core/src/validate-content/index.ts
@@ -1,5 +1,6 @@
 export { resolveCapacityAllocation } from "./capacity-policy.js";
 export { computeReport, renderReport } from "./capacity-show.js";
+export * as depositRequired from "./deposit-required.js";
 export { isDatePrefixedVbriefFilename } from "./filename.js";
 export { extractLinkTargets, shouldSkipLinkTarget } from "./link-parser.js";
 export * from "./types.js";

--- a/packaging/openpackage/deft-directive-skills/AGENTS.md
+++ b/packaging/openpackage/deft-directive-skills/AGENTS.md
@@ -2,6 +2,6 @@
 
 Deft is installed via `@deftai/directive` (`directive init`). Full guidelines: `.deft/core/main.md`.
 
-! Before improvising a multi-step workflow, scan `.deft/core/REFERENCES.md` Skills Index and load the matching skill — do not rely on skill enumeration in this file.
+! Before improvising a multi-step workflow, run `npx deft packs:slice skills list` (text form, not `--json`) and load the matching skill — do not rely on skill enumeration in this file.
 
 ⊗ Treat this OpenPackage-deposited AGENTS.md as a skill catalog — tiers and install live in the package README and `deft-tiers.json`.

--- a/packaging/openpackage/deft-directive-skills/README.md
+++ b/packaging/openpackage/deft-directive-skills/README.md
@@ -73,4 +73,4 @@ opkg uninstall @deftai/deft-directive-skills
 
 ## AGENTS.md contract
 
-Consumer AGENTS.md stays **pointer-thin** — scan `.deft/core/REFERENCES.md` Skills Index before improvising; do not enumerate skills in the managed section (#2371 / Q1).
+Consumer AGENTS.md stays **pointer-thin** — run `npx deft packs:slice skills list` before improvising; do not enumerate skills in the managed section (#2371 / Q1).

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -23883,7 +23883,7 @@
       "agentsMdBudget": {
         "managedMaxLines": 166,
         "unmanagedMaxLines": 162,
-        "absoluteMaxBytes": 16530,
+        "absoluteMaxBytes": 16547,
         "skillFrontmatterTier": "daily-core",
         "skillFrontmatterMaxBytes": 2260
       },

--- a/xbrief/active/2026-08-30-3601-consumer-skills-index-via-pack-slice.xbrief.json
+++ b/xbrief/active/2026-08-30-3601-consumer-skills-index-via-pack-slice.xbrief.json
@@ -1,0 +1,155 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for GitHub issue #3601 under bound #3899 design",
+    "updated": "2026-08-30T16:38:09Z"
+  },
+  "plan": {
+    "title": "Consumer Skills Index points at packs:slice; C1 declared deposit closure",
+    "status": "running",
+    "narratives": {
+      "Description": "Point the managed consumer Skills Index at the existing pack slice instead of shipping REFERENCES.md, and add C1 declared deposit closure.",
+      "Origin": "https://github.com/deftai/directive/issues/3601",
+      "Overview": "Bound by #3899 synthesis 5466693576 (citing lean 5466189787) and installed-deposit probe 5466727900. Do not re-open that arc.\\n\\nBranch 1 (reclassify root REFERENCES.md as content and ship it) is rejected: repo-dev is an audience boundary. Branch 2 lands by pointing the managed AGENTS.md card at npx deft packs:slice skills list (text form, not --json; local spelling npx deft or .\\\\node_modules\\\\.bin\\\\deft). Do not generate a new index artifact.\\n\\nC1: every path the deposit mandates an agent to read must resolve in staged pack output. Required paths are a closed typed declaration, not a regex over agents-entry prose. Extraction is tested against positive and negative fixtures (consumer-owned, conditional, historical, prohibited). C1 fails on a deliberately mutated staged tree.\\n\\nRecord the REFERENCES.md classification decision and the version-skew residual via decision:write.\\n\\nDo not close #3899. Closes #3601.",
+      "Labels": "bug, vendored-deposit, area:installer"
+    },
+    "items": [
+      {
+        "title": "Managed consumer Skills Index points at npx deft packs:slice skills list (text form, not --json; local spelling)",
+        "status": "proposed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/skills/agents_entry_contract.test.ts + packages/core/src/content-contracts/skills/agents_md_session_start.test.ts",
+          "recorded_at": "2026-08-30T16:38:09Z",
+          "recorded_by": "leaf-worker/3601"
+        }
+      },
+      {
+        "title": "REFERENCES.md stays bucket repo-dev; consumer template no longer mandates reading it",
+        "status": "proposed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/standards/deposit_required_closure.test.ts#consumer template no longer mandates .deft/core/REFERENCES.md",
+          "recorded_at": "2026-08-30T16:38:09Z",
+          "recorded_by": "leaf-worker/3601"
+        }
+      },
+      {
+        "title": "Closed typed declaration of required deposit paths; extraction fixtures cover consumer-owned, conditional, historical, and prohibited references with no misclassification",
+        "status": "proposed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/validate-content/deposit-required.test.ts",
+          "recorded_at": "2026-08-30T16:38:09Z",
+          "recorded_by": "leaf-worker/3601"
+        }
+      },
+      {
+        "title": "C1 checks declared paths against staged pack output and fails on a mutated staged tree",
+        "status": "proposed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/content-contracts/standards/deposit_required_closure.test.ts#fails when a declared file is deleted from the staged pack output",
+          "recorded_at": "2026-08-30T16:38:09Z",
+          "recorded_by": "leaf-worker/3601"
+        }
+      },
+      {
+        "title": "Decision log records the classification choice and the version-skew residual",
+        "status": "proposed",
+        "x-directive/evidence": {
+          "kind": "observed_behavior",
+          "pointer": "xbrief/decisions/2026-08-30-keep-references-md-repo-dev-point-consumer-index-at-pack-slice.decision.json + xbrief/decisions/2026-08-30-record-packs-slice-cli-bundled-content-version-skew-residual.decision.json",
+          "recorded_at": "2026-08-30T16:38:09Z",
+          "recorded_by": "leaf-worker/3601"
+        }
+      },
+      {
+        "title": "CHANGELOG [Unreleased] entry; Closes #3601; does not close #3899",
+        "status": "proposed",
+        "x-directive/evidence": {
+          "kind": "observed_behavior",
+          "pointer": "CHANGELOG.md [Unreleased] #3601; https://github.com/deftai/directive/pull/3958 body Closes #3601 and does not close #3899",
+          "recorded_at": "2026-08-30T16:38:09Z",
+          "recorded_by": "leaf-worker/3601"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "packaging",
+      "agents"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3601",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3601: consumer AGENTS points to REFERENCES.md that npm never deposits"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/3899",
+        "type": "x-xbrief/refs",
+        "title": "Issue #3899: post-release remediation sequencing"
+      }
+    ],
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "Issue AC is outcome-shaped; no verbatim shell commands were stated as the pass bar.",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "Manifest classification of REFERENCES.md and the consumer template mandatory read agree",
+          "artifact_path": "content/templates/agents-entry.md",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "Packed consumer deposit contains every path declared required, checked against staged pack output",
+          "artifact_path": "content/contracts/deposit-required-paths.json",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "Required-path set is declared in a closed typed form; extraction tested against prose fixtures with no misclassification",
+          "artifact_path": "packages/core/src/validate-content/deposit-required.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "C1 fails on a deliberately mutated staged tree",
+          "artifact_path": "packages/core/src/validate-content/deposit-required.test.ts",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "Decision log records classification and version-skew residual",
+          "artifact_path": "xbrief/decisions/",
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "CHANGELOG [Unreleased] entry; PR closes #3601 and does not close #3899",
+          "artifact_path": "CHANGELOG.md",
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "metadata": {
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      }
+    },
+    "updated": "2026-08-30T16:38:09Z"
+  }
+}

--- a/xbrief/decisions/2026-08-30-keep-references-md-repo-dev-point-consumer-index-at-pack-slice.decision.json
+++ b/xbrief/decisions/2026-08-30-keep-references-md-repo-dev-point-consumer-index-at-pack-slice.decision.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "keep-references-md-repo-dev-point-consumer-index-at-pack-slice",
+  "decision": "Keep root REFERENCES.md as bucket repo-dev and point the consumer Skills Index at npx deft packs:slice skills list (text form) instead of shipping that file",
+  "governingRule": {
+    "description": "content-manifest buckets classify by who a file is for; repo-dev means maintainer-only. Bound #3899 synthesis 5466693576 rejected reclassifying REFERENCES.md as content.",
+    "path": "content/conventions/content-manifest.json",
+    "rfc2119": "MUST"
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Reclassify REFERENCES.md as content with harnessEntry true and ship it (branch 1)",
+      "whyNot": "repo-dev is an audience boundary, not a size cap; the file cites maintainer paths and ./content/skills links no deposit contains"
+    },
+    {
+      "option": "Generate a new consumer Skills Index artifact",
+      "whyNot": "Dominated by the existing pack slice; adds a projection five surfaces must agree on"
+    },
+    {
+      "option": "Delete the mandate with no replacement",
+      "whyNot": "Removes the only promised route to 19 on-demand skills"
+    }
+  ],
+  "whyWinner": "Installed-deposit probe 5466727900 measured npx deft packs:slice skills list working from two greenfield 0.108.0 installs (exit 0, 25 records, all paths resolving, no session:start). Naming the text form avoids the 545 KB --json body inline. Local spelling npx deft / .\\node_modules\\.bin\\deft avoids the host global shim.",
+  "confidence": "high",
+  "activeScopeRefs": [
+    "xbrief/active/2026-08-30-3601-consumer-skills-index-via-pack-slice.xbrief.json"
+  ],
+  "timestamp": "2026-08-30T11:10:00Z",
+  "revisitTrigger": "If a version-skewed CLI and deposit pair is measured to emit an index citing paths absent from that deposit, revisit generating a deposit-local index",
+  "tags": [
+    "packaging",
+    "process"
+  ],
+  "relatedIssues": [
+    3601,
+    3899
+  ]
+}

--- a/xbrief/decisions/2026-08-30-record-packs-slice-cli-bundled-content-version-skew-residual.decision.json
+++ b/xbrief/decisions/2026-08-30-record-packs-slice-cli-bundled-content-version-skew-residual.decision.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "record-packs-slice-cli-bundled-content-version-skew-residual",
+  "decision": "Record as residual that packs:slice reads the CLI bundled content pack, not the consumer deposit",
+  "governingRule": {
+    "description": "Significant hard-to-reverse process choices leave a revisit trigger (#1396). Probe 5466727900 measured the slice output unchanged after renaming .deft/core/packs away.",
+    "path": "content/docs/decision-log.md",
+    "rfc2119": "SHOULD"
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Generate a deposit-local Skills Index artifact so the index cannot cite missing deposit paths",
+      "whyNot": "Not measured as needed; the pack slice already covers 25/25 resolving paths on a matched install and adding a projection is the dominated option from the bound lean"
+    },
+    {
+      "option": "Make packs:slice read .deft/core/packs instead of the CLI bundle",
+      "whyNot": "Out of this story; would change runtime for every consumer and was not the bound remedy"
+    }
+  ],
+  "whyWinner": "The mismatch is real and unmeasured on a skewed pair. Recording it is the bound requirement. A generated artifact stays rejected unless this residual is later measured to bite.",
+  "confidence": "high",
+  "activeScopeRefs": [
+    "xbrief/active/2026-08-30-3601-consumer-skills-index-via-pack-slice.xbrief.json"
+  ],
+  "timestamp": "2026-08-30T11:10:00Z",
+  "revisitTrigger": "If a consumer with a version-skewed CLI versus deposit reports packs:slice listing skills whose SKILL.md is missing from .deft/core, reopen whether the index should be deposit-local",
+  "tags": [
+    "packaging",
+    "process"
+  ],
+  "relatedIssues": [
+    3601,
+    3899
+  ]
+}


### PR DESCRIPTION
## Summary

Consumer AGENTS.md no longer mandates `.deft/core/REFERENCES.md` as the Level-0 Skills Index. That file is bucket `repo-dev` (maintainer-only) and is not deposited. Bound #3899 synthesis rejected shipping it.

The managed card now names `npx deft packs:slice skills list` (text form, not `--json`; local also `.\node_modules\.bin\deft`).

C1 declared deposit closure: required consumer-deposit paths are a closed JSON declaration (`content/contracts/deposit-required-paths.json`) plus a parser-visible HTML comment field tested against prose fixtures. Existence is checked against staged pack output (prepack mapping), and the gate fails when a declared file is deleted from that tree.

## Decisions

- Keep `REFERENCES.md` as `repo-dev`; do not reclassify as content.
- Record the residual that `packs:slice` reads CLI bundled content, not the deposit.

## Test plan

- [x] Extractor fixtures: consumer-owned, conditional, historical, prohibited references are not misclassified
- [x] C1 fails after deleting `main.md` from a staged pack
- [x] Live declaration paths resolve via prepack mapping
- [x] agents-entry contract + session-start pointer tests
- [x] `verify:forward-coverage` / `verify:encoding`

Closes #3601
