### PR TITLE
docs(changelog): restore Grok identity prerequisite note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Known issue: Grok Build shell writes bypass the write gate and occupancy-lease refresh (#3987).** Its unmatched `run_terminal_command` tool can write after an edit-tool denial and can let an active worktree appear abandoned. Matcher coverage is tracked in #3990; Claude Code, Cursor, and Codex are unaffected.
+- **Known issue: Grok Build shell writes bypass the write gate and occupancy-lease refresh (#3987).** Its unmatched `run_terminal_command` tool can write after an edit-tool denial and can let an active worktree appear abandoned. This release carries the Grok host-identity transport (#3948) that lease refresh depends on; matcher coverage is tracked in #3990. Claude Code, Cursor, and Codex are unaffected.
 ## [0.108.0] - 2026-08-29
 
 > Worktree leases admit named child sessions, a missing hook runtime is now recoverable instead of an opaque lockout, and lifecycle gates stop trusting stale issue state.


### PR DESCRIPTION
## Summary

Restores the #3948 prerequisite sentence that was dropped by the P2 condense in #3991, at operator instruction. This keeps the release note explicit that this release carries the Grok host-identity transport required by lease refresh.

## Related Issues

Refs #3987, #3990, #3948

## Checklist

- [x] `/deft:change` — N/A: one-file, documentation-only correction
- [x] `CHANGELOG.md` — corrected under `[Unreleased]` → `Security`
- [x] `ROADMAP.md` — N/A: this PR does not close a tracked issue
- [x] Tests pass locally — 3 files, 23 tests passed

## Post-Merge

- [x] Verify #3987 and #3990 remain open; #3948 is already closed and must remain closed
- [x] Branch protection on `master` is already repository policy