### PR TITLE
fix(update): keep stale vbrief spec banners from blocking deposit refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Generated spec export with a stale vbrief banner no longer blocks npm deposit refresh (#4117).** A current xBRIEF project whose rendered specification still names the old vbrief source is classified as current. Content drift stays a render warning, not a frozen-migrator hard block. Closes #4117.
 - **session:start git probes stay silent on an npm deposit (#4118).** Both resolveFrameworkSha and payloadIsOwnGitRoot swallow recoverable `fatal: not a git repository` from a non-checkout payload root. Mutation start no longer prints that line twice; read-only stays silent too. Actionable Git failures still print. Does not recut #3914.
 - **Land completed-tracked artifact for #4118 (#3264 / #1358).** The #4118 xBRIEF stayed untracked after squash of PR 4139 (0c419070). Moved to xbrief/completed/ via scope:complete. Does not recut that issue. Refs #2321, #3476.
 - **Land completed-tracked artifact for #4060 (#3264 / #1358).** The #4060 xBRIEF stayed untracked after squash of PR 4124 (0d5da1e7). Moved to xbrief/completed/ via scope:complete. Does not recut that issue. Refs #2321, #3476.

--- a/packages/core/src/spec-authority/constants.ts
+++ b/packages/core/src/spec-authority/constants.ts
@@ -15,6 +15,12 @@ export const GENERATED_SPEC_SOURCE_PD =
 export const GENERATED_SPEC_SOURCE_PD_XBRIEF =
   "<!-- Source of truth: xbrief/PROJECT-DEFINITION.xbrief.json -->";
 
+/** Stale vbrief generated-source banners aliased when the named file is gone (#4117). */
+export const LEGACY_GENERATED_SPEC_SOURCE_MARKERS = [
+  GENERATED_SPEC_SOURCE_SPEC,
+  GENERATED_SPEC_SOURCE_PD,
+] as const;
+
 const GENERATED_SOURCE_MARKER = /^<!-- Source of truth: (.+?) -->\r?$/gm;
 const PROJECT_DEFINITION_SOURCE = /(?:^|\/)PROJECT-DEFINITION\.(?:vbrief|xbrief)\.json$/i;
 

--- a/packages/core/src/spec-authority/resolver.ts
+++ b/packages/core/src/spec-authority/resolver.ts
@@ -86,8 +86,10 @@ function contentHasAbsentLegacyGeneratedSource(projectRoot: string, content: str
     const relative = relativePathFromSourceMarker(marker);
     try {
       if (statSync(sourcePathFromMarker(projectRoot, relative)).isFile()) continue;
-    } catch {
-      // Named legacy file is gone; render-staleness owns content warning (#4117).
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // Permission or IO errors are not absence; keep fail-closed (#4117).
+      if (code !== "ENOENT" && code !== "ENOTDIR") continue;
     }
     return true;
   }

--- a/packages/core/src/spec-authority/resolver.ts
+++ b/packages/core/src/spec-authority/resolver.ts
@@ -85,13 +85,13 @@ function contentHasAbsentLegacyGeneratedSource(projectRoot: string, content: str
     if (!content.includes(marker)) continue;
     const relative = relativePathFromSourceMarker(marker);
     try {
-      if (statSync(sourcePathFromMarker(projectRoot, relative)).isFile()) continue;
+      statSync(sourcePathFromMarker(projectRoot, relative));
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      // Permission or IO errors are not absence; keep fail-closed (#4117).
-      if (code !== "ENOENT" && code !== "ENOTDIR") continue;
+      // Only a missing path is absence. Existing files, directories, and
+      // permission errors stay fail-closed (#4117).
+      if (code === "ENOENT" || code === "ENOTDIR") return true;
     }
-    return true;
   }
   return false;
 }

--- a/packages/core/src/spec-authority/resolver.ts
+++ b/packages/core/src/spec-authority/resolver.ts
@@ -14,6 +14,7 @@ import {
   contentHasGeneratedSpecSource,
   GENERATED_SPEC_PURPOSE,
   generatedSpecSourcePaths,
+  LEGACY_GENERATED_SPEC_SOURCE_MARKERS,
 } from "./constants.js";
 
 export type SpecAuthorityKind = "full-spec" | "greenfield";
@@ -73,12 +74,33 @@ function sourcePathFromMarker(projectRoot: string, source: string): string {
   return isAbsolute(source) ? source : resolve(projectRoot, source);
 }
 
+function relativePathFromSourceMarker(marker: string): string {
+  const prefix = "<!-- Source of truth: ";
+  const suffix = " -->";
+  return marker.slice(prefix.length, marker.length - suffix.length);
+}
+
+function contentHasAbsentLegacyGeneratedSource(projectRoot: string, content: string): boolean {
+  for (const marker of LEGACY_GENERATED_SPEC_SOURCE_MARKERS) {
+    if (!content.includes(marker)) continue;
+    const relative = relativePathFromSourceMarker(marker);
+    try {
+      if (statSync(sourcePathFromMarker(projectRoot, relative)).isFile()) continue;
+    } catch {
+      // Named legacy file is gone; render-staleness owns content warning (#4117).
+    }
+    return true;
+  }
+  return false;
+}
+
 function contentMatchesResolvedSpecSource(
   projectRoot: string,
   content: string,
   resolvedSourcePath: string,
 ): boolean {
   if (contentHasGeneratedSpecSource(content, resolvedSourcePath)) return true;
+  if (contentHasAbsentLegacyGeneratedSource(projectRoot, content)) return true;
 
   let resolvedSource: unknown;
   try {

--- a/packages/core/src/spec-authority/spec-authority.test.ts
+++ b/packages/core/src/spec-authority/spec-authority.test.ts
@@ -5,10 +5,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { exportSpec, exportSpecMain, parseExportSpecArgv } from "../render/export-spec.js";
 import { aggregateScopeSection, buildScopeOutlookSection } from "../render/scope-outlook.js";
 import { renderSpec } from "../render/spec-render.js";
+import { detectPreCutover } from "../vbrief-validate/precutover.js";
 import {
   GENERATED_SPEC_PURPOSE,
+  GENERATED_SPEC_SOURCE_PD,
   GENERATED_SPEC_SOURCE_PD_XBRIEF,
+  GENERATED_SPEC_SOURCE_SPEC,
   GENERATED_SPEC_SOURCE_SPEC_XBRIEF,
+  LEGACY_GENERATED_SPEC_SOURCE_MARKERS,
 } from "./constants.js";
 import { checkSpecMigrationFidelity } from "./migration-fidelity.js";
 import { renderNarrativeSections, resolveExportNarratives } from "./narratives.js";
@@ -311,6 +315,121 @@ describe("spec-authority resolver", () => {
     );
     expect(isFullSpecState(root)).toBe(true);
     expect(isGreenfieldSpecExport(root)).toBe(false);
+  });
+
+  it("treats a stale vbrief spec banner as current when xbrief spec and lifecycle exist (#4117)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-stale-vbrief-"));
+    roots.push(root);
+    const vbrief = join(root, "xbrief");
+    for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+      mkdirSync(join(vbrief, folder), { recursive: true });
+    }
+    writeProjectDef(vbrief, { Overview: "PD overview" });
+    writeJson(join(vbrief, "specification.xbrief.json"), {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Full spec",
+        status: "running",
+        narratives: { Overview: "Spec overview" },
+        items: [],
+      },
+    });
+    writeFileSync(
+      join(root, "SPECIFICATION.md"),
+      `${GENERATED_SPEC_PURPOSE}\n${GENERATED_SPEC_SOURCE_SPEC}\n`,
+      "utf8",
+    );
+    expect(isFullSpecState(root)).toBe(true);
+    expect(isCurrentGeneratedSpecification(root)).toBe(true);
+    expect(detectPreCutover(root)).toEqual({ preCutover: false, reasons: [] });
+  });
+
+  it("does not alias a stale vbrief banner when the named file still exists with different content (#4117)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-stale-present-"));
+    roots.push(root);
+    const vbrief = join(root, "xbrief");
+    for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+      mkdirSync(join(vbrief, folder), { recursive: true });
+    }
+    writeProjectDef(vbrief, { Overview: "PD overview" });
+    writeJson(join(vbrief, "specification.xbrief.json"), {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Full spec",
+        status: "running",
+        narratives: { Overview: "Spec overview" },
+        items: [],
+      },
+    });
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    writeJson(join(root, "vbrief", "specification.vbrief.json"), {
+      xBRIEFInfo: { version: "0.8" },
+      plan: { title: "Different", status: "running", narratives: {}, items: [] },
+    });
+    writeFileSync(
+      join(root, "SPECIFICATION.md"),
+      `${GENERATED_SPEC_PURPOSE}\n${GENERATED_SPEC_SOURCE_SPEC}\n`,
+      "utf8",
+    );
+    expect(isFullSpecState(root)).toBe(false);
+    expect(isCurrentGeneratedSpecification(root)).toBe(false);
+  });
+
+  it("treats a stale vbrief PD banner as current when the named file is gone (#4117)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-stale-pd-"));
+    roots.push(root);
+    const vbrief = join(root, "xbrief");
+    for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+      mkdirSync(join(vbrief, folder), { recursive: true });
+    }
+    writeProjectDef(vbrief, { Overview: "PD overview" });
+    writeJson(join(vbrief, "specification.xbrief.json"), {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Full spec",
+        status: "running",
+        narratives: { Overview: "Spec overview" },
+        items: [],
+      },
+    });
+    writeFileSync(
+      join(root, "SPECIFICATION.md"),
+      `${GENERATED_SPEC_PURPOSE}\n${GENERATED_SPEC_SOURCE_PD}\n`,
+      "utf8",
+    );
+    expect(isFullSpecState(root)).toBe(true);
+    expect(isCurrentGeneratedSpecification(root)).toBe(true);
+    expect(detectPreCutover(root)).toEqual({ preCutover: false, reasons: [] });
+  });
+
+  it("keeps the generated-source legacy-alias list to the two known vbrief banners (#4117)", () => {
+    expect([...LEGACY_GENERATED_SPEC_SOURCE_MARKERS]).toEqual([
+      GENERATED_SPEC_SOURCE_SPEC,
+      GENERATED_SPEC_SOURCE_PD,
+    ]);
+  });
+
+  it("still classifies a hand-authored SPECIFICATION.md as pre-cutover (#4117)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-hand-authored-"));
+    roots.push(root);
+    const vbrief = join(root, "xbrief");
+    for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+      mkdirSync(join(vbrief, folder), { recursive: true });
+    }
+    writeProjectDef(vbrief, { Overview: "PD overview" });
+    writeJson(join(vbrief, "specification.xbrief.json"), {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Full spec",
+        status: "running",
+        narratives: { Overview: "Spec overview" },
+        items: [],
+      },
+    });
+    writeFileSync(join(root, "SPECIFICATION.md"), "# Hand authored spec\n", "utf8");
+    expect(isFullSpecState(root)).toBe(false);
+    expect(isCurrentGeneratedSpecification(root)).toBe(false);
+    expect(detectPreCutover(root).preCutover).toBe(true);
   });
 
   it("recognizes a source-derived banner from an explicit spec path", () => {

--- a/packages/core/src/spec-authority/spec-authority.test.ts
+++ b/packages/core/src/spec-authority/spec-authority.test.ts
@@ -375,6 +375,33 @@ describe("spec-authority resolver", () => {
     expect(isCurrentGeneratedSpecification(root)).toBe(false);
   });
 
+  it("does not alias a stale vbrief banner when the named path is a directory (#4117)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-stale-dir-"));
+    roots.push(root);
+    const vbrief = join(root, "xbrief");
+    for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+      mkdirSync(join(vbrief, folder), { recursive: true });
+    }
+    writeProjectDef(vbrief, { Overview: "PD overview" });
+    writeJson(join(vbrief, "specification.xbrief.json"), {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "Full spec",
+        status: "running",
+        narratives: { Overview: "Spec overview" },
+        items: [],
+      },
+    });
+    mkdirSync(join(root, "vbrief", "specification.vbrief.json"), { recursive: true });
+    writeFileSync(
+      join(root, "SPECIFICATION.md"),
+      `${GENERATED_SPEC_PURPOSE}\n${GENERATED_SPEC_SOURCE_SPEC}\n`,
+      "utf8",
+    );
+    expect(isFullSpecState(root)).toBe(false);
+    expect(isCurrentGeneratedSpecification(root)).toBe(false);
+  });
+
   it.skipIf(process.platform === "win32")(
     "does not alias a stale vbrief banner when the named file is unreadable (#4117)",
     () => {

--- a/packages/core/src/spec-authority/spec-authority.test.ts
+++ b/packages/core/src/spec-authority/spec-authority.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -374,6 +374,46 @@ describe("spec-authority resolver", () => {
     expect(isFullSpecState(root)).toBe(false);
     expect(isCurrentGeneratedSpecification(root)).toBe(false);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "does not alias a stale vbrief banner when the named file is unreadable (#4117)",
+    () => {
+      const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-stale-unreadable-"));
+      roots.push(root);
+      const vbrief = join(root, "xbrief");
+      for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+        mkdirSync(join(vbrief, folder), { recursive: true });
+      }
+      writeProjectDef(vbrief, { Overview: "PD overview" });
+      writeJson(join(vbrief, "specification.xbrief.json"), {
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          title: "Full spec",
+          status: "running",
+          narratives: { Overview: "Spec overview" },
+          items: [],
+        },
+      });
+      mkdirSync(join(root, "vbrief"), { recursive: true });
+      const legacy = join(root, "vbrief", "specification.vbrief.json");
+      writeJson(legacy, {
+        xBRIEFInfo: { version: "0.8" },
+        plan: { title: "Different", status: "running", narratives: {}, items: [] },
+      });
+      chmodSync(legacy, 0o000);
+      writeFileSync(
+        join(root, "SPECIFICATION.md"),
+        `${GENERATED_SPEC_PURPOSE}\n${GENERATED_SPEC_SOURCE_SPEC}\n`,
+        "utf8",
+      );
+      try {
+        expect(isFullSpecState(root)).toBe(false);
+        expect(isCurrentGeneratedSpecification(root)).toBe(false);
+      } finally {
+        chmodSync(legacy, 0o644);
+      }
+    },
+  );
 
   it("treats a stale vbrief PD banner as current when the named file is gone (#4117)", () => {
     const root = mkdtempSync(join(tmpdir(), "deft-spec-auth-stale-pd-"));


### PR DESCRIPTION
## Summary

A generated specification export whose source banner still names the old vbrief path is no longer treated as a pre-v0.20 hand-authored spec when the live xBRIEF specification and lifecycle folders exist. Update can refresh the deposit instead of sending a current project to the frozen migrator. Render-staleness still warns when export content is behind.

Narrow alias only: the two known legacy generated-source banners. Unrelated source paths still fail. detectPreCutover is unchanged.

## Test plan

- [x] Stale vbrief spec banner plus live xbrief spec and lifecycle is not pre-cutover
- [x] Stale PD banner aliases when the named file is gone
- [x] Present-but-different vbrief file is not aliased
- [x] Hand-authored SPECIFICATION.md remains pre-cutover
- [x] Unrelated source regression remains
- [x] task check green

Closes #4117.
