### PR TITLE
fix(release): exempt rehearsal tag-push from closed-verb grant (#4000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`task release:e2e` reaches npm dry-run without a grant (#4000).** Tag-push closed-verb exemption is keyed to the throwaway slug prefix and sentinel `0.0.1`, not `DEFT_RELEASE_E2E`. Production `deftai/directive` plus a real version still denies at Step 10 even when that env is set. Does not close #3916 or #4079.
 
 ### Removed
 

--- a/packages/core/src/authz/closed-verb.test.ts
+++ b/packages/core/src/authz/closed-verb.test.ts
@@ -136,6 +136,19 @@ describe("evaluateClosedVerb (#1095)", () => {
     });
     expect(d.allowed).toBe(true);
     expect(d.code).toBe("closed-verb-env-bypass");
+    expect(d.humanApprovalRef).toBeNull();
+  });
+
+  it("does not honour DEFT_RELEASE_E2E as a closed-verb allow (#4000)", () => {
+    const d = evaluateClosedVerb({
+      verb: "release-publish",
+      target: "0.110.0",
+      grants: [],
+      env: { DEFT_RELEASE_E2E: "1" },
+      repo: "deftai/directive",
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.code).toBe("closed-verb-deny-missing");
   });
 
   it("allows matching operator-cli release-publish grant", () => {

--- a/packages/core/src/release-e2e/main.test.ts
+++ b/packages/core/src/release-e2e/main.test.ts
@@ -200,6 +200,7 @@ describe("rehearsal step helpers", () => {
     expect(captured).not.toContain("--allow-skip-ci=716");
     expect(captured).toContain("--skip-build");
     expect(captured).toContain("--allow-vbrief-drift");
+    expect(captured).not.toContain("--skip-tag");
   });
 
   it("callReleaseEntrypoint pins DEFT_PROJECT_ROOT", () => {

--- a/packages/core/src/release/closed-verb-gate.test.ts
+++ b/packages/core/src/release/closed-verb-gate.test.ts
@@ -70,7 +70,10 @@ function v105Config(projectRoot: string, overrides: Partial<ReleaseConfig> = {})
   };
 }
 
-function recordingSeams(overrides: ReleaseSeams = {}): ReleaseSeams & { gitMutations: string[][] } {
+function recordingSeams(
+  overrides: ReleaseSeams = {},
+  originRemote = "https://github.com/deftai/directive.git",
+): ReleaseSeams & { gitMutations: string[][] } {
   const gitMutations: string[][] = [];
   const seams: ReleaseSeams & { gitMutations: string[][] } = {
     gitMutations,
@@ -78,6 +81,9 @@ function recordingSeams(overrides: ReleaseSeams = {}): ReleaseSeams & { gitMutat
       const argv = [...args];
       if (argv.includes("tag") || argv.includes("push")) {
         gitMutations.push(argv);
+      }
+      if (args.includes("remote") && args.includes("get-url")) {
+        return { status: 0, stdout: `${originRemote}\n`, stderr: "" };
       }
       if (args.includes("status")) return { status: 0, stdout: "", stderr: "" };
       if (args.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
@@ -293,7 +299,7 @@ describe("tag-push closed-verb gate (#3527)", () => {
     dirs.push(projectRoot);
     const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const repo = `deftai/${REPO_SLUG_PREFIX}20260902-abc`;
-    const seams = recordingSeams();
+    const seams = recordingSeams({}, `https://github.com/${repo}.git`);
     const rc = runPipeline(
       v105Config(projectRoot, { version: REHEARSAL_VERSION, repo, skipRelease: true }),
       seams,
@@ -306,6 +312,21 @@ describe("tag-push closed-verb gate (#3527)", () => {
     expect(out).not.toContain("closed-verb-allow");
     expect(out).not.toContain("closed-verb-env-bypass");
     expect(out).not.toMatch(/grant=/);
+  });
+
+  it("rehearsal --repo with production origin still denies (#4000)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const repo = `deftai/${REPO_SLUG_PREFIX}20260902-abc`;
+    const seams = recordingSeams();
+    expect(
+      runPipeline(
+        v105Config(projectRoot, { version: REHEARSAL_VERSION, repo, skipRelease: true }),
+        seams,
+      ),
+    ).toBe(EXIT_VIOLATION);
+    expect(seams.gitMutations.some((a) => a.includes("push"))).toBe(false);
   });
 
   it("sentinel version on deftai/directive still denies (#4000)", () => {

--- a/packages/core/src/release/closed-verb-gate.test.ts
+++ b/packages/core/src/release/closed-verb-gate.test.ts
@@ -1,10 +1,13 @@
 import { rmSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { evaluateClosedVerb } from "../authz/closed-verb.js";
 import type { HumanOriginGrant } from "../authz/types.js";
+import { REHEARSAL_VERSION, REPO_SLUG_PREFIX } from "../release-e2e/constants.js";
 import { evaluateReleasePublishGate } from "../release-publish/pipeline.js";
 import {
   assertTagPushClosedVerb,
   evaluateReleaseTagPushGate,
+  isRehearsalClosedVerbExempt,
   TAG_PUSH_CLOSED_VERB,
 } from "./closed-verb-gate.js";
 import { EXIT_OK, EXIT_VIOLATION } from "./constants.js";
@@ -214,6 +217,138 @@ describe("tag-push closed-verb gate (#3527)", () => {
         closedVerbEnv: {},
       }),
     ).toBe(EXIT_OK);
+  });
+
+  it("conjunction of throwaway slug prefix and sentinel version is rehearsal-owned", () => {
+    const slug = `${REPO_SLUG_PREFIX}20260902-abc`;
+    expect(isRehearsalClosedVerbExempt(`deftai/${slug}`, REHEARSAL_VERSION)).toBe(true);
+    expect(isRehearsalClosedVerbExempt(`deftai/${slug}`, `v${REHEARSAL_VERSION}`)).toBe(true);
+    expect(isRehearsalClosedVerbExempt("deftai/directive", REHEARSAL_VERSION)).toBe(false);
+    expect(isRehearsalClosedVerbExempt(`deftai/${slug}`, V105)).toBe(false);
+    expect(isRehearsalClosedVerbExempt("deftai/directive", V105)).toBe(false);
+    expect(isRehearsalClosedVerbExempt(`evil-${slug}`, REHEARSAL_VERSION)).toBe(false);
+  });
+
+  it("production deftai/directive + real version + DEFT_RELEASE_E2E=1 still denies (#4000)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const prev = process.env.DEFT_RELEASE_E2E;
+    process.env.DEFT_RELEASE_E2E = "1";
+    try {
+      const seams = recordingSeams({
+        closedVerbEnv: { DEFT_RELEASE_E2E: "1" },
+        closedVerbGrants: [],
+      });
+      expect(runPipeline(v105Config(projectRoot), seams)).toBe(EXIT_VIOLATION);
+      expect(seams.gitMutations.some((a) => a.includes("tag") && a.includes("-a"))).toBe(false);
+      expect(seams.gitMutations.some((a) => a.includes("push"))).toBe(false);
+      const out = spy.mock.calls.map((c) => String(c[0])).join("");
+      expect(out).toContain("closed-verb-deny-missing");
+      expect(out).not.toContain("rehearsal-closed-verb-exempt");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.DEFT_RELEASE_E2E;
+      } else {
+        process.env.DEFT_RELEASE_E2E = prev;
+      }
+    }
+  });
+
+  it("evaluateClosedVerb does not honour DEFT_RELEASE_E2E on production identity (#4000)", () => {
+    const d = evaluateClosedVerb({
+      verb: "release-publish",
+      target: V105,
+      grants: [],
+      env: { DEFT_RELEASE_E2E: "1" },
+      repo: "deftai/directive",
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.code).toBe("closed-verb-deny-missing");
+    const publish = evaluateReleasePublishGate(V105, ".", {
+      grants: [],
+      env: { DEFT_RELEASE_E2E: "1" },
+      repo: "deftai/directive",
+    });
+    expect(publish.allowed).toBe(false);
+    expect(publish.code).toBe("closed-verb-deny-missing");
+  });
+
+  it("evaluator still denies rehearsal identity; exemption is the tag-push wrapper (#4000)", () => {
+    const repo = `deftai/${REPO_SLUG_PREFIX}20260902-abc`;
+    const denied = evaluateReleaseTagPushGate(
+      REHEARSAL_VERSION,
+      ".",
+      { closedVerbGrants: [], closedVerbEnv: {} },
+      repo,
+    );
+    expect(denied.allowed).toBe(false);
+    expect(denied.code).toBe("closed-verb-deny-missing");
+  });
+
+  it("rehearsal slug + sentinel version tags without a grant or env bypass (#4000)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const repo = `deftai/${REPO_SLUG_PREFIX}20260902-abc`;
+    const seams = recordingSeams();
+    const rc = runPipeline(
+      v105Config(projectRoot, { version: REHEARSAL_VERSION, repo, skipRelease: true }),
+      seams,
+    );
+    expect(rc).toBe(EXIT_OK);
+    expect(seams.gitMutations.some((a) => a.includes("tag") && a.includes("-a"))).toBe(true);
+    expect(seams.gitMutations.some((a) => a.includes("push") && a.includes("--atomic"))).toBe(true);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("rehearsal-closed-verb-exempt");
+    expect(out).not.toContain("closed-verb-allow");
+    expect(out).not.toContain("closed-verb-env-bypass");
+    expect(out).not.toMatch(/grant=/);
+  });
+
+  it("sentinel version on deftai/directive still denies (#4000)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = recordingSeams();
+    expect(
+      runPipeline(
+        v105Config(projectRoot, { version: REHEARSAL_VERSION, skipRelease: true }),
+        seams,
+      ),
+    ).toBe(EXIT_VIOLATION);
+    expect(seams.gitMutations.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  it("throwaway slug with a real version still denies (#4000)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = recordingSeams();
+    expect(
+      runPipeline(
+        v105Config(projectRoot, {
+          repo: `deftai/${REPO_SLUG_PREFIX}20260902-abc`,
+        }),
+        seams,
+      ),
+    ).toBe(EXIT_VIOLATION);
+    expect(seams.gitMutations.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  it("env-bypass OK log does not share the authorized-grant shape (#4000 / #3916 AC3)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = recordingSeams({
+      closedVerbEnv: { DEFT_ALLOW_RELEASE_PUBLISH: "1" },
+      closedVerbGrants: [],
+    });
+    expect(runPipeline(v105Config(projectRoot), seams)).toBe(EXIT_OK);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("closed-verb-env-bypass");
+    expect(out).not.toContain("closed-verb-allow");
+    expect(out).not.toMatch(/grant=/);
   });
 
   it("production path reads DEFT_ALLOW_RELEASE_PUBLISH from process.env when seams omit env", () => {

--- a/packages/core/src/release/closed-verb-gate.test.ts
+++ b/packages/core/src/release/closed-verb-gate.test.ts
@@ -227,6 +227,8 @@ describe("tag-push closed-verb gate (#3527)", () => {
     expect(isRehearsalClosedVerbExempt(`deftai/${slug}`, V105)).toBe(false);
     expect(isRehearsalClosedVerbExempt("deftai/directive", V105)).toBe(false);
     expect(isRehearsalClosedVerbExempt(`evil-${slug}`, REHEARSAL_VERSION)).toBe(false);
+    expect(isRehearsalClosedVerbExempt(`otherorg/${slug}`, REHEARSAL_VERSION)).toBe(false);
+    expect(isRehearsalClosedVerbExempt(slug, REHEARSAL_VERSION)).toBe(false);
   });
 
   it("production deftai/directive + real version + DEFT_RELEASE_E2E=1 still denies (#4000)", () => {
@@ -314,6 +316,24 @@ describe("tag-push closed-verb gate (#3527)", () => {
     expect(
       runPipeline(
         v105Config(projectRoot, { version: REHEARSAL_VERSION, skipRelease: true }),
+        seams,
+      ),
+    ).toBe(EXIT_VIOLATION);
+    expect(seams.gitMutations.some((a) => a.includes("push"))).toBe(false);
+  });
+
+  it("prefix-matching slug under another owner still denies (#4000)", () => {
+    const projectRoot = seedReleaseProjectDir();
+    dirs.push(projectRoot);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = recordingSeams();
+    expect(
+      runPipeline(
+        v105Config(projectRoot, {
+          version: REHEARSAL_VERSION,
+          repo: `otherorg/${REPO_SLUG_PREFIX}20260902-abc`,
+          skipRelease: true,
+        }),
         seams,
       ),
     ).toBe(EXIT_VIOLATION);

--- a/packages/core/src/release/closed-verb-gate.ts
+++ b/packages/core/src/release/closed-verb-gate.ts
@@ -11,7 +11,7 @@
  */
 import { closedVerbEnvBypassKey } from "../authz/closed-verb.js";
 import type { ClosedVerbDecision } from "../authz/types.js";
-import { REHEARSAL_VERSION, REPO_SLUG_PREFIX } from "../release-e2e/constants.js";
+import { DEFAULT_OWNER, REHEARSAL_VERSION, REPO_SLUG_PREFIX } from "../release-e2e/constants.js";
 import { evaluateReleasePublishGate } from "../release-publish/pipeline.js";
 import { EXIT_OK, EXIT_VIOLATION, TOTAL_STEPS } from "./constants.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
@@ -24,12 +24,6 @@ export const TAG_PUSH_CLOSED_VERB = "release-publish" as const;
 
 export const REHEARSAL_CLOSED_VERB_EXEMPT_STATUS = "OK (rehearsal-closed-verb-exempt)";
 
-function rehearsalRepoSlug(repo: string): string {
-  const trimmed = repo.trim();
-  const slash = trimmed.lastIndexOf("/");
-  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
-}
-
 function normaliseSentinelVersion(version: string): string {
   const trimmed = version.trim();
   if (trimmed.startsWith("v") || trimmed.startsWith("V")) return trimmed.slice(1);
@@ -37,12 +31,18 @@ function normaliseSentinelVersion(version: string): string {
 }
 
 /**
- * True only for the throwaway rehearsal identity: slug prefix AND sentinel
- * version. Production deftai/directive cannot satisfy the conjunction even
- * when DEFT_RELEASE_E2E=1.
+ * True only for the throwaway rehearsal identity: owner DEFAULT_OWNER, slug
+ * prefix, AND sentinel version. Production deftai/directive cannot satisfy
+ * the conjunction even when DEFT_RELEASE_E2E=1. A prefix-matching slug under
+ * another owner is not rehearsal-owned.
  */
 export function isRehearsalClosedVerbExempt(repo: string, version: string): boolean {
-  const slug = rehearsalRepoSlug(repo);
+  const trimmed = repo.trim();
+  const slash = trimmed.lastIndexOf("/");
+  if (slash <= 0) return false;
+  const owner = trimmed.slice(0, slash);
+  const slug = trimmed.slice(slash + 1);
+  if (owner.toLowerCase() !== DEFAULT_OWNER.toLowerCase()) return false;
   if (!slug.startsWith(REPO_SLUG_PREFIX)) return false;
   return normaliseSentinelVersion(version) === REHEARSAL_VERSION;
 }

--- a/packages/core/src/release/closed-verb-gate.ts
+++ b/packages/core/src/release/closed-verb-gate.ts
@@ -14,6 +14,7 @@ import type { ClosedVerbDecision } from "../authz/types.js";
 import { DEFAULT_OWNER, REHEARSAL_VERSION, REPO_SLUG_PREFIX } from "../release-e2e/constants.js";
 import { evaluateReleasePublishGate } from "../release-publish/pipeline.js";
 import { EXIT_OK, EXIT_VIOLATION, TOTAL_STEPS } from "./constants.js";
+import { runGit } from "./git.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 
 function emitGate(label: string, status: string): void {
@@ -36,6 +37,21 @@ function normaliseSentinelVersion(version: string): string {
  * the conjunction even when DEFT_RELEASE_E2E=1. A prefix-matching slug under
  * another owner is not rehearsal-owned.
  */
+export function githubOwnerRepoFromRemoteUrl(url: string): string | null {
+  const match =
+    /^(?:https?:\/\/github\.com\/|git@github\.com:)(?<owner>[^/]+)\/(?<repo>[^/]+?)(?:\.git)?$/.exec(
+      url.trim(),
+    );
+  if (!match?.groups) return null;
+  return `${match.groups.owner}/${match.groups.repo}`;
+}
+
+function originOwnerRepo(projectRoot: string, seams: ReleaseSeams): string | null {
+  const result = runGit(projectRoot, ["remote", "get-url", "origin"], seams);
+  if (result.status !== 0) return null;
+  return githubOwnerRepoFromRemoteUrl(result.stdout);
+}
+
 export function isRehearsalClosedVerbExempt(repo: string, version: string): boolean {
   const trimmed = repo.trim();
   const slash = trimmed.lastIndexOf("/");
@@ -82,8 +98,15 @@ export function assertTagPushClosedVerb(config: ReleaseConfig, seams: ReleaseSea
     return EXIT_OK;
   }
   if (isRehearsalClosedVerbExempt(config.repo, config.version)) {
-    emitGate(label, REHEARSAL_CLOSED_VERB_EXEMPT_STATUS);
-    return EXIT_OK;
+    const originRepo = originOwnerRepo(config.projectRoot, seams);
+    if (
+      originRepo !== null &&
+      originRepo.toLowerCase() === config.repo.toLowerCase() &&
+      isRehearsalClosedVerbExempt(originRepo, config.version)
+    ) {
+      emitGate(label, REHEARSAL_CLOSED_VERB_EXEMPT_STATUS);
+      return EXIT_OK;
+    }
   }
   const gate = evaluateReleaseTagPushGate(config.version, config.projectRoot, seams, config.repo);
   if (!gate.allowed) {

--- a/packages/core/src/release/closed-verb-gate.ts
+++ b/packages/core/src/release/closed-verb-gate.ts
@@ -4,9 +4,14 @@
  * Reuses the draft-flip evaluator (`evaluateReleasePublishGate`) so the
  * distributing step carries the same authz tier. Does not delete or weaken
  * the later `release:publish` draft-flip check.
+ *
+ * Rehearsal exemption (#4000) is keyed to the throwaway slug prefix and
+ * sentinel version the e2e owns. It does not teach the evaluator to honour
+ * DEFT_RELEASE_E2E.
  */
 import { closedVerbEnvBypassKey } from "../authz/closed-verb.js";
 import type { ClosedVerbDecision } from "../authz/types.js";
+import { REHEARSAL_VERSION, REPO_SLUG_PREFIX } from "../release-e2e/constants.js";
 import { evaluateReleasePublishGate } from "../release-publish/pipeline.js";
 import { EXIT_OK, EXIT_VIOLATION, TOTAL_STEPS } from "./constants.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
@@ -16,6 +21,31 @@ function emitGate(label: string, status: string): void {
 }
 
 export const TAG_PUSH_CLOSED_VERB = "release-publish" as const;
+
+export const REHEARSAL_CLOSED_VERB_EXEMPT_STATUS = "OK (rehearsal-closed-verb-exempt)";
+
+function rehearsalRepoSlug(repo: string): string {
+  const trimmed = repo.trim();
+  const slash = trimmed.lastIndexOf("/");
+  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+}
+
+function normaliseSentinelVersion(version: string): string {
+  const trimmed = version.trim();
+  if (trimmed.startsWith("v") || trimmed.startsWith("V")) return trimmed.slice(1);
+  return trimmed;
+}
+
+/**
+ * True only for the throwaway rehearsal identity: slug prefix AND sentinel
+ * version. Production deftai/directive cannot satisfy the conjunction even
+ * when DEFT_RELEASE_E2E=1.
+ */
+export function isRehearsalClosedVerbExempt(repo: string, version: string): boolean {
+  const slug = rehearsalRepoSlug(repo);
+  if (!slug.startsWith(REPO_SLUG_PREFIX)) return false;
+  return normaliseSentinelVersion(version) === REHEARSAL_VERSION;
+}
 
 export function evaluateReleaseTagPushGate(
   version: string,
@@ -33,8 +63,10 @@ export function evaluateReleaseTagPushGate(
 /**
  * Fail closed before git tag + atomic tag push when skipTag is false.
  * Dry-run and `--skip-tag` do not require a grant (no npm distribution).
- * Returns EXIT_OK to continue, EXIT_VIOLATION to halt. Never spends the grant
- * — draft-flip `release:publish` still owns markGrantUsed (#1095).
+ * Rehearsal throwaway slug + sentinel version may tag without a grant (#4000);
+ * that path still tags and pushes. Returns EXIT_OK to continue, EXIT_VIOLATION
+ * to halt. Never spends the grant — draft-flip `release:publish`
+ * still owns markGrantUsed (#1095).
  */
 export function assertTagPushClosedVerb(config: ReleaseConfig, seams: ReleaseSeams): number {
   if (config.skipTag) {
@@ -47,6 +79,10 @@ export function assertTagPushClosedVerb(config: ReleaseConfig, seams: ReleaseSea
       label,
       "DRYRUN (would require human-origin grant or DEFT_ALLOW_RELEASE_PUBLISH=1 before tag push)",
     );
+    return EXIT_OK;
+  }
+  if (isRehearsalClosedVerbExempt(config.repo, config.version)) {
+    emitGate(label, REHEARSAL_CLOSED_VERB_EXEMPT_STATUS);
     return EXIT_OK;
   }
   const gate = evaluateReleaseTagPushGate(config.version, config.projectRoot, seams, config.repo);
@@ -64,7 +100,9 @@ export function assertTagPushClosedVerb(config: ReleaseConfig, seams: ReleaseSea
   }
   emitGate(
     label,
-    `OK (${gate.code}${gate.humanApprovalRef !== null ? ` grant=${gate.humanApprovalRef}` : ""})`,
+    gate.code === "closed-verb-allow" && gate.humanApprovalRef !== null
+      ? `OK (${gate.code} grant=${gate.humanApprovalRef})`
+      : `OK (${gate.code})`,
   );
   return EXIT_OK;
 }


### PR DESCRIPTION
## Summary

task release:e2e died at Step 10 closed-verb-deny-missing for sentinel 0.0.1, so npm dry-run never ran.

This recut lets the throwaway rehearsal tag without a grant. The exemption is a conjunction of REPO_SLUG_PREFIX and REHEARSAL_VERSION on the tag-push wrapper. evaluateClosedVerb / evaluateReleasePublishGate still do not honour DEFT_RELEASE_E2E. Production deftai/directive plus a real version still denies at Step 10 even when that env is set. Rehearsal argv still has no --skip-tag.

Optional log-shape pin: OK (closed-verb-env-bypass) does not share the authorized-grant grant= shape.

Does not implement #4079. Does not close or reopen #3916.

## Related Issues

Closes #4000
Refs #3916, #4079, #3527, #1910, #1095, #3156

## Checklist

- [x] /deft:change -- N/A: single recut of #4000; operator-approved solo dispatch; covered by task check
- [x] CHANGELOG.md -- added entry under [Unreleased]
- [x] ROADMAP.md -- N/A (bugfix, not a tracked roadmap item)
- [x] Tests pass locally (task check exit 0)

## Post-Merge

- [ ] Verify issue auto-close after squash merge.
- [ ] Enable branch protection on master requiring CI status check (one-time setup, see #57)
