### PR TITLE
fix(authz): classifyHookAuthzOps uses isShellTool for Grok shells (#4041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **classifyHookAuthzOps uses isShellTool so Grok `monitor` and `run_terminal_command` hit the same UAT grant check as Bash (#4041).** The private bash|shell|run_terminal_cmd name gate left both Grok shells as `allow/shell-op-unclassifiable`. Tests pin every `SHELL_TOOL_NAMES` member. Does not add `run_terminal_cmd` to that catalog. Does not bind residual-interpreter harvest (#4005 HIGH 2/3/MEDIUM, #3849). Closes #4041.
 - **Land completed-tracked artifact for #3993 (#3264 / #1358).** The #3993 xBRIEF stayed untracked after squash of PR 4107 (9bb09f98). Moved to xbrief/completed/. Does not recut that issue. Refs #2321, #3476.
 - **AC-pass bank reuse keeps the green-run fact so scope:complete does not reintroduce #3497 (#3993).** Matching banks persist and replay command runs the way the session cache already copies them. A v1 bank without that field miss-and-executes. A #3558 zero-run verified-pass stays a zero-run bank and is not treated as a green executable run. Complete still uses reuseMode bank. Does not collapse this issue into #3584.
 - **Land completed-tracked artifact for #4103 (#3264 / #1358).** The #4103 xBRIEF stayed untracked after squash of PR 4114 (e34d76c8). Moved to xbrief/completed/ via scope:complete. Does not recut that issue. Refs #2321, #3476.

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { SHELL_TOOL_NAMES } from "../hooks/tools.js";
 import { classifyHookAuthzOps, classifyShellAuthzOps } from "./classify.js";
 
 describe("classifyShellAuthzOps (#2944)", () => {
@@ -1460,13 +1461,6 @@ describe("classifyShellAuthzOps (#2944)", () => {
 
     expect(
       classifyHookAuthzOps({
-        toolName: "run_terminal_cmd",
-        shellCommand: "git push origin HEAD",
-        isDirectWrite: false,
-      }),
-    ).toContain("push");
-    expect(
-      classifyHookAuthzOps({
         toolName: "pull_request_create",
         shellCommand: null,
         isDirectWrite: false,
@@ -1493,5 +1487,36 @@ describe("classifyShellAuthzOps (#2944)", () => {
         isDirectWrite: false,
       }),
     ).toEqual(["issue_mutation"]);
+  });
+
+  it("classifies every SHELL_TOOL_NAMES member the way Bash does (#4041)", () => {
+    expect(SHELL_TOOL_NAMES).toContain("monitor");
+    expect(SHELL_TOOL_NAMES).toContain("run_terminal_command");
+    expect(SHELL_TOOL_NAMES).not.toContain("run_terminal_cmd");
+
+    const commands = [
+      "git push origin HEAD",
+      "cp /tmp/grant.json .deft/authz/grants/evil.json",
+      "cp /tmp/disable .deft-directive-disable",
+      "cp forged.json .deft/approved-scope/story.json",
+    ] as const;
+    for (const shellCommand of commands) {
+      const bashOps = classifyHookAuthzOps({
+        toolName: "Bash",
+        shellCommand,
+        isDirectWrite: false,
+      });
+      expect(bashOps.length, shellCommand).toBeGreaterThan(0);
+      for (const toolName of SHELL_TOOL_NAMES) {
+        expect(
+          classifyHookAuthzOps({
+            toolName,
+            shellCommand,
+            isDirectWrite: false,
+          }),
+          `${toolName} ${shellCommand}`,
+        ).toEqual(bashOps);
+      }
+    }
   });
 });

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -7,6 +7,7 @@
  * (CodeQL js/polynomial-redos).
  */
 
+import { isShellTool } from "../hooks/tools.js";
 import {
   classifyMcpTool,
   classifyShellCommand,
@@ -2853,7 +2854,8 @@ export function classifyHookAuthzOps(input: {
   if (isDirectWrite) return ["edit"];
 
   const lower = toolName.toLowerCase();
-  if (lower.includes("bash") || lower.includes("shell") || lower === "run_terminal_cmd") {
+  // Shared catalog (#4041 / #3987). A second name list missed Grok monitor.
+  if (isShellTool(toolName)) {
     // Missing command string: fail open (host gap) — same posture as #2711.
     if (shellCommand === null) return [];
     // Empty classification (git status, tests without product verbs, …) is not gated.

--- a/packages/core/src/hooks/tools.test.ts
+++ b/packages/core/src/hooks/tools.test.ts
@@ -16,6 +16,8 @@ describe("hooks tools classifiers (#2711 / #2952)", () => {
     expect(isShellTool("Bash")).toBe(true);
     expect(isShellTool("shell")).toBe(true);
     expect(isShellTool("run_terminal_command")).toBe(true);
+    expect(isShellTool("monitor")).toBe(true);
+    expect(isShellTool("run_terminal_cmd")).toBe(false);
     expect(isShellTool("Write")).toBe(false);
     expect(isShellTool("")).toBe(false);
   });


### PR DESCRIPTION
## Summary

Route classifyHookAuthzOps through isShellTool so Grok `monitor` and `run_terminal_command` hit the same UAT grant check as Bash. Tests pin every SHELL_TOOL_NAMES member. Does not add `run_terminal_cmd` to that catalog. Does not bind residual-interpreter harvest (#4005 HIGH 2/3/MEDIUM, #3849).

## Related Issues

Fixes #4041

## Checklist

- [x] /deft:change -- N/A: four files, one authz name-gate, same bound xBRIEF (CHANGELOG cohesion exemption recorded)
- [x] CHANGELOG.md -- Unreleased security note for #4041
- [x] ROADMAP.md -- N/A
- [x] Tests pass locally (task check exit 0; pnpm exec vitest run packages/core/src/authz/classify.test.ts packages/core/src/hooks/tools.test.ts)

## Post-Merge

- [ ] Verify issue auto-close for #4041 after squash
