### PR TITLE
docs(changelog): record the Grok Build write-gate known issue for this release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Known issue: on Grok Build, shell-issued writes bypass the write gate and do not refresh the occupancy lease (#3987).** Directive's PreToolUse hooks gate this host's edit and spawn tools, but its shell tool is named `run_terminal_command` and is absent from the matcher set, so a write refused through the edit tool succeeds when reissued through the shell. Because that same gate is also the only thing that refreshes a worktree occupancy lease, a session whose writes all go through the shell can appear abandoned within the staleness window and have its worktree legitimately claimed by a concurrent agent. This release carries the Grok host-identity transport (#3948) that lease refresh depends on; matcher coverage is in flight separately (#3990), and the remaining lease-liveness work is tracked on #3987. Claude Code, Cursor, and Codex deposits carry the shell matcher and are not affected. Refs #3599, #3742, #3785.
+- **Known issue: Grok Build shell writes bypass the write gate and occupancy-lease refresh (#3987).** Its unmatched `run_terminal_command` tool can write after an edit-tool denial and can let an active worktree appear abandoned. Matcher coverage is tracked in #3990; Claude Code, Cursor, and Codex are unaffected.
 ## [0.108.0] - 2026-08-29
 
 > Worktree leases admit named child sessions, a missing hook runtime is now recoverable instead of an opaque lockout, and lifecycle gates stop trusting stale issue state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Security
+
+- **Known issue: on Grok Build, shell-issued writes bypass the write gate and do not refresh the occupancy lease (#3987).** Directive's PreToolUse hooks gate this host's edit and spawn tools, but its shell tool is named `run_terminal_command` and is absent from the matcher set, so a write refused through the edit tool succeeds when reissued through the shell. Because that same gate is also the only thing that refreshes a worktree occupancy lease, a session whose writes all go through the shell can appear abandoned within the staleness window and have its worktree legitimately claimed by a concurrent agent. This release carries the Grok host-identity transport (#3948) that lease refresh depends on; matcher coverage is in flight separately (#3990), and the remaining lease-liveness work is tracked on #3987. Claude Code, Cursor, and Codex deposits carry the shell matcher and are not affected. Refs #3599, #3742, #3785.
 ## [0.108.0] - 2026-08-29
 
 > Worktree leases admit named child sessions, a missing hook runtime is now recoverable instead of an opaque lockout, and lifecycle gates stop trusting stale issue state.


### PR DESCRIPTION
Adds one `### Security` entry under `[Unreleased]` so the release notes state a known gap rather than leaving it implicit. Documentation only; no code changes.

## Why

All three seats of the design-critique panel on #3987 independently concluded that cutting a release from a host whose write gate observes a small fraction of its tool calls is a process defect that belongs stated explicitly. Arc record 5471391657, accepted lean 5471385046, verified-claims table 5471389091.

## What the note says

On Grok Build the PreToolUse hooks gate the edit and spawn tools, but the host's shell tool is `run_terminal_command` and is absent from the matcher set — so a write refused through the edit tool succeeds when reissued through the shell. Because that same gate is the only feed that refreshes a worktree occupancy lease, a session whose writes all go through the shell can appear abandoned inside the staleness window and lose its worktree to a concurrent agent.

It also records the parts a reader needs to size it: this release carries the Grok host-identity transport (#3948) that lease refresh depends on, matcher coverage is in flight separately (#3990), and the Claude Code, Cursor, and Codex deposits carry the shell matcher and are unaffected.

## Verification

`task check` green on this branch (exit 0). Pre-commit gates green: branch protection, encoding, forward coverage, vBRIEF conformance, xBRIEF drift.

Refs #3987, #3990, #3948, #3599, #3742, #3785