### PR TITLE
chore: land completed-tracked artifact for #3612

### DIFF
--- a/xbrief/completed/2026-08-30-3612-runtime-writer-ignore-containment.xbrief.json
+++ b/xbrief/completed/2026-08-30-3612-runtime-writer-ignore-containment.xbrief.json
@@ -2,59 +2,95 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF for #3612: couple runtime writer paths to both shipped gitignore baselines, relocate the three filed .deft writers under .deft/cache/, and fail-closed prove containment.",
-    "updated": "2026-08-30T18:35:34Z"
+    "updated": "2026-08-30T19:08:31Z"
   },
   "plan": {
     "title": "BLOCKER: bug(init): acceptance lifecycle writes unignored .deft runtime state",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Bound design-critique for #3612. The defect is real: verify:ac and scope:complete write .deft/ac-pass-banks/, .deft/verify-ac-session-cache/, and .deft/last-completed.json, which are absent from both ignore baselines, so a freshly initialised consumer dirties. The one-line list-add is refuted. Authority is critic 5470426194, successor lean 5470455968, verified-claims 5470459185, synthesis 5470462960.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3612",
       "Overview": "Bound contract: couple ignore set to writers on both shipped surfaces; prefer relocate under .deft/cache/; name skip-update and already-tracked holes; occupancy remains the shared-worktree fence.",
       "Labels": "bug, blocks-release-tag, design-critique:triage-ready",
-      "Decisions": "- xbrief/decisions/2026-08-30-relocate-the-three-3612-session-ac-runtime-writers-under-already.decision.json \u2014 Relocate the three #3612 session/AC runtime writers under already-ignored .deft/cache/; keep authz, delivery-attempts, metrics, escalations, and approved-scope at their historical names; couple both shipped ignore lists to imported writer path constants with a fail-closed containment test."
+      "Decisions": "- xbrief/decisions/2026-08-30-relocate-the-three-3612-session-ac-runtime-writers-under-already.decision.json — Relocate the three #3612 session/AC runtime writers under already-ignored .deft/cache/; keep authz, delivery-attempts, metrics, escalations, and approved-scope at their historical names; couple both shipped ignore lists to imported writer path constants with a fail-closed containment test."
     },
     "items": [
       {
         "title": "Relocate the three filed runtime writers under .deft/cache/",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "AC_PASS_BANK_DIR, VERIFY_AC_SESSION_CACHE_DIR, and SESSION_COMPLETED_MARKER_REL write under .deft/cache/, which is already in the TypeScript baseline; occupancy remains the shared-worktree fence."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/runtime-writers.test.ts#relocate-under-cache",
+          "recorded_at": "2026-08-30T19:08:21Z",
+          "recorded_by": "leaf-worker/3612"
         }
       },
       {
         "title": "Fail-closed containment of every runtime writer path on both shipped ignore surfaces",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "A registry built from imported writer path constants is covered by CANONICAL_GITIGNORE_BASELINE and by canonicalGitignoreLines; the check fails closed on either surface."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/runtime-writers.test.ts#containment-both-surfaces",
+          "recorded_at": "2026-08-30T19:08:21Z",
+          "recorded_by": "leaf-worker/3612"
         }
       },
       {
         "title": "Containment helper is not vacuous",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "A deliberately added writer path that is not in the ignore set fails the containment check on both surfaces."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/runtime-writers.test.ts#non-vacuous",
+          "recorded_at": "2026-08-30T19:08:21Z",
+          "recorded_by": "leaf-worker/3612"
         }
       },
       {
         "title": "Throwaway consumer seeded with the baseline stays clean after the three writers run",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "In an OS-temp git repo whose .gitignore is the shipped baseline, writing the three relocated paths yields no git status --short hit and git check-ignore -v matches .deft/cache/. Not verified against this clone."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/init-deposit/runtime-writers.test.ts#throwaway-consumer",
+          "recorded_at": "2026-08-30T19:08:21Z",
+          "recorded_by": "leaf-worker/3612"
         }
       },
       {
         "title": "Cover remaining exported runtime writer roots and restore TS/Go ignore parity",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "AUTHZ_DIR, DELIVERY_ATTEMPT_DIR, PROJECT_LOCAL_METRICS_DIR, ESCALATION_DIR, and APPROVED_SCOPE_DIR are in the registry and covered on both surfaces. Every TypeScript baseline line is present in the Go list."
+        },
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "cmd/deft-install/gitignore_runtime_writers_test.go#TestCanonicalGitignoreContainsTypeScriptBaseline",
+          "recorded_at": "2026-08-30T19:08:21Z",
+          "recorded_by": "leaf-worker/3612"
         }
       },
       {
         "title": "CHANGELOG names the two unreachable cases and the update-append heal",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "CHANGELOG [Unreleased] states: consumers who never run update are not reached; a path already tracked in a consumer index is unaffected by an ignore rule; directive update / Go install already append missing baseline lines."
+        },
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "CHANGELOG.md#[Unreleased] #3612",
+          "recorded_at": "2026-08-30T19:08:21Z",
+          "recorded_by": "leaf-worker/3612"
         }
       }
     ],
@@ -92,7 +128,30 @@
         ],
         "module_boundary": "packages/core/src/init-deposit",
         "cohesion_exemption": "CHANGELOG.md is a chronological append-only release log. Go installer baseline lives in cmd/deft-install/setup.go, the second shipped surface."
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3971,
+        "prBase": null,
+        "mergeCommit": "b8a0900bc9c7173ecff104e26b29f242e6f4dc64",
+        "deliveryBranch": "master",
+        "deliveryCommit": "b8a0900bc9c7173ecff104e26b29f242e6f4dc64",
+        "verifiedAt": "2026-08-30T19:08:31Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-08-30T19:08:31Z"
+      },
+      "completedAt": "2026-08-30T19:08:31Z",
+      "capacityBucket": "new-capability"
     },
     "acceptance": {
       "commands": [],
@@ -127,6 +186,6 @@
       ],
       "ambiguity_attestation": "none_found"
     },
-    "updated": "2026-08-30T18:35:34Z"
+    "updated": "2026-08-30T19:08:31Z"
   }
 }


### PR DESCRIPTION
## Summary

Land the completed-tracked artifact for #3612 after squash of PR 3971 (b8a0900b). Moves the running xBRIEF from xbrief/active/ to xbrief/completed/. Does not reopen or recut that issue.

## Related Issues

Refs #3612, #2321, #3476

## Checklist

- [x] /deft:change - N/A (lifecycle move only)
- [x] CHANGELOG.md - N/A (lifecycle tracking, same pattern as prior completed-tracked landings)
- [x] ROADMAP.md - N/A
- [x] Tests pass locally - N/A (xBRIEF move only)
