### PR TITLE
fix(scope): bind derived AC clauses to exact file_scope at promote (#4008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`scope:promote` now binds a derived acceptance clause to an exact `file_scope` member, or refuses the promote (#4008).** After #3835, derivation stores no prose path, so a story that already declared `plan.metadata.swarm.file_scope` still walked as unverifiable. Promote copies the matching declared member onto the clause (and stored `readings[]`); a path-bearing clause that names no unique exact member fails closed. Basename matching stays refused. Does not walk `ImplementationPlan` as acceptance or move the literal-AC allowlist. Closes #4008. Refs #3835, #3323.
 - **A copied occupancy lease from another worktree no longer occupies a fresh tree (#3926).** `.deft/occupancy.json` whose `worktree_path` is not this checkout is residue, not a live occupant: first `session:start` claims, and the steal-then-start path reports the stealer as occupant when identity is consistent. Same-tree two-session conflict still fails closed. Identity minting and the TTL/cap stay on #3954 / #3599. Closes #3926. Refs #3433, #3954.
 
 - **Land completed-tracked artifact for #4035 (#3264 / #1358).** The #4035 xBRIEF stayed untracked after squash of PR 4036 (`11b4c407`). Moved to `xbrief/completed/` via scope:complete. Does not recut that issue. Refs #2321, #3476.

--- a/packages/core/src/scope/clause-file-scope-bind.test.ts
+++ b/packages/core/src/scope/clause-file-scope-bind.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPromoteClauseFileScopeBind,
+  evaluatePromoteClauseFileScopeBind,
+} from "./clause-file-scope-bind.js";
+
+const DECLARED = "src/ui/ledger-table/useDensity.ts";
+
+function planWith(clauses: unknown[], fileScope: string[] = [DECLARED]): Record<string, unknown> {
+  return {
+    title: "density",
+    narratives: { Overview: `## Acceptance sketch\n- Add ${DECLARED} exposing mode\n` },
+    metadata: { swarm: { file_scope: fileScope } },
+    acceptance: {
+      commands: [],
+      none_stated: true,
+      source_rung: "derived",
+      clauses,
+    },
+  };
+}
+
+describe("promote clause file_scope bind (#4008)", () => {
+  it("stamps the declared member onto a matching derived clause", () => {
+    const plan = planWith([
+      {
+        id: 1,
+        text: `Add ${DECLARED} exposing mode`,
+        artifact_path: null,
+        ambiguous: false,
+      },
+    ]);
+    const result = applyPromoteClauseFileScopeBind(plan);
+    expect(result.ok).toBe(true);
+    expect(result.changed).toBe(true);
+    const acceptance = plan.acceptance as { clauses: { artifact_path: string | null }[] };
+    expect(acceptance.clauses[0]?.artifact_path).toBe(DECLARED);
+  });
+
+  it("refuses promote when a path-bearing clause names no exact member", () => {
+    const plan = planWith([
+      {
+        id: 1,
+        text: "Add useDensity.ts exposing mode",
+        artifact_path: null,
+        ambiguous: false,
+      },
+    ]);
+    const result = evaluatePromoteClauseFileScopeBind(plan);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("#4008");
+    expect(result.message).toContain("Basename matching is refused");
+  });
+
+  it("skips the gate when file_scope is empty", () => {
+    const plan = planWith(
+      [
+        {
+          id: 1,
+          text: `Add ${DECLARED} exposing mode`,
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      [],
+    );
+    const result = applyPromoteClauseFileScopeBind(plan);
+    expect(result.ok).toBe(true);
+    expect(result.changed).toBe(false);
+  });
+});

--- a/packages/core/src/scope/clause-file-scope-bind.test.ts
+++ b/packages/core/src/scope/clause-file-scope-bind.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyPromoteClauseFileScopeBind,
   evaluatePromoteClauseFileScopeBind,
+  shouldApplyPromoteClauseFileScopeBind,
 } from "./clause-file-scope-bind.js";
 
 const DECLARED = "src/ui/ledger-table/useDensity.ts";
@@ -50,6 +51,46 @@ describe("promote clause file_scope bind (#4008)", () => {
     expect(result.ok).toBe(false);
     expect(result.message).toContain("#4008");
     expect(result.message).toContain("Basename matching is refused");
+  });
+
+  it("stamps duplicate clause ids in row order rather than last-id-wins", () => {
+    const plan = planWith([
+      {
+        id: 1,
+        text: `Add ${DECLARED} exposing mode`,
+        artifact_path: null,
+        ambiguous: false,
+      },
+      {
+        id: 1,
+        text: "No clause-count cap is introduced",
+        artifact_path: null,
+        ambiguous: false,
+      },
+    ]);
+    const result = applyPromoteClauseFileScopeBind(plan);
+    expect(result.ok).toBe(true);
+    const acceptance = plan.acceptance as { clauses: { artifact_path: string | null }[] };
+    expect(acceptance.clauses[0]?.artifact_path).toBe(DECLARED);
+    expect(acceptance.clauses[1]?.artifact_path).toBeNull();
+  });
+
+  it("does not apply the derived bind gate to stated stamps unless derivation ran", () => {
+    expect(
+      shouldApplyPromoteClauseFileScopeBind(
+        { acceptance: { source_rung: "stated", clauses: [{ id: 1, text: "x" }] } },
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      shouldApplyPromoteClauseFileScopeBind(
+        { acceptance: { source_rung: "stated", clauses: [{ id: 1, text: "x" }] } },
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      shouldApplyPromoteClauseFileScopeBind({ acceptance: { source_rung: "derived" } }, false),
+    ).toBe(true);
   });
 
   it("skips the gate when file_scope is empty", () => {

--- a/packages/core/src/scope/clause-file-scope-bind.test.ts
+++ b/packages/core/src/scope/clause-file-scope-bind.test.ts
@@ -75,22 +75,15 @@ describe("promote clause file_scope bind (#4008)", () => {
     expect(acceptance.clauses[1]?.artifact_path).toBeNull();
   });
 
-  it("does not apply the derived bind gate to stated stamps unless derivation ran", () => {
+  it("does not apply the derived bind gate to stated stamps", () => {
     expect(
-      shouldApplyPromoteClauseFileScopeBind(
-        { acceptance: { source_rung: "stated", clauses: [{ id: 1, text: "x" }] } },
-        false,
-      ),
+      shouldApplyPromoteClauseFileScopeBind({
+        acceptance: { source_rung: "stated", clauses: [{ id: 1, text: "x" }] },
+      }),
     ).toBe(false);
-    expect(
-      shouldApplyPromoteClauseFileScopeBind(
-        { acceptance: { source_rung: "stated", clauses: [{ id: 1, text: "x" }] } },
-        true,
-      ),
-    ).toBe(true);
-    expect(
-      shouldApplyPromoteClauseFileScopeBind({ acceptance: { source_rung: "derived" } }, false),
-    ).toBe(true);
+    expect(shouldApplyPromoteClauseFileScopeBind({ acceptance: { source_rung: "derived" } })).toBe(
+      true,
+    );
   });
 
   it("skips the gate when file_scope is empty", () => {

--- a/packages/core/src/scope/clause-file-scope-bind.ts
+++ b/packages/core/src/scope/clause-file-scope-bind.ts
@@ -29,13 +29,7 @@ export function evaluatePromoteClauseFileScopeBind(
 }
 
 /** Derived stamps only: stated/legacy clauses are not this gate (#4008 Greptile P1). */
-export function shouldApplyPromoteClauseFileScopeBind(
-  plan: Record<string, unknown>,
-  derivationApplied: boolean,
-): boolean {
-  if (derivationApplied) {
-    return true;
-  }
+export function shouldApplyPromoteClauseFileScopeBind(plan: Record<string, unknown>): boolean {
   const acceptance = asRecord(plan.acceptance);
   return acceptance?.source_rung === "derived";
 }

--- a/packages/core/src/scope/clause-file-scope-bind.ts
+++ b/packages/core/src/scope/clause-file-scope-bind.ts
@@ -1,0 +1,67 @@
+/**
+ * Promote-time bind of derived clauses to approved file_scope members (#4008).
+ *
+ * Walk-time basename matching is refused (#3835). This gate copies an exact
+ * declared member onto the clause, or refuses the lifecycle write.
+ */
+
+import {
+  bindClausesToDeclaredScope,
+  type ClauseFileScopeBindResult,
+  readAcceptanceClauses,
+  readDeclaredArtifactScope,
+} from "../verify-ac/clauses.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+export function evaluatePromoteClauseFileScopeBind(
+  plan: Record<string, unknown>,
+): ClauseFileScopeBindResult {
+  return bindClausesToDeclaredScope(
+    readAcceptanceClauses(plan.acceptance),
+    readDeclaredArtifactScope(plan),
+  );
+}
+
+export function applyPromoteClauseFileScopeBind(
+  plan: Record<string, unknown>,
+): ClauseFileScopeBindResult {
+  const result = evaluatePromoteClauseFileScopeBind(plan);
+  if (!result.ok || !result.changed) {
+    return result;
+  }
+  const acceptance = asRecord(plan.acceptance);
+  if (acceptance === null || !Array.isArray(acceptance.clauses)) {
+    return result;
+  }
+  const byId = new Map(result.clauses.map((clause) => [clause.id, clause]));
+  acceptance.clauses = acceptance.clauses.map((entry) => {
+    const row = asRecord(entry);
+    if (row === null || typeof row.id !== "number") {
+      return entry;
+    }
+    const bound = byId.get(row.id);
+    if (bound === undefined) {
+      return entry;
+    }
+    const stamped: Record<string, unknown> = {
+      ...row,
+      artifact_path: bound.artifact_path,
+    };
+    if (bound.readings !== undefined) {
+      stamped.readings = bound.readings.map((reading) => ({
+        text: reading.text,
+        artifact_path: reading.artifact_path,
+      }));
+      stamped.chosen_reading = bound.chosen_reading ?? 0;
+    }
+    return stamped;
+  });
+  plan.acceptance = acceptance;
+  return result;
+}

--- a/packages/core/src/scope/clause-file-scope-bind.ts
+++ b/packages/core/src/scope/clause-file-scope-bind.ts
@@ -28,6 +28,18 @@ export function evaluatePromoteClauseFileScopeBind(
   );
 }
 
+/** Derived stamps only: stated/legacy clauses are not this gate (#4008 Greptile P1). */
+export function shouldApplyPromoteClauseFileScopeBind(
+  plan: Record<string, unknown>,
+  derivationApplied: boolean,
+): boolean {
+  if (derivationApplied) {
+    return true;
+  }
+  const acceptance = asRecord(plan.acceptance);
+  return acceptance?.source_rung === "derived";
+}
+
 export function applyPromoteClauseFileScopeBind(
   plan: Record<string, unknown>,
 ): ClauseFileScopeBindResult {
@@ -39,13 +51,18 @@ export function applyPromoteClauseFileScopeBind(
   if (acceptance === null || !Array.isArray(acceptance.clauses)) {
     return result;
   }
-  const byId = new Map(result.clauses.map((clause) => [clause.id, clause]));
+  let nextBound = 0;
   acceptance.clauses = acceptance.clauses.map((entry) => {
     const row = asRecord(entry);
-    if (row === null || typeof row.id !== "number") {
+    if (row === null) {
       return entry;
     }
-    const bound = byId.get(row.id);
+    const text = typeof row.text === "string" ? row.text.trim() : "";
+    if (text.length === 0) {
+      return entry;
+    }
+    const bound = result.clauses[nextBound];
+    nextBound += 1;
     if (bound === undefined) {
       return entry;
     }

--- a/packages/core/src/scope/index.ts
+++ b/packages/core/src/scope/index.ts
@@ -2,6 +2,7 @@ export * from "./acceptance-activate-gate.js";
 export * from "./acceptance-evidence.js";
 export * from "./audit-log.js";
 export * from "./batch-promote.js";
+export * from "./clause-file-scope-bind.js";
 export * from "./constants.js";
 export * from "./coverage-map.js";
 export * from "./decomposed-refs.js";

--- a/packages/core/src/scope/transition.test.ts
+++ b/packages/core/src/scope/transition.test.ts
@@ -331,6 +331,33 @@ describe("runTransition", () => {
     expect(existsSync(join(root, "xbrief", "pending", "stated.xbrief.json"))).toBe(true);
   });
 
+  it("does not refuse command-only stated acceptance that derivation supplements (#4008)", () => {
+    root = makeRepo();
+    const path = join(root, "xbrief", "proposed", "cmd-scope.xbrief.json");
+    writeFile(path, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Command only with scope",
+        status: "proposed",
+        narratives: {
+          Overview: "## Acceptance sketch\n- Add useDensity.ts exposing mode\n",
+        },
+        metadata: {
+          swarm: { file_scope: ["src/ui/ledger-table/useDensity.ts"] },
+        },
+        acceptance: {
+          commands: [{ command: "pnpm test" }],
+          none_stated: false,
+          source_rung: "stated",
+        },
+        items: [],
+      },
+    });
+    const result = runTransition("promote", path);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(root, "xbrief", "pending", "cmd-scope.xbrief.json"))).toBe(true);
+  });
+
   it("surfaces refused-derivation remediation on activate even when applied is false (#3398)", () => {
     root = makeRepo();
     const path = join(root, "xbrief", "pending", "impl-only.xbrief.json");

--- a/packages/core/src/scope/transition.test.ts
+++ b/packages/core/src/scope/transition.test.ts
@@ -244,6 +244,60 @@ describe("runTransition", () => {
     expect(data.plan.acceptance.clauses).toHaveLength(1);
   });
 
+  it("binds a derived clause to an exact file_scope member on promote (#4008)", () => {
+    root = makeRepo();
+    const path = join(root, "xbrief", "proposed", "density.xbrief.json");
+    writeFile(path, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Density helper",
+        status: "proposed",
+        narratives: {
+          Overview: "## Acceptance sketch\n- Add src/ui/ledger-table/useDensity.ts exposing mode\n",
+        },
+        metadata: {
+          swarm: { file_scope: ["src/ui/ledger-table/useDensity.ts"] },
+        },
+        items: [],
+      },
+    });
+    const result = runTransition("promote", path);
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("#4008");
+    const dest = join(root, "xbrief", "pending", "density.xbrief.json");
+    const data = JSON.parse(readFileSync(dest, "utf8")) as {
+      plan: { acceptance: { clauses: { artifact_path: string | null }[] } };
+    };
+    expect(data.plan.acceptance.clauses).toHaveLength(1);
+    expect(data.plan.acceptance.clauses[0]?.artifact_path).toBe(
+      "src/ui/ledger-table/useDensity.ts",
+    );
+  });
+
+  it("refuses promote when a derived clause cannot bind to file_scope (#4008)", () => {
+    root = makeRepo();
+    const path = join(root, "xbrief", "proposed", "bare.xbrief.json");
+    writeFile(path, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Bare filename",
+        status: "proposed",
+        narratives: {
+          Overview: "## Acceptance sketch\n- Add useDensity.ts exposing mode\n",
+        },
+        metadata: {
+          swarm: { file_scope: ["src/ui/ledger-table/useDensity.ts"] },
+        },
+        items: [],
+      },
+    });
+    const result = runTransition("promote", path);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("#4008");
+    expect(result.message).toContain("Basename matching is refused");
+    expect(existsSync(join(root, "xbrief", "pending", "bare.xbrief.json"))).toBe(false);
+  });
+
   it("surfaces refused-derivation remediation on activate even when applied is false (#3398)", () => {
     root = makeRepo();
     const path = join(root, "xbrief", "pending", "impl-only.xbrief.json");

--- a/packages/core/src/scope/transition.test.ts
+++ b/packages/core/src/scope/transition.test.ts
@@ -298,6 +298,39 @@ describe("runTransition", () => {
     expect(existsSync(join(root, "xbrief", "pending", "bare.xbrief.json"))).toBe(false);
   });
 
+  it("does not refuse a stated stamp that already has clauses (#4008)", () => {
+    root = makeRepo();
+    const path = join(root, "xbrief", "proposed", "stated.xbrief.json");
+    writeFile(path, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Stated stamp",
+        status: "proposed",
+        narratives: { Overview: "Hand-authored stated acceptance" },
+        metadata: {
+          swarm: { file_scope: ["src/ui/ledger-table/useDensity.ts"] },
+        },
+        acceptance: {
+          commands: [{ command: "pnpm test" }],
+          none_stated: false,
+          source_rung: "stated",
+          clauses: [
+            {
+              id: 1,
+              text: "Add useDensity.ts exposing mode",
+              artifact_path: null,
+              ambiguous: false,
+            },
+          ],
+        },
+        items: [],
+      },
+    });
+    const result = runTransition("promote", path);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(root, "xbrief", "pending", "stated.xbrief.json"))).toBe(true);
+  });
+
   it("surfaces refused-derivation remediation on activate even when applied is false (#3398)", () => {
     root = makeRepo();
     const path = join(root, "xbrief", "pending", "impl-only.xbrief.json");

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -240,7 +240,7 @@ export function runTransition(
     if (derivation.notice.length > 0) {
       derivationNotice = derivation.notice;
     }
-    if (shouldApplyPromoteClauseFileScopeBind(planObj, derivation.applied)) {
+    if (shouldApplyPromoteClauseFileScopeBind(planObj)) {
       const bind = applyPromoteClauseFileScopeBind(planObj);
       if (!bind.ok) {
         return { ok: false, message: bind.message };

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -28,7 +28,10 @@ import {
 import { append, canonicalLogPath, newDecisionId } from "./audit-log.js";
 import { atomicWriteBrief, formatBriefJson, readBriefForMutation } from "./brief-io.js";
 import { stampCompletionMetadata } from "./capacity-stamp.js";
-import { applyPromoteClauseFileScopeBind } from "./clause-file-scope-bind.js";
+import {
+  applyPromoteClauseFileScopeBind,
+  shouldApplyPromoteClauseFileScopeBind,
+} from "./clause-file-scope-bind.js";
 import {
   LIFECYCLE_FOLDERS,
   MOVE_LABELS,
@@ -237,13 +240,15 @@ export function runTransition(
     if (derivation.notice.length > 0) {
       derivationNotice = derivation.notice;
     }
-    const bind = applyPromoteClauseFileScopeBind(planObj);
-    if (!bind.ok) {
-      return { ok: false, message: bind.message };
-    }
-    if (bind.message.length > 0) {
-      derivationNotice =
-        derivationNotice.length > 0 ? `${derivationNotice}\n${bind.message}` : bind.message;
+    if (shouldApplyPromoteClauseFileScopeBind(planObj, derivation.applied)) {
+      const bind = applyPromoteClauseFileScopeBind(planObj);
+      if (!bind.ok) {
+        return { ok: false, message: bind.message };
+      }
+      if (bind.message.length > 0) {
+        derivationNotice =
+          derivationNotice.length > 0 ? `${derivationNotice}\n${bind.message}` : bind.message;
+      }
     }
   }
 

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -28,6 +28,7 @@ import {
 import { append, canonicalLogPath, newDecisionId } from "./audit-log.js";
 import { atomicWriteBrief, formatBriefJson, readBriefForMutation } from "./brief-io.js";
 import { stampCompletionMetadata } from "./capacity-stamp.js";
+import { applyPromoteClauseFileScopeBind } from "./clause-file-scope-bind.js";
 import {
   LIFECYCLE_FOLDERS,
   MOVE_LABELS,
@@ -235,6 +236,14 @@ export function runTransition(
     });
     if (derivation.notice.length > 0) {
       derivationNotice = derivation.notice;
+    }
+    const bind = applyPromoteClauseFileScopeBind(planObj);
+    if (!bind.ok) {
+      return { ok: false, message: bind.message };
+    }
+    if (bind.message.length > 0) {
+      derivationNotice =
+        derivationNotice.length > 0 ? `${derivationNotice}\n${bind.message}` : bind.message;
     }
   }
 

--- a/packages/core/src/verify-ac/clauses.test.ts
+++ b/packages/core/src/verify-ac/clauses.test.ts
@@ -215,6 +215,22 @@ describe("bindClausesToDeclaredScope (#4008)", () => {
     expect(result.clauses[0]?.artifact_path).toBeNull();
   });
 
+  it("binds an exact declared directory named in the clause", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Ship helpers under src/ui/ledger-table/",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      ["src/ui/ledger-table"],
+    );
+    expect(result.ok).toBe(true);
+    expect(result.clauses[0]?.artifact_path).toBe("src/ui/ledger-table");
+  });
+
   it("is a no-op when file_scope is empty", () => {
     const result = bindClausesToDeclaredScope(
       [

--- a/packages/core/src/verify-ac/clauses.test.ts
+++ b/packages/core/src/verify-ac/clauses.test.ts
@@ -231,6 +231,36 @@ describe("bindClausesToDeclaredScope (#4008)", () => {
     expect(result.clauses[0]?.artifact_path).toBe("src/ui/ledger-table");
   });
 
+  it("binds ./ and backslash spellings of a declared directory", () => {
+    const declared = ["src/ui/ledger-table"];
+    const dotted = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Ship helpers under ./src/ui/ledger-table",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      declared,
+    );
+    expect(dotted.ok).toBe(true);
+    expect(dotted.clauses[0]?.artifact_path).toBe("src/ui/ledger-table");
+    const win = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Ship helpers under src\\ui\\ledger-table",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      declared,
+    );
+    expect(win.ok).toBe(true);
+    expect(win.clauses[0]?.artifact_path).toBe("src/ui/ledger-table");
+  });
+
   it("is a no-op when file_scope is empty", () => {
     const result = bindClausesToDeclaredScope(
       [

--- a/packages/core/src/verify-ac/clauses.test.ts
+++ b/packages/core/src/verify-ac/clauses.test.ts
@@ -3,11 +3,13 @@ import { tmpdir } from "node:os";
 import { join, parse } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  bindClausesToDeclaredScope,
   collectPlanItemAcceptanceSurface,
   countAdjudicableClauses,
   countUnverifiedAdjudicableClauses,
   deriveAcceptanceClauses,
   formatClauseWalkMessage,
+  isDeclaredArtifactPath,
   isScratchArtifactPath,
   readAcceptanceClauses,
   serializeAcceptanceClauses,
@@ -100,6 +102,142 @@ AcceptanceCriteria: Third constraint binds CHANGELOG.md
     expect(fromBare).toHaveLength(1);
     expect(fromBare[0]?.text).toBe("Write CHANGELOG.md under Unreleased");
     expect(fromBare[0]?.artifact_path).toBeNull();
+  });
+});
+
+describe("bindClausesToDeclaredScope (#4008)", () => {
+  const declared = ["src/ui/ledger-table/useDensity.ts", "src/ui/ledger-table/useTableKeyboard.ts"];
+
+  it("binds a clause to the exact file_scope member named in the text", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Add src/ui/ledger-table/useDensity.ts exposing mode",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      declared,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.changed).toBe(true);
+    expect(result.clauses[0]?.artifact_path).toBe("src/ui/ledger-table/useDensity.ts");
+  });
+
+  it("does not bind a bare filename against a longer file_scope member", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Add useDensity.ts exposing mode",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      declared,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures[0]?.kind).toBe("unbound-path");
+    expect(result.message).toContain("Basename matching is refused");
+  });
+
+  it("fails when two exact file_scope members are named", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Touch src/ui/ledger-table/useDensity.ts or src/ui/ledger-table/useTableKeyboard.ts",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      declared,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures[0]?.kind).toBe("ambiguous-scope");
+  });
+
+  it("fails a stored bare reading instead of basename-matching it", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "keyboard helper",
+          artifact_path: "src/ui/ledger-table/useTableKeyboard.ts",
+          ambiguous: true,
+          chosen_reading: 0,
+          readings: [
+            { text: "keyboard helper", artifact_path: "useTableKeyboard.ts" },
+            { text: "expansion helper", artifact_path: "useRowExpansion.ts" },
+          ],
+        },
+      ],
+      declared,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failures[0]?.kind).toBe("undeclared-binding");
+  });
+
+  it("binds stored readings that already name exact file_scope members", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "keyboard helper",
+          artifact_path: null,
+          ambiguous: true,
+          chosen_reading: 0,
+          readings: [
+            {
+              text: "keyboard helper",
+              artifact_path: "src/ui/ledger-table/useTableKeyboard.ts",
+            },
+          ],
+        },
+      ],
+      declared,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.clauses[0]?.artifact_path).toBe("src/ui/ledger-table/useTableKeyboard.ts");
+    expect(result.clauses[0]?.readings?.[0]?.artifact_path).toBe(
+      "src/ui/ledger-table/useTableKeyboard.ts",
+    );
+  });
+
+  it("leaves behavioral clauses unbound when file_scope is present", () => {
+    const result = bindClausesToDeclaredScope(
+      [{ id: 1, text: "No clause-count cap is introduced", artifact_path: null, ambiguous: false }],
+      declared,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.changed).toBe(false);
+    expect(result.clauses[0]?.artifact_path).toBeNull();
+  });
+
+  it("is a no-op when file_scope is empty", () => {
+    const result = bindClausesToDeclaredScope(
+      [
+        {
+          id: 1,
+          text: "Add src/ui/ledger-table/useDensity.ts exposing mode",
+          artifact_path: null,
+          ambiguous: false,
+        },
+      ],
+      [],
+    );
+    expect(result.ok).toBe(true);
+    expect(result.changed).toBe(false);
+    expect(result.clauses[0]?.artifact_path).toBeNull();
+  });
+});
+
+describe("isDeclaredArtifactPath basename refuse (#4008)", () => {
+  it("does not treat a basename as a declared file_scope member", () => {
+    expect(isDeclaredArtifactPath("useDensity.ts", ["src/ui/ledger-table/useDensity.ts"])).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/core/src/verify-ac/clauses.ts
+++ b/packages/core/src/verify-ac/clauses.ts
@@ -489,6 +489,210 @@ export function isDeclaredArtifactPath(
   });
 }
 
+export type ClauseBindFailureKind = "unbound-path" | "ambiguous-scope" | "undeclared-binding";
+
+export interface ClauseBindFailure {
+  readonly id: number;
+  readonly text: string;
+  readonly kind: ClauseBindFailureKind;
+  readonly detail: string;
+}
+
+export interface ClauseFileScopeBindResult {
+  readonly ok: boolean;
+  readonly changed: boolean;
+  readonly clauses: readonly AcceptanceClause[];
+  readonly failures: readonly ClauseBindFailure[];
+  readonly message: string;
+}
+
+type BoundPathResult =
+  | { readonly ok: true; readonly path: string | null }
+  | { readonly ok: false; readonly kind: ClauseBindFailureKind; readonly detail: string };
+
+function uniqueExactDeclaredHits(tokens: readonly string[], declared: readonly string[]): string[] {
+  const hits = new Set<string>();
+  const members = new Set(declared);
+  for (const token of tokens) {
+    const normalized = normalizeScopePath(token);
+    if (members.has(normalized)) {
+      hits.add(normalized);
+    }
+  }
+  return [...hits];
+}
+
+function bindStoredOrTokens(
+  storedPath: string | null,
+  text: string,
+  declared: readonly string[],
+): BoundPathResult {
+  if (storedPath !== null && storedPath.trim().length > 0) {
+    const normalized = normalizeScopePath(storedPath);
+    if (declared.includes(normalized)) {
+      return { ok: true, path: normalized };
+    }
+    return {
+      ok: false,
+      kind: "undeclared-binding",
+      detail: `${storedPath} is not an exact plan.metadata.swarm.file_scope member`,
+    };
+  }
+  const tokens = extractPathTokens(text);
+  const hits = uniqueExactDeclaredHits(tokens, declared);
+  if (hits.length === 1) {
+    return { ok: true, path: hits[0] ?? null };
+  }
+  if (hits.length > 1) {
+    return {
+      ok: false,
+      kind: "ambiguous-scope",
+      detail: `names more than one file_scope member: ${hits.join(", ")}`,
+    };
+  }
+  if (tokens.length > 0) {
+    return {
+      ok: false,
+      kind: "unbound-path",
+      detail: `names ${tokens.join(", ")} which is not an exact file_scope member`,
+    };
+  }
+  return { ok: true, path: null };
+}
+
+function bindOneClause(
+  clause: AcceptanceClause,
+  declared: readonly string[],
+):
+  | { readonly ok: true; readonly clause: AcceptanceClause; readonly changed: boolean }
+  | { readonly ok: false; readonly failure: ClauseBindFailure } {
+  const readings = clause.readings;
+  if (readings !== undefined && readings.length > 0) {
+    const boundReadings: AcceptanceClauseReading[] = [];
+    let changed = false;
+    for (const reading of readings) {
+      const result = bindStoredOrTokens(reading.artifact_path, reading.text, declared);
+      if (result.ok === false) {
+        return {
+          ok: false,
+          failure: {
+            id: clause.id,
+            text: clause.text,
+            kind: result.kind,
+            detail: result.detail,
+          },
+        };
+      }
+      if (result.path !== reading.artifact_path) {
+        changed = true;
+      }
+      boundReadings.push({ text: reading.text, artifact_path: result.path });
+    }
+    const chosen = clause.chosen_reading ?? 0;
+    const chosenPath =
+      boundReadings[chosen]?.artifact_path ?? boundReadings[0]?.artifact_path ?? null;
+    if (chosenPath !== clause.artifact_path) {
+      changed = true;
+    }
+    return {
+      ok: true,
+      changed,
+      clause: {
+        ...clause,
+        artifact_path: chosenPath,
+        readings: boundReadings,
+      },
+    };
+  }
+  const result = bindStoredOrTokens(clause.artifact_path, clause.text, declared);
+  if (result.ok === false) {
+    return {
+      ok: false,
+      failure: {
+        id: clause.id,
+        text: clause.text,
+        kind: result.kind,
+        detail: result.detail,
+      },
+    };
+  }
+  return {
+    ok: true,
+    changed: result.path !== clause.artifact_path,
+    clause: { ...clause, artifact_path: result.path },
+  };
+}
+
+function formatBindFailures(failures: readonly ClauseBindFailure[]): string {
+  const lines = [
+    "Refusing promote: a derived clause is not bound to a declared file_scope path (#4008).",
+  ];
+  for (const failure of failures) {
+    lines.push(`  clause ${failure.id}: ${failure.detail}`);
+  }
+  lines.push(
+    "  remedy: set artifact_path to a plan.metadata.swarm.file_scope entry, or name that exact path in the clause. Basename matching is refused.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Bind derived clauses to exact `plan.metadata.swarm.file_scope` members (#4008).
+ *
+ * Empty declared scope is a no-op: there is no approved member to bind to.
+ * Path tokens match only as exact normalized members — never by basename,
+ * including stored `readings[]`. Derivation still stores no prose path; this
+ * step copies the declared member onto the clause.
+ */
+export function bindClausesToDeclaredScope(
+  clauses: readonly AcceptanceClause[],
+  declaredScope: readonly string[],
+): ClauseFileScopeBindResult {
+  const declared = declaredScope
+    .map((entry) => normalizeScopePath(entry))
+    .filter((entry) => entry.length > 0);
+  if (declared.length === 0 || clauses.length === 0) {
+    return { ok: true, changed: false, clauses, failures: [], message: "" };
+  }
+  const next: AcceptanceClause[] = [];
+  const failures: ClauseBindFailure[] = [];
+  let changed = false;
+  let boundCount = 0;
+  for (const clause of clauses) {
+    const bound = bindOneClause(clause, declared);
+    if (bound.ok === false) {
+      failures.push(bound.failure);
+      next.push(clause);
+      continue;
+    }
+    if (bound.changed) {
+      changed = true;
+    }
+    if (bound.clause.artifact_path !== null) {
+      boundCount += 1;
+    }
+    next.push(bound.clause);
+  }
+  if (failures.length > 0) {
+    return {
+      ok: false,
+      changed: false,
+      clauses,
+      failures,
+      message: formatBindFailures(failures),
+    };
+  }
+  return {
+    ok: true,
+    changed,
+    clauses: next,
+    failures: [],
+    message: changed
+      ? `bound ${boundCount} clause(s) to plan.metadata.swarm.file_scope (#4008)`
+      : "",
+  };
+}
+
 function isContained(root: string, child: string): boolean {
   const rel = relative(resolve(root), resolve(child));
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));

--- a/packages/core/src/verify-ac/clauses.ts
+++ b/packages/core/src/verify-ac/clauses.ts
@@ -510,13 +510,50 @@ type BoundPathResult =
   | { readonly ok: true; readonly path: string | null }
   | { readonly ok: false; readonly kind: ClauseBindFailureKind; readonly detail: string };
 
-function uniqueExactDeclaredHits(tokens: readonly string[], declared: readonly string[]): string[] {
+function isPathContinueChar(ch: string): boolean {
+  return ch.length === 1 && /[A-Za-z0-9_./\\-]/.test(ch);
+}
+
+/** Exact declared member in clause text, including extensionless directory paths. */
+function memberAppearsInText(text: string, member: string): boolean {
+  if (member.length < 2) {
+    return false;
+  }
+  const needles = [member, `${member}/`, `${member}\\`];
+  for (const needle of needles) {
+    let from = 0;
+    while (from < text.length) {
+      const idx = text.indexOf(needle, from);
+      if (idx < 0) {
+        break;
+      }
+      const before = idx === 0 ? "" : (text[idx - 1] ?? "");
+      const after = text[idx + needle.length] ?? "";
+      if (!isPathContinueChar(before) && !isPathContinueChar(after)) {
+        return true;
+      }
+      from = idx + 1;
+    }
+  }
+  return false;
+}
+
+function uniqueExactDeclaredHits(
+  tokens: readonly string[],
+  declared: readonly string[],
+  text: string,
+): string[] {
   const hits = new Set<string>();
   const members = new Set(declared);
   for (const token of tokens) {
     const normalized = normalizeScopePath(token);
     if (members.has(normalized)) {
       hits.add(normalized);
+    }
+  }
+  for (const member of declared) {
+    if (memberAppearsInText(text, member)) {
+      hits.add(member);
     }
   }
   return [...hits];
@@ -539,7 +576,7 @@ function bindStoredOrTokens(
     };
   }
   const tokens = extractPathTokens(text);
-  const hits = uniqueExactDeclaredHits(tokens, declared);
+  const hits = uniqueExactDeclaredHits(tokens, declared, text);
   if (hits.length === 1) {
     return { ok: true, path: hits[0] ?? null };
   }

--- a/packages/core/src/verify-ac/clauses.ts
+++ b/packages/core/src/verify-ac/clauses.ts
@@ -514,12 +514,28 @@ function isPathContinueChar(ch: string): boolean {
   return ch.length === 1 && /[A-Za-z0-9_./\\-]/.test(ch);
 }
 
+function memberNeedles(member: string): string[] {
+  const unix = member.split("\\").join("/");
+  const win = unix.split("/").join("\\");
+  const out = new Set<string>();
+  for (const base of [unix, win]) {
+    out.add(base);
+    out.add(`./${base}`);
+    out.add(`.\\${base}`);
+    out.add(`${base}/`);
+    out.add(`${base}\\`);
+    out.add(`./${base}/`);
+    out.add(`.\\${base}\\`);
+  }
+  return [...out];
+}
+
 /** Exact declared member in clause text, including extensionless directory paths. */
 function memberAppearsInText(text: string, member: string): boolean {
   if (member.length < 2) {
     return false;
   }
-  const needles = [member, `${member}/`, `${member}\\`];
+  const needles = memberNeedles(member);
   for (const needle of needles) {
     let from = 0;
     while (from < text.length) {

--- a/packages/core/src/verify-ac/index.test.ts
+++ b/packages/core/src/verify-ac/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  bindClausesToDeclaredScope,
   commandCountFromFingerprint,
   deriveAcceptanceClauses,
   emitVerifyAcAttempts,
@@ -22,6 +23,7 @@ describe("verify-ac public exports (#3322 / #3323 / #3337)", () => {
     expect(typeof methodFingerprintForWalk).toBe("function");
     expect(typeof commandCountFromFingerprint).toBe("function");
     expect(typeof deriveAcceptanceClauses).toBe("function");
+    expect(typeof bindClausesToDeclaredScope).toBe("function");
     expect(typeof walkAcceptanceClauses).toBe("function");
     expect(typeof stampDerivedClausesOnAcceptance).toBe("function");
     expect(typeof verifyAcCheckId).toBe("function");

--- a/packages/core/src/verify-ac/index.ts
+++ b/packages/core/src/verify-ac/index.ts
@@ -8,7 +8,10 @@
 export {
   type AcceptanceClause,
   type AcceptanceClauseReading,
+  bindClausesToDeclaredScope,
+  type ClauseBindFailure,
   type ClauseDerivationSources,
+  type ClauseFileScopeBindResult,
   type ClauseOutcome,
   type ClauseWalkOptions,
   type ClauseWalkReport,


### PR DESCRIPTION
## Summary

At promote (and activate), bind derived acceptance clauses to an exact plan.metadata.swarm.file_scope member, including stored 
eadings[]. A path-bearing clause that names no unique exact member fails closed. Basename matching stays refused; derivation still stores no prose path. ImplementationPlan-as-acceptance and the late literal-AC allowlist stay out of this story.

## Related Issues

Closes #4008

## Checklist

- [x] /deft:change <name> — N/A: single-issue bug fix on the clause-bind/promote path, covered by 	ask check and the active #4008 xBRIEF
- [x] CHANGELOG.md — added entry under [Unreleased]
- [x] ROADMAP.md — N/A (bug fix, not a tracked roadmap item)
- [x] Tests pass locally (pnpm exec vitest run on clauses, clause-file-scope-bind, transition; biome check on changed files)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed.
- [ ] Enable branch protection on master requiring CI status check (one-time setup, see #57)
