### PR TITLE
fix(verify-ac): pair quote delimiters in extractExpectedTokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **verify:ac no longer false-FAILS a clause because `'` and `"` share one delimiter class (#4103).** `extractExpectedTokens` pairs each quote type with itself and does not treat an in-word apostrophe as a quote opener. A lone possessive was already a non-event. Closes #4103.
 - **Land completed-tracked artifact for #4081 (#3264 / #1358).** The #4081 xBRIEF stayed untracked after squash of PR 4110 (efdbcd60). Moved to xbrief/completed/ via scope:complete. Does not recut that issue. Refs #2321, #3476.
 - **`verify:links` C3 evaluates an initialized consumer deposit in deposit-relative coordinates (#4081).** From a consumer root the gate walks `.deft/core`, not the project tree and not `contentRoot(cwd)`. Declared exclusions match. Consumer markdown naming `path/to.py` is out of the walk. A product `content/` directory no longer fail-opens a dirty deposit. Closes #4081.
 - **Land completed-tracked artifact for #4072 (#3264 / #1358).** The #4072 xBRIEF stayed in active/ after squash of PR 4108 (18d50df3). Moved to xbrief/completed/ via scope:complete. Does not recut that issue. Refs #2321, #3476.

--- a/packages/core/src/verify-ac/clauses.test.ts
+++ b/packages/core/src/verify-ac/clauses.test.ts
@@ -8,6 +8,7 @@ import {
   countAdjudicableClauses,
   countUnverifiedAdjudicableClauses,
   deriveAcceptanceClauses,
+  extractExpectedTokens,
   formatClauseWalkMessage,
   isDeclaredArtifactPath,
   isScratchArtifactPath,
@@ -817,5 +818,53 @@ describe("verified > 0 binds only where the walk has an oracle (#3826)", () => {
     expect(countUnverifiedAdjudicableClauses(rows)).toBe(1);
     expect(countAdjudicableClauses([])).toBe(0);
     expect(countUnverifiedAdjudicableClauses([])).toBe(0);
+  });
+});
+
+describe("extractExpectedTokens quote-class pairing (#4103)", () => {
+  const bound = (text: string) => ({
+    id: 1,
+    text,
+    artifact_path: "shipped.ts",
+    ambiguous: false,
+  });
+
+  it("extracts no quoted token from a lone possessive with no other quote-class character", () => {
+    expect(extractExpectedTokens(bound("the schedule's total"))).toEqual([]);
+  });
+
+  it("does not extract a spurious fragment from a two-apostrophe contraction-pair clause", () => {
+    expect(
+      extractExpectedTokens(bound("verify:ac doesn't fail when the artifact isn't scratch")),
+    ).toEqual([]);
+  });
+
+  it("does not steal a genuine quoted literal from a mixed apostrophe/double-quote clause", () => {
+    expect(
+      extractExpectedTokens(
+        bound('the response returns the user\'s id and logs "unauthorized" on failure'),
+      ),
+    ).toEqual(["unauthorized"]);
+  });
+
+  it("still extracts a genuine same-delimiter quoted literal for verbatim match", () => {
+    expect(extractExpectedTokens(bound('shipped.ts contains "exact string"'))).toEqual([
+      "exact string",
+    ]);
+    expect(extractExpectedTokens(bound("the clause names 'exact string' verbatim"))).toEqual([
+      "exact string",
+    ]);
+  });
+
+  it("does not FAIL a correct artifact on a contraction-pair clause", () => {
+    const root = mkdtempSync(join(tmpdir(), "clause-4103-pair-"));
+    writeFileSync(join(root, "shipped.ts"), "export const ok = true;\n", "utf8");
+    const report = walkAcceptanceClauses(
+      [bound("verify:ac doesn't fail when the artifact isn't scratch")],
+      root,
+      { declaredScope: ["shipped.ts"] },
+    );
+    expect(report.clauses[0]?.outcome).not.toBe("failed");
+    expect(report.clauses[0]?.detail).not.toMatch(/expected token/);
   });
 });

--- a/packages/core/src/verify-ac/clauses.ts
+++ b/packages/core/src/verify-ac/clauses.ts
@@ -751,23 +751,33 @@ function isContained(root: string, child: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-function extractExpectedTokens(clause: AcceptanceClause): string[] {
+/**
+ * Quoted literals a clause asks the walk to find verbatim in the artifact.
+ *
+ * Apostrophe and double-quote are separate delimiter classes. An apostrophe
+ * immediately after alphanumeric is a possessive or contraction, not a quote
+ * opener. Pairing those as one class captured fragments that cannot exist
+ * in the artifact and false-FAILED correct work (#4103).
+ */
+export function extractExpectedTokens(clause: AcceptanceClause): string[] {
   const tokens: string[] = [];
   const seen = new Set<string>();
-  const quoted = /["']([^"'\n]{3,80})["']/g;
-  let match = quoted.exec(clause.text);
-  while (match !== null) {
-    const token = (match[1] ?? "").trim();
-    const skip =
-      token.length === 0 ||
-      token === clause.artifact_path ||
-      looksLikeFilePath(token) ||
-      seen.has(token);
-    if (!skip) {
-      seen.add(token);
-      tokens.push(token);
+  const patterns = [/"([^"\n]{3,80})"/g, /(?<![A-Za-z0-9])'([^'\n]{3,80})'/g];
+  for (const quoted of patterns) {
+    let match = quoted.exec(clause.text);
+    while (match !== null) {
+      const token = (match[1] ?? "").trim();
+      const skip =
+        token.length === 0 ||
+        token === clause.artifact_path ||
+        looksLikeFilePath(token) ||
+        seen.has(token);
+      if (!skip) {
+        seen.add(token);
+        tokens.push(token);
+      }
+      match = quoted.exec(clause.text);
     }
-    match = quoted.exec(clause.text);
   }
   return tokens;
 }


### PR DESCRIPTION
## Summary

extractExpectedTokens treated apostrophe and double-quote as one delimiter class, so two or more quote-class characters in a clause captured a fragment that cannot exist in the artifact and verify:ac reported FAILED on correct work. A lone possessive did not fire.

This recut pairs each quote type with itself and does not treat an in-word apostrophe as a quote opener. Tests cover lone-possessive non-regression, contraction-pair, mixed delimiters, and a genuine same-delimiter quoted literal.

Fixes #4103

## Test plan

- [x] pnpm exec vitest run packages/core/src/verify-ac/clauses.test.ts
- [x] task check
