### PR TITLE
fix(validate-links): evaluate consumer C3 against the deposit root (#4081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`verify:links` C3 evaluates an initialized consumer deposit in deposit-relative coordinates (#4081).** From a consumer root the gate walks `.deft/core`, not the project tree and not `contentRoot(cwd)`. Declared exclusions match. Consumer markdown naming `path/to.py` is out of the walk. A product `content/` directory no longer fail-opens a dirty deposit. Closes #4081.
 - **Land completed-tracked artifact for #4083 (#3264 / #1358).** The #4083 xBRIEF stayed untracked after squash of PR 4106 (80cbaadb). Moved to xbrief/completed/ via scope:complete. Does not recut that issue. Refs #2321, #3476.
 - **`triage:evaluate` spawns Windows npm `deft.cmd` for isolated `session:start --read-only` (#4083).** Bare `deft` argv0 ENOENTed under `execFileSync`. Resolve via PATHEXT-aware `whichAllFromPath`, spawn through `cliSpawnPlan`; `runText` stays `shell: false`. Closes #4083. Refs #2606, #2911.
 - **Release skill names the real mint CLI at Phase 1 and does not stall rehearsal on a grant (#4079).** After version confirm it prints deft authz:grant with template release-publish and --confirm, and keeps mint immediately before Phase 4. Phase 3 halt is retry-or-stop; rehearsal 0.0.1 is not minted. Policy restore closeout names both default-branch and destructive-gh env bypasses on those git commands. Phase 1 CI is task check. Closes #4079. Refs #4000.

--- a/packages/core/src/validate-content/validate-content.test.ts
+++ b/packages/core/src/validate-content/validate-content.test.ts
@@ -188,11 +188,7 @@ describe("validate-links C3 consumer root (#4081)", () => {
     const { cwd, deposit } = initializedConsumer();
     const resolved = resolveC3EvaluationRoot(cwd);
     expect(resolved.stagedRoot).toBe(resolve(deposit));
-    expect(resolved.extraFiles.map((f) => f.relativePath).sort()).toEqual(
-      extraDepositMarkdownFiles(deposit)
-        .map((f) => f.relativePath)
-        .sort(),
-    );
+    expect(resolved.extraFiles).toEqual([]);
     const fromConsumer = evaluateLiveProcedureTargets(resolved);
     const fromDeposit = evaluateLiveProcedureTargets({
       stagedRoot: deposit,
@@ -264,6 +260,15 @@ describe("validate-links C3 consumer root (#4081)", () => {
     const result = evaluateLinks({ cwd });
     expect(result.code).toBe(1);
     expect(result.message).toContain("scripts/definitely_missing.py");
+  });
+
+  it("does not double-scan deposit extras already in the walk", () => {
+    const { cwd, deposit } = initializedConsumer();
+    writeFileSync(join(deposit, "main.md"), "! run `scripts/dup.py`\n", "utf8");
+    const result = evaluateLinks({ cwd });
+    expect(result.code).toBe(1);
+    const hits = result.message.split("\n").filter((line) => line.includes("scripts/dup.py"));
+    expect(hits).toHaveLength(1);
   });
 
   it("binds C3 extras to the deposit, not consumer-root main.md", () => {

--- a/packages/core/src/validate-content/validate-content.test.ts
+++ b/packages/core/src/validate-content/validate-content.test.ts
@@ -1,12 +1,22 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  evaluateLiveProcedureTargets,
+  extraDepositMarkdownFiles,
+} from "../deposit/live-procedure-targets.js";
+import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
 import { resolveCapacityAllocation, validateCapacityAllocation } from "./capacity-policy.js";
 import { computeReport, renderReport } from "./capacity-show.js";
 import { isDatePrefixedVbriefFilename } from "./filename.js";
 import { extractLinkTargets, shouldSkipLinkTarget } from "./link-parser.js";
-import { evaluate as evaluateLinks } from "./validate-links.js";
+import {
+  collectBrokenLinks,
+  evaluate as evaluateLinks,
+  resolveC3EvaluationRoot,
+} from "./validate-links.js";
 import {
   evaluate as evaluateStrategy,
   validateStrategyOutput,
@@ -117,6 +127,186 @@ describe("validate-links", () => {
     expect(evaluateLinks({ cwd: root, strict: true }).message).toContain(
       "All internal markdown links valid",
     );
+  });
+});
+
+describe("validate-links C3 consumer root (#4081)", () => {
+  const repoRoot = resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
+
+  function packDeposit(dest: string): void {
+    const copies: readonly [string, string][] = [
+      ["content/UPGRADING.md", "UPGRADING.md"],
+      ["content/scm/github.md", "scm/github.md"],
+      ["content/docs/BROWNFIELD.md", "docs/BROWNFIELD.md"],
+      ["content/skills/deft-directive-setup/SKILL.md", "skills/deft-directive-setup/SKILL.md"],
+      ["main.md", "main.md"],
+      ["SKILL.md", "SKILL.md"],
+    ];
+    for (const [src, rel] of copies) {
+      const from = join(repoRoot, src);
+      if (!existsSync(from)) continue;
+      const to = join(dest, rel);
+      mkdirSync(dirname(to), { recursive: true });
+      cpSync(from, to);
+    }
+    mkdirSync(join(dest, "skills", "demo"), { recursive: true });
+    writeFileSync(join(dest, "skills", "demo", "SKILL.md"), "# Demo\nLive procedure.\n", "utf8");
+  }
+
+  function initializedConsumer(opts?: {
+    readonly dirtyDeposit?: boolean;
+    readonly contentDir?: boolean;
+    readonly npmContentPackage?: boolean;
+  }): { cwd: string; deposit: string } {
+    const cwd = tempRoot();
+    const deposit = join(cwd, CANONICAL_INSTALL_ROOT);
+    mkdirSync(deposit, { recursive: true });
+    packDeposit(deposit);
+    writeFileSync(join(cwd, "package.json"), '{"name":"consumer"}\n', "utf8");
+    writeFileSync(join(cwd, "README.md"), "App entry is `path/to.py`.\n", "utf8");
+    if (opts?.dirtyDeposit) {
+      writeFileSync(
+        join(deposit, "skills", "demo", "SKILL.md"),
+        "! run `scripts/definitely_missing.py`\n",
+        "utf8",
+      );
+    }
+    if (opts?.contentDir) {
+      mkdirSync(join(cwd, "content", "blog"), { recursive: true });
+      writeFileSync(join(cwd, "content", "blog", "hello.md"), "`scripts/seed.py`\n", "utf8");
+    }
+    if (opts?.npmContentPackage) {
+      const pkg = join(cwd, "node_modules", "@deftai", "directive-content");
+      mkdirSync(pkg, { recursive: true });
+      writeFileSync(join(pkg, "package.json"), '{"name":"@deftai/directive-content"}\n', "utf8");
+      writeFileSync(join(pkg, "README.md"), "clean package copy\n", "utf8");
+    }
+    return { cwd, deposit };
+  }
+
+  it("evaluates a packed consumer deposit in deposit-relative coordinates", () => {
+    const { cwd, deposit } = initializedConsumer();
+    const resolved = resolveC3EvaluationRoot(cwd);
+    expect(resolved.stagedRoot).toBe(resolve(deposit));
+    expect(resolved.extraFiles.map((f) => f.relativePath).sort()).toEqual(
+      extraDepositMarkdownFiles(deposit)
+        .map((f) => f.relativePath)
+        .sort(),
+    );
+    const fromConsumer = evaluateLiveProcedureTargets(resolved);
+    const fromDeposit = evaluateLiveProcedureTargets({
+      stagedRoot: deposit,
+      extraFiles: extraDepositMarkdownFiles(deposit),
+    });
+    expect(fromConsumer.uniqueTargets, "consumer-root C3").toEqual([]);
+    expect(fromDeposit.uniqueTargets, "deposit-root C3").toEqual([]);
+    expect(evaluateLinks({ cwd }).code).toBe(0);
+    expect(evaluateLinks({ cwd: deposit }).code).toBe(0);
+  });
+
+  it("does not walk consumer-authored path/to.py mentions (recut AC5)", () => {
+    const { cwd } = initializedConsumer();
+    const c3 = evaluateLiveProcedureTargets(resolveC3EvaluationRoot(cwd));
+    expect(c3.uniqueTargets).toEqual([]);
+    expect(c3.hits.map((h) => h.file)).not.toContain("README.md");
+    expect(c3.uniqueTargets).not.toContain("path/to.py");
+    expect(evaluateLinks({ cwd }).code).toBe(0);
+  });
+
+  it("keeps declared exclusions excluded from both consumer and deposit roots", () => {
+    const { cwd, deposit } = initializedConsumer();
+    const consumerHits = evaluateLiveProcedureTargets(resolveC3EvaluationRoot(cwd)).hits.map(
+      (h) => h.file,
+    );
+    const depositHits = evaluateLiveProcedureTargets({
+      stagedRoot: deposit,
+      extraFiles: extraDepositMarkdownFiles(deposit),
+    }).hits.map((h) => h.file);
+    expect(consumerHits).not.toContain("UPGRADING.md");
+    expect(consumerHits).not.toContain(".deft/core/UPGRADING.md");
+    expect(depositHits).not.toContain("UPGRADING.md");
+  });
+
+  it("fails C3 when the missing helper is planted in the deposit, not the consumer tree (recut AC4)", () => {
+    const dirty = initializedConsumer({ dirtyDeposit: true });
+    const consumerDirty = evaluateLinks({ cwd: dirty.cwd });
+    const depositDirty = evaluateLinks({ cwd: dirty.deposit });
+    expect(consumerDirty.code).toBe(1);
+    expect(depositDirty.code).toBe(1);
+    expect(consumerDirty.message).toContain("scripts/definitely_missing.py");
+    expect(consumerDirty.message).toContain("skills/demo/SKILL.md");
+    expect(consumerDirty.message).not.toContain(".deft/core/skills/demo/SKILL.md");
+    expect(consumerDirty.message).not.toContain("path/to.py");
+
+    const clean = initializedConsumer();
+    mkdirSync(join(clean.cwd, "docs"), { recursive: true });
+    writeFileSync(join(clean.cwd, "docs", "deploy.md"), "`scripts/mytool.py`\n", "utf8");
+    const consumerPlant = evaluateLinks({ cwd: clean.cwd });
+    expect(consumerPlant.code).toBe(0);
+    expect(consumerPlant.message).not.toContain("scripts/mytool.py");
+  });
+
+  it("does not fail-open a dirty deposit when the consumer owns content/", () => {
+    const { cwd } = initializedConsumer({ dirtyDeposit: true, contentDir: true });
+    const result = evaluateLinks({ cwd });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("scripts/definitely_missing.py");
+    expect(result.message).not.toContain("scripts/seed.py");
+    expect(result.message).not.toContain("content/blog/hello.md");
+  });
+
+  it("does not substitute contentRoot(cwd) npm package for the initialized deposit", () => {
+    const { cwd, deposit } = initializedConsumer({
+      dirtyDeposit: true,
+      npmContentPackage: true,
+    });
+    expect(resolveC3EvaluationRoot(cwd).stagedRoot).toBe(resolve(deposit));
+    const result = evaluateLinks({ cwd });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("scripts/definitely_missing.py");
+  });
+
+  it("binds C3 extras to the deposit, not consumer-root main.md", () => {
+    const { cwd } = initializedConsumer();
+    writeFileSync(join(cwd, "main.md"), "! run `scripts/injected.py`\n", "utf8");
+    const result = evaluateLinks({ cwd });
+    expect(result.code).toBe(0);
+    expect(result.message).not.toContain("scripts/injected.py");
+  });
+
+  it("probes framework source before a nested deposit", () => {
+    const root = resolveC3EvaluationRoot(repoRoot);
+    expect(root.stagedRoot).toBe(resolve(repoRoot, "content"));
+  });
+
+  it("evaluates a legacy deft/ consumer deposit", () => {
+    const cwd = tempRoot();
+    const deposit = join(cwd, "deft");
+    mkdirSync(deposit, { recursive: true });
+    packDeposit(deposit);
+    writeFileSync(join(cwd, "README.md"), "`path/to.py`\n", "utf8");
+    expect(resolveC3EvaluationRoot(cwd).stagedRoot).toBe(resolve(deposit));
+    expect(evaluateLiveProcedureTargets(resolveC3EvaluationRoot(cwd)).uniqueTargets).toEqual([]);
+  });
+
+  it("fails closed when the selected C3 root is not a directory", () => {
+    const cwd = tempRoot();
+    writeFileSync(join(cwd, "not-a-dir"), "x\n", "utf8");
+    const result = evaluateLinks({ cwd: join(cwd, "not-a-dir") });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("deposit root is missing or not a directory");
+  });
+
+  it("still warns on consumer broken links separately from C3", () => {
+    const { cwd } = initializedConsumer();
+    writeFileSync(join(cwd, "README.md"), "See [missing](nope.md) and `path/to.py`.\n", "utf8");
+    const c3 = evaluateLiveProcedureTargets(resolveC3EvaluationRoot(cwd));
+    expect(c3.uniqueTargets).toEqual([]);
+    const broken = collectBrokenLinks(cwd);
+    expect(
+      broken.some((b) => b.file.replaceAll("\\", "/") === "README.md" && b.target === "nope.md"),
+    ).toBe(true);
+    expect(evaluateLinks({ cwd, linkCheckStrict: false }).code).toBe(0);
   });
 });
 

--- a/packages/core/src/validate-content/validate-links.ts
+++ b/packages/core/src/validate-content/validate-links.ts
@@ -1,10 +1,14 @@
-import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
+import { isFrameworkRepoRoot } from "../check/context.js";
 import {
+  type ExtraMarkdownFile,
   evaluateLiveProcedureTargets,
+  extraDepositMarkdownFiles,
   formatLiveProcedureFailure,
 } from "../deposit/live-procedure-targets.js";
 import { NON_PRODUCT_DIRS } from "../fs/non-product-dirs.js";
+import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
 import { extractLinkTargets, shouldSkipLinkTarget } from "./link-parser.js";
 import type { EvaluateResult } from "./types.js";
 
@@ -102,20 +106,59 @@ export function collectBrokenLinks(cwd: string): BrokenLink[] {
 /**
  * Validate internal markdown links. Faithful to `scripts/validate-links.py`.
  */
-function contentRootForC3(cwd: string): string {
-  const underContent = join(cwd, "content");
-  return existsSync(underContent) ? underContent : cwd;
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
-function extraMarkdownForC3(cwd: string): { relativePath: string; absolutePath: string }[] {
-  const extras: { relativePath: string; absolutePath: string }[] = [];
-  for (const name of ["main.md", "SKILL.md"] as const) {
-    const absolutePath = join(cwd, name);
-    if (existsSync(absolutePath)) {
-      extras.push({ relativePath: name, absolutePath });
-    }
+function consumerDepositDir(cwd: string): string | null {
+  for (const rel of [CANONICAL_INSTALL_ROOT, "deft"] as const) {
+    const candidate = join(cwd, rel);
+    if (isDirectory(candidate)) return candidate;
   }
-  return extras;
+  return null;
+}
+
+export interface C3EvaluationRoot {
+  readonly stagedRoot: string;
+  readonly extraFiles: ExtraMarkdownFile[];
+}
+
+/**
+ * Choose the C3 walk root. Probe framework source first, then an initialized
+ * consumer deposit, then treat cwd as a flattened deposit. Do not use
+ * contentRoot(cwd): that prefers the npm content package over the vendored
+ * deposit (#4081).
+ */
+export function resolveC3EvaluationRoot(cwd: string): C3EvaluationRoot {
+  if (isFrameworkRepoRoot(cwd)) {
+    const underContent = join(cwd, "content");
+    return {
+      stagedRoot: isDirectory(underContent) ? underContent : cwd,
+      extraFiles: extraDepositMarkdownFiles(cwd),
+    };
+  }
+  const deposit = consumerDepositDir(cwd);
+  if (deposit !== null) {
+    return {
+      stagedRoot: deposit,
+      extraFiles: extraDepositMarkdownFiles(deposit),
+    };
+  }
+  return {
+    stagedRoot: cwd,
+    extraFiles: extraDepositMarkdownFiles(cwd),
+  };
+}
+
+function formatMissingC3Root(stagedRoot: string): string {
+  return (
+    "C3 live-procedure target validation failed: deposit root is missing or not a directory: " +
+    stagedRoot
+  );
 }
 
 export function evaluate(options: ValidateLinksOptions = {}): EvaluateResult {
@@ -126,9 +169,17 @@ export function evaluate(options: ValidateLinksOptions = {}): EvaluateResult {
     (options.argv ?? []).includes("--strict") ||
     process.env.LINK_CHECK_STRICT === "1";
 
+  const c3Root = resolveC3EvaluationRoot(cwd);
+  if (!isDirectory(c3Root.stagedRoot)) {
+    return {
+      code: 1,
+      message: formatMissingC3Root(c3Root.stagedRoot),
+      stream: "stdout",
+    };
+  }
   const c3 = evaluateLiveProcedureTargets({
-    stagedRoot: contentRootForC3(cwd),
-    extraFiles: extraMarkdownForC3(cwd),
+    stagedRoot: c3Root.stagedRoot,
+    extraFiles: c3Root.extraFiles,
   });
   if (c3.uniqueTargets.length > 0) {
     return {

--- a/packages/core/src/validate-content/validate-links.ts
+++ b/packages/core/src/validate-content/validate-links.ts
@@ -145,12 +145,12 @@ export function resolveC3EvaluationRoot(cwd: string): C3EvaluationRoot {
   if (deposit !== null) {
     return {
       stagedRoot: deposit,
-      extraFiles: extraDepositMarkdownFiles(deposit),
+      extraFiles: [],
     };
   }
   return {
     stagedRoot: cwd,
-    extraFiles: extraDepositMarkdownFiles(cwd),
+    extraFiles: [],
   };
 }
 


### PR DESCRIPTION
From an initialized consumer root, C3 now walks .deft/core as its own stagedRoot instead of the project tree.

- Declared deposit-relative exclusions match
- Consumer markdown naming path/to.py is out of the walk
- A product content/ directory no longer fail-opens a dirty deposit
- Extras bind to the deposit
- Missing deposit root fails closed
- Does not substitute contentRoot(cwd) (npm content package)

Closes #4081
