### PR TITLE
fix(issue-eval): spawn Windows npm deft.cmd for session:start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`triage:evaluate` spawns Windows npm `deft.cmd` for isolated `session:start --read-only` (#4083).** Bare `deft` argv0 ENOENTed under `execFileSync`. Resolve via PATHEXT-aware `whichAllFromPath`, spawn through `cliSpawnPlan`; `runText` stays `shell: false`. Closes #4083. Refs #2606, #2911.
 - **Release skill names the real mint CLI at Phase 1 and does not stall rehearsal on a grant (#4079).** After version confirm it prints deft authz:grant with template release-publish and --confirm, and keeps mint immediately before Phase 4. Phase 3 halt is retry-or-stop; rehearsal 0.0.1 is not minted. Policy restore closeout names both default-branch and destructive-gh env bypasses on those git commands. Phase 1 CI is task check. Closes #4079. Refs #4000.
 - **`task release:e2e` reaches npm dry-run without a grant (#4000).** Tag-push closed-verb exemption is keyed to the throwaway slug prefix and sentinel `0.0.1`, not `DEFT_RELEASE_E2E`. Production `deftai/directive` plus a real version still denies at Step 10 even when that env is set. Does not close #3916 or #4079.
 

--- a/packages/core/src/swarm/subprocess.ts
+++ b/packages/core/src/swarm/subprocess.ts
@@ -22,6 +22,7 @@ export function runText(
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       maxBuffer: SUBPROCESS_MAX_BUFFER,
+      shell: false,
     });
     return {
       returncode: 0,

--- a/packages/core/src/triage/evaluate/evaluate-spawn.test.ts
+++ b/packages/core/src/triage/evaluate/evaluate-spawn.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runText } from "../../swarm/subprocess.js";
+import { sessionStartSpawnPlan } from "./evaluate.js";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const WIN32_NPM = "C:\\Users\\test\\AppData\\Roaming\\npm";
+
+describe("sessionStartSpawnPlan (#4083)", () => {
+  it("resolves deft.cmd on win32 instead of a bare deft argv0", () => {
+    const plan = sessionStartSpawnPlan({
+      platform: "win32",
+      env: {
+        PATH: WIN32_NPM,
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      },
+      exists: (p) => /deft\.cmd$/i.test(p),
+      isExecutable: () => true,
+    });
+    expect(plan.command).toBe("cmd.exe");
+    expect(plan.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+    const line = plan.args[3] ?? "";
+    expect(line.toLowerCase()).toContain("deft.cmd");
+    expect(line.toLowerCase()).toContain("session:start");
+    expect(line.toLowerCase()).toContain("--read-only");
+    expect(plan.command).not.toBe("deft");
+    expect(line.split(/\s+/)[0]?.toLowerCase()).not.toBe("deft");
+  });
+
+  it("uses the PATH binary as argv0 on posix", () => {
+    const plan = sessionStartSpawnPlan({
+      platform: "linux",
+      env: { PATH: "/usr/bin" },
+      exists: (p) => p === "/usr/bin/deft",
+      isExecutable: () => true,
+    });
+    expect(plan).toEqual({
+      command: "/usr/bin/deft",
+      args: ["session:start", "--read-only"],
+    });
+  });
+
+  it("uses directive.cmd when deft is absent", () => {
+    const plan = sessionStartSpawnPlan({
+      platform: "win32",
+      env: {
+        PATH: WIN32_NPM,
+        PATHEXT: ".CMD",
+      },
+      exists: (p) => /directive\.cmd$/i.test(p),
+      isExecutable: () => true,
+    });
+    expect(plan.command).toBe("cmd.exe");
+    expect(plan.args[3]?.toLowerCase()).toContain("directive.cmd");
+    expect(plan.args[3]?.toLowerCase()).not.toContain("deft.cmd");
+  });
+
+  it("falls back to cliSpawnPlan of deft when PATH has no engine", () => {
+    const plan = sessionStartSpawnPlan({
+      platform: "win32",
+      env: { PATH: "C:\\empty", PATHEXT: ".CMD" },
+      exists: () => false,
+      isExecutable: () => true,
+    });
+    expect(plan.command).toBe("cmd.exe");
+    expect(plan.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+    expect(plan.args[3]).toBe("deft session:start --read-only");
+  });
+});
+
+describe("runText shell-false (#4083 / #2911)", () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+    vi.mocked(execFileSync).mockReturnValue("");
+  });
+
+  it("passes shell: false to execFileSync and never shell: true", () => {
+    runText(["deft", "session:start", "--read-only"]);
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(execFileSync).mock.calls[0];
+    expect(call?.[2]).toEqual(expect.objectContaining({ shell: false }));
+    expect(call?.[2]).not.toEqual(expect.objectContaining({ shell: true }));
+  });
+
+  it("locks swarm/subprocess.ts against shell: true", () => {
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../swarm/subprocess.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(/shell:\s*false/);
+    expect(src).not.toMatch(/shell:\s*true/);
+  });
+});

--- a/packages/core/src/triage/evaluate/evaluate.ts
+++ b/packages/core/src/triage/evaluate/evaluate.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { cliSpawnPlan } from "../../check/cli-native-gates.js";
+import { whichAllFromPath } from "../../doctor/which.js";
 import { runText } from "../../swarm/subprocess.js";
 import { defaultGitRunner } from "../../swarm/worktrees.js";
 import { defaultGithubReader, pullsMentioning } from "./github.js";
@@ -33,8 +35,46 @@ function resolveOriginSha(projectRoot: string, git: GitRunner): string {
   return proc.stdout.trim();
 }
 
+export interface SessionStartSpawnPlanInput {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly exists?: (path: string) => boolean;
+  readonly isExecutable?: (path: string) => boolean;
+}
+
+const SESSION_START_ARGV = ["session:start", "--read-only"] as const;
+const ENGINE_BINS = ["deft", "directive"] as const;
+
+/**
+ * PATHEXT-aware spawn plan for isolated `session:start --read-only` (#4083).
+ * Resolves `deft` then `directive` via whichAllFromPath, then cliSpawnPlan
+ * so win32 npm `.cmd` shims run without `shell: true` (#2911).
+ */
+export function sessionStartSpawnPlan(input: SessionStartSpawnPlanInput = {}): {
+  readonly command: string;
+  readonly args: string[];
+} {
+  const platform = input.platform ?? process.platform;
+  const whichOpts = {
+    platform,
+    env: input.env,
+    exists: input.exists,
+    isExecutable: input.isExecutable,
+  };
+  let cliBin = "deft";
+  for (const name of ENGINE_BINS) {
+    const hit = whichAllFromPath(name, whichOpts)[0];
+    if (hit !== undefined && hit.length > 0) {
+      cliBin = hit;
+      break;
+    }
+  }
+  return cliSpawnPlan(cliBin, SESSION_START_ARGV, platform);
+}
+
 function defaultSessionStart(worktreePath: string): void {
-  const proc = runText(["deft", "session:start", "--read-only"], { cwd: worktreePath });
+  const plan = sessionStartSpawnPlan();
+  const proc = runText([plan.command, ...plan.args], { cwd: worktreePath });
   if (proc.returncode !== 0) {
     throw new EvaluateError(
       `session:start --read-only failed in ${worktreePath}: ${proc.stderr.trim() || "<no stderr>"}`,

--- a/packages/core/src/triage/evaluate/index.ts
+++ b/packages/core/src/triage/evaluate/index.ts
@@ -1,4 +1,10 @@
-export { EvaluateError, evaluateIssues, renderEvaluateText } from "./evaluate.js";
+export type { SessionStartSpawnPlanInput } from "./evaluate.js";
+export {
+  EvaluateError,
+  evaluateIssues,
+  renderEvaluateText,
+  sessionStartSpawnPlan,
+} from "./evaluate.js";
 export { evaluatorWorktreePath, sha12Of, sinkDir } from "./paths.js";
 export type {
   EvaluateOptions,


### PR DESCRIPTION
## Summary

`task triage:evaluate` spawned isolated `session:start --read-only` as a bare `deft` argv0. On Windows, Node `execFileSync` does not resolve npm global `deft.cmd`, so Stage A died with `spawnSync deft ENOENT`.

This recut resolves `deft` then `directive` via PATHEXT-aware `whichAllFromPath` and spawns through `cliSpawnPlan` (`cmd.exe /d /s /c` on win32). `runText` stays `shell: false` (#2911).

## Test plan

- Unit: default session-start spawn plan resolves `deft.cmd` on win32
- Unit: `runText` passes `shell: false`
- Affected vitest: evaluate + subprocess

Closes #4083
