### PR TITLE
docs(files): reconcile labeled-current FILES.md trees (#4087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Orientation file map matches the current checkout (#4087).** Labeled-current directory trees no longer teach deleted Python launchers or root guidance paths. Skills and consumer state use `content/skills/` and `xbrief/`. A fail-closed content-contract pin covers those trees. Partial of #4087. Refs #4085.
+
 ### Fixed
 
 ### Removed

--- a/docs/FILES.md
+++ b/docs/FILES.md
@@ -55,11 +55,13 @@ Shipped guidance lives under `content/`. Root `docs/`, `meta/`, and `incidents/`
 ```text
 content/
 ├── coding/        # Coding, testing, hygiene, toolchain, and build-output rules
+├── ci-cd/         # CI/CD runner notes
 ├── context/       # Context management patterns and spec-delta guidance
 ├── contracts/     # Boundary maps, hierarchy, deterministic question contracts
 ├── conventions/   # Cross-cutting conventions such as references and banners
 ├── deployments/   # Platform deployment guides
 ├── docs/          # Shipped user, maintainer, and process docs
+├── doctor/        # Doctor session-coda payload
 ├── events/        # Event registry and schemas
 ├── incidents/     # Incident templates
 ├── interfaces/    # CLI, REST, TUI, and web interface guidance
@@ -70,6 +72,7 @@ content/
 ├── references/    # External/reference material
 ├── resilience/    # Continue-here and context-pruning protocols
 ├── scm/           # Git, GitHub, and changelog guidance
+├── secrets/       # Secrets placeholders
 ├── skills/        # Current skill directories (see Skills)
 ├── strategies/    # Interview, map, research, speckit, yolo, and related strategies
 ├── swarm/         # Multi-agent coordination reference
@@ -79,6 +82,7 @@ content/
 ├── packs/         # Content-pack JSON sources
 ├── vbrief/        # Schemas and vBRIEF usage reference (legacy name on disk)
 ├── commands.md    # Command lifecycle and task references
+├── glossary.md    # Glossary
 ├── QUICK-START.md # Manual bootstrap pointer
 ├── UPGRADING.md   # Upgrade and installer-state guidance
 └── LICENSE.md     # Content-tree license copy; repo license is LICENSE

--- a/docs/FILES.md
+++ b/docs/FILES.md
@@ -4,6 +4,17 @@ Current directory map and per-area index for the Deft Directive framework reposi
 
 > **See also**: [ARCHITECTURE.md](./ARCHITECTURE.md) | [CONCEPTS.md](./CONCEPTS.md) | [RELEASING.md](./RELEASING.md)
 
+## Path classes
+
+Every path in a labeled-current tree below is one of:
+
+- **repo-tracked** — present in this checkout (the default if a line does not name another class)
+- **generated-on-demand** — produced by a task, not committed (MAP)
+- **consumer-install** — created when Deft is installed into another project (`.deft/core/`, USER.md)
+- **illustrative** — names a class of path, not a single tracked file
+
+Python/run-era names appear only in historically labeled blocks.
+
 ## Top Level
 
 ```text
@@ -12,167 +23,199 @@ deft/
 ├── SKILL.md               # Alternate skill-loader entry surface
 ├── main.md                # General AI behavior and rule-authority axiom
 ├── README.md              # User-facing overview and getting started
-├── QUICK-START.md         # Manual bootstrap pointer
 ├── CONTRIBUTING.md        # Contributor setup and conventions
 ├── CHANGELOG.md           # Release notes
-├── LICENSE.md             # MIT license
+├── LICENSE                # MIT license (root file is LICENSE, not LICENSE.md)
 ├── REFERENCES.md          # Lazy-loading reference guidance
-├── UPGRADING.md           # Upgrade and installer-state guidance
-├── commands.md            # Command lifecycle and task references
+├── SECURITY.md            # Security policy
+├── COST-ESTIMATE.md       # Pre-build cost transparency
 ├── Taskfile.yml           # Root deterministic command graph
-├── run                    # Compatibility / interactive Python launcher
-├── run.py                 # Import shim for tests and tooling
-├── run.bat                # Windows launcher for run
-├── go.mod                 # Go installer module
+├── go.mod                 # Frozen Go installer module
 ├── package.json           # TypeScript workspace scripts and package metadata
 ├── pnpm-lock.yaml         # TypeScript dependency lock
 ├── pnpm-workspace.yaml    # TypeScript workspace layout
-├── pyproject.toml         # Python tooling and test configuration
 ├── tsconfig.base.json     # Shared TypeScript compiler configuration
 ├── tsconfig.json          # TypeScript project references
 ├── vitest.config.ts       # TypeScript test configuration
-├── uv.lock                # Python dependency lock
-├── PROJECT.md             # Deprecated redirect to vBRIEF project definition
+├── biome.json             # Formatter/linter config
+├── PROJECT.md             # Deprecated redirect to xBRIEF project definition
 ├── PRD.md                 # Rendered PRD view
 ├── ROADMAP.md             # Rendered backlog view
-└── SPECIFICATION.md       # Rendered spec view from vbrief/specification.vbrief.json
+└── SPECIFICATION.md       # Rendered spec view from xbrief/specification.xbrief.json
 ```
+
+Guidance files `QUICK-START.md`, `UPGRADING.md`, and `commands.md` live under `content/`, not the repo root.
+
+> **Historical (Python/run era):** root `run`, `run.py`, `run.bat`, `pyproject.toml`, and `uv.lock` were launchers and Python tooling manifests. They are not in the current tree.
 
 ## Framework Guidance
 
+Shipped guidance lives under `content/`. Root `docs/`, `meta/`, and `incidents/` are repo-dev orientation, not the shipped guidance root.
+
 ```text
-coding/        # Coding, testing, hygiene, toolchain, and build-output rules
-context/       # Context management patterns and spec-delta guidance
-contracts/     # Boundary maps, hierarchy, deterministic question contracts
-conventions/   # Cross-cutting conventions such as references and banners
-core/          # Detailed glossary, project template, versioning, Ralph concepts
-deployments/   # Platform deployment guides
-docs/          # User, maintainer, audit, architecture, and research docs
-events/        # Event registry and schemas
-incidents/     # Incident records and analyses
-interfaces/    # CLI, REST, TUI, and web interface guidance
-languages/     # Language-specific standards
-meta/          # Philosophy, morals, security, lessons, ideas, and suggestions
-patterns/      # Reusable architectural and LLM-application patterns
-platforms/     # Niche platform guidance
-references/    # External/reference material
-resilience/    # Continue-here and context-pruning protocols
-scm/           # Git, GitHub, and changelog guidance
-strategies/    # Interview, map, research, speckit, yolo, and related strategies
-swarm/         # Multi-agent coordination reference
-tools/         # Tool-specific guidance such as Taskfile and telemetry
-verification/  # Verification ladder and validation guidance
+content/
+├── coding/        # Coding, testing, hygiene, toolchain, and build-output rules
+├── context/       # Context management patterns and spec-delta guidance
+├── contracts/     # Boundary maps, hierarchy, deterministic question contracts
+├── conventions/   # Cross-cutting conventions such as references and banners
+├── deployments/   # Platform deployment guides
+├── docs/          # Shipped user, maintainer, and process docs
+├── events/        # Event registry and schemas
+├── incidents/     # Incident templates
+├── interfaces/    # CLI, REST, TUI, and web interface guidance
+├── languages/     # Language-specific standards
+├── meta/          # Philosophy, morals, security, lessons, ideas, and suggestions
+├── patterns/      # Reusable architectural and LLM-application patterns
+├── platforms/     # Niche platform guidance
+├── references/    # External/reference material
+├── resilience/    # Continue-here and context-pruning protocols
+├── scm/           # Git, GitHub, and changelog guidance
+├── skills/        # Current skill directories (see Skills)
+├── strategies/    # Interview, map, research, speckit, yolo, and related strategies
+├── swarm/         # Multi-agent coordination reference
+├── templates/     # Agent prompt and project templates
+├── tools/         # Tool-specific guidance such as Taskfile and telemetry
+├── verification/  # Verification ladder and validation guidance
+├── packs/         # Content-pack JSON sources
+├── vbrief/        # Schemas and vBRIEF usage reference (legacy name on disk)
+├── commands.md    # Command lifecycle and task references
+├── QUICK-START.md # Manual bootstrap pointer
+├── UPGRADING.md   # Upgrade and installer-state guidance
+└── LICENSE.md     # Content-tree license copy; repo license is LICENSE
+```
+
+Repo-dev (not shipped as `content/`):
+
+```text
+docs/          # Maintainer orientation (ARCHITECTURE, CONCEPTS, FILES)
+meta/          # Ideas, lessons, suggestions
+incidents/     # Repo incident records
 ```
 
 ## Automation And Runtime
 
 ```text
-cmd/deft-install/  # Go installer source and embedded payload logic
-packages/          # TypeScript engine packages, CLI shims, and parity tests
-scripts/           # Python validators, renderers, lifecycle tools, triage/cache/scm/release helpers
+cmd/deft-install/  # Frozen Go installer source and embedded payload logic
+packages/          # TypeScript engine packages (types, core, content, cli)
+scripts/           # Remaining JS helpers (not a Python validator layer)
 tasks/             # Taskfile include fragments for command namespaces
 .github/           # GitHub Actions workflows and PR template
 .githooks/         # Local branch/commit/push hooks
-tests/             # CLI, content, contract, fixture, and regression tests
+tests/             # Content snapshots and fixtures
 ```
 
 Important task include areas:
 
-- `tasks/core.yml`, `tasks/verify.yml`, `tasks/vbrief.yml`, `tasks/spec.yml`, `tasks/project.yml`
+- `tasks/core.yml`, `tasks/verify.yml`, `tasks/vbrief.yml`, `tasks/xbrief.yml`, `tasks/spec.yml`, `tasks/project.yml`
 - `tasks/scope.yml`, `tasks/scope-undo.yml`
 - `tasks/triage-*.yml`, `tasks/cache.yml`
 - `tasks/codebase.yml`, `tasks/architecture.yml`, `tasks/packs.yml`
-- `tasks/pr.yml`, `tasks/release.yml`, `tasks/swarm.yml`
+- `tasks/pr.yml`, `tasks/swarm.yml`
 - `tasks/policy.yml`, `tasks/capacity.yml`, `tasks/scm.yml`
 
-Use `task --list` for the authoritative current command list.
+Use `task --list` for the authoritative current command list. Release operations are `task release:*`.
 
 ## Skills
 
-Current skill directories include:
+Current skill directories live under `content/skills/`:
 
 ```text
-skills/deft-directive-article-review/
-skills/deft-directive-build/
-skills/deft-directive-cost/
-skills/deft-directive-debug/
-skills/deft-directive-decompose/
-skills/deft-directive-gh-arch/
-skills/deft-directive-gh-slice/
-skills/deft-directive-glossary/
-skills/deft-directive-interview/
-skills/deft-directive-pre-pr/
-skills/deft-directive-probe/
-skills/deft-directive-refinement/
-skills/deft-directive-release/
-skills/deft-directive-review-cycle/
-skills/deft-directive-setup/
-skills/deft-directive-swarm/
-skills/deft-directive-sync/
-skills/deft-directive-triage/
-skills/deft-directive-write-skill/
+content/skills/deft-directive-article-review/
+content/skills/deft-directive-build/
+content/skills/deft-directive-cost/
+content/skills/deft-directive-debug/
+content/skills/deft-directive-decompose/
+content/skills/deft-directive-design-critique/
+content/skills/deft-directive-feedback/
+content/skills/deft-directive-gh-arch/
+content/skills/deft-directive-gh-slice/
+content/skills/deft-directive-glossary/
+content/skills/deft-directive-interview/
+content/skills/deft-directive-issue-eval/
+content/skills/deft-directive-portfolio-priority/
+content/skills/deft-directive-pre-pr/
+content/skills/deft-directive-probe/
+content/skills/deft-directive-product-signal/
+content/skills/deft-directive-refinement/
+content/skills/deft-directive-release/
+content/skills/deft-directive-review-cycle/
+content/skills/deft-directive-setup/
+content/skills/deft-directive-swarm/
+content/skills/deft-directive-sync/
+content/skills/deft-directive-triage/
+content/skills/deft-directive-write-skill/
+content/skills/deft-directive-xbrief/
 ```
 
-Compatibility skill aliases such as `deft-build/`, `deft-setup/`, `deft-swarm/`, and related legacy names remain for older loaders.
+> **Historical:** compatibility skill aliases such as `deft-build/`, `deft-setup/`, and `deft-swarm/` remain only for older loaders.
 
-## vBRIEF State
+## xBRIEF State
+
+Lifecycle state is `xbrief/`, not `vbrief/`.
 
 ```text
-vbrief/
-├── PROJECT-DEFINITION.vbrief.json   # Project identity, policy, scope registry, codeStructure
-├── specification.vbrief.json        # Project specification source of truth
-├── vbrief.md                        # Canonical vBRIEF usage reference
-├── schemas/                         # JSON schemas
-├── proposed/                        # Candidate scope vBRIEFs
-├── pending/                         # Accepted backlog scope vBRIEFs
-├── active/                          # Running scope vBRIEFs
-├── completed/                       # Completed scope vBRIEFs
-├── cancelled/                       # Cancelled or rejected scope vBRIEFs
-├── .triage-cache/                   # Local triage audit/working-set, gitignored
-└── .eval/                           # Framework eval results (`.eval/results/`), gitignored
+xbrief/
+├── PROJECT-DEFINITION.xbrief.json   # Project identity, policy, scope registry, codeStructure
+├── specification.xbrief.json        # Project specification source of truth
+├── plan.xbrief.json                 # Plan envelope
+├── proposed/                        # Candidate scope xBRIEFs
+├── pending/                         # illustrative — created on first promote; may be absent when empty
+├── active/                          # Running scope xBRIEFs
+├── completed/                       # Completed scope xBRIEFs
+├── cancelled/                       # Cancelled or rejected scope xBRIEFs
+├── decisions/                       # Structured decision log
+├── migration/                       # Migration notes and manifests
+├── .triage-cache/                   # generated-on-demand, gitignored
+└── .eval/                           # generated-on-demand, gitignored
 ```
 
-`PROJECT-DEFINITION.vbrief.json` replaces the old `PROJECT.md` authority role. `SPECIFICATION.md` is generated from `vbrief/specification.vbrief.json`; do not hand-edit it for durable changes.
+`PROJECT-DEFINITION.xbrief.json` replaces the old `PROJECT.md` authority role. `SPECIFICATION.md` is generated from `xbrief/specification.xbrief.json`; do not hand-edit it for durable changes.
+
+> **Historical:** durable state used to live under `vbrief/` with `*.vbrief.json` names. New writes use `xbrief/` and xBRIEF 0.8.
 
 ## Content Packs
 
 ```text
-packs/
+content/packs/
 ```
 
 Content packs package selected framework guidance into sliceable agent memory. The `task packs:*` namespace renders and checks pack drift.
 
 ## Planning And Generated Architecture
 
+`.planning/codebase/STACK.md` and `.planning/codebase/CONVENTIONS.md` are residual planning notes, not current architecture authority.
+
 ```text
 .planning/codebase/
-├── ARCHITECTURE.md   # Historical planning note unless generated banner says otherwise
-├── CONCERNS.md       # Planning note
-├── CONVENTIONS.md    # Historical planning note unless generated banner says otherwise
-├── MAP.md            # Generated codebase orientation projection
-└── STACK.md          # Planning note
+├── ARCHITECTURE.md   # residual planning note
+├── CONCERNS.md       # residual planning note
+├── CONVENTIONS.md    # residual planning note, not current architecture authority
+├── MAP.md            # generated-on-demand codebase orientation projection
+└── STACK.md          # residual planning note, not current architecture authority
 ```
 
-`vbrief/PROJECT-DEFINITION.vbrief.json` `plan.architecture.codeStructure` is the authored source of truth for codebase structure. `.planning/codebase/MAP.md` is generated by `task codebase:map` and checked by `task verify:codebase-map-fresh`.
+`xbrief/PROJECT-DEFINITION.xbrief.json` `plan.architecture.codeStructure` is the authored source of truth for codebase structure. `.planning/codebase/MAP.md` is generated by `task codebase:map` and checked by `task verify:codebase-map-fresh`.
 
 ## Consumer Project Artifacts
 
 When Deft is installed into another project, the important locations are:
 
-- `.deft/core/` -- vendored framework payload installed by `deft-install`.
-- `AGENTS.md` -- consumer entry point with a managed Deft section.
-- `vbrief/` -- consumer project vBRIEF root.
-- `vbrief/PROJECT-DEFINITION.vbrief.json` -- consumer project identity and policy.
-- `vbrief/{proposed,pending,active,completed,cancelled}/` -- consumer scope lifecycle folders.
-- `.deft-cache/` and `<lifecycle-root>/.triage-cache/` -- local content cache and triage audit/working-set, normally gitignored; `<lifecycle-root>/.eval/results/` holds framework-eval ledgers (#1703).
-- `~/.config/deft/USER.md` on Unix/macOS or `%APPDATA%\deft\USER.md` on Windows -- personal preferences.
+- `.deft/core/` -- consumer-install vendored framework payload
+- `AGENTS.md` -- illustrative consumer entry point with a managed Deft section
+- `xbrief/` -- consumer-install project xBRIEF root
+- `xbrief/PROJECT-DEFINITION.xbrief.json` -- consumer-install project identity and policy
+- `xbrief/{proposed,pending,active,completed,cancelled}/` -- illustrative consumer scope lifecycle folders
+- `.deft-cache/` -- consumer-install local content cache, normally gitignored
+- `~/.config/deft/USER.md` -- consumer-install personal preferences (Unix/macOS)
+- `%APPDATA%\deft\USER.md` -- consumer-install personal preferences (Windows)
 
-Legacy `deft/` installs can appear during migration, but `.deft/core/` is the canonical installed framework path.
+> **Historical (legacy consumer layout):** older installs used `vbrief/` as the lifecycle root and a tracked `deft/` payload. Current consumer writes use `xbrief/`; `.deft/core/` is the canonical installed framework path.
+
+> **Historical:** `tasks/release.yml` was listed as a Taskfile include; that file is not in the current tree. Release work uses `task release:*`.
 
 ## Notes
 
 - `PROJECT.md` is a deprecated redirect in this repository.
 - `PRD.md`, `ROADMAP.md`, and `SPECIFICATION.md` are rendered views.
-- `run`, `run.py`, and `run.bat` are retained compatibility surfaces.
 - `tasks/` is the current Taskfile include directory; there is no separate `taskfiles/` directory in the current tree.
-- `vbrief/architecture/` is not a current directory. Authored architecture metadata lives in `vbrief/PROJECT-DEFINITION.vbrief.json`.
+- `xbrief/architecture/` is not a current directory. Authored architecture metadata lives in `xbrief/PROJECT-DEFINITION.xbrief.json`.

--- a/packages/core/src/content-contracts/docs-orientation-current.test.ts
+++ b/packages/core/src/content-contracts/docs-orientation-current.test.ts
@@ -215,7 +215,13 @@ function splitComment(raw: string): { code: string; comment: string } {
 }
 
 function lineToken(code: string): string {
-  return code.replace(/[│├└─┬┤┌┐┘┴]/g, " ").replace(/\s+/g, " ").trim().split(" ")[0] ?? "";
+  return (
+    code
+      .replace(/[│├└─┬┤┌┐┘┴]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .split(" ")[0] ?? ""
+  );
 }
 
 function normalizeTreePath(path: string): string {
@@ -447,4 +453,3 @@ describe("docs orientation current-tense (#4087 Wave 1b FILES.md) — FAIL-CLOSE
     }
   });
 });
-

--- a/packages/core/src/content-contracts/docs-orientation-current.test.ts
+++ b/packages/core/src/content-contracts/docs-orientation-current.test.ts
@@ -1,22 +1,29 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { readText } from "./standards/_helpers.js";
+import { readText, repoRoot } from "./standards/_helpers.js";
 
 /**
- * #4087 Wave 1a — content-contract over labeled-current trees in
- * docs/ARCHITECTURE.md and docs/CONCEPTS.md (same family as branch_gate.test.ts).
+ * #4087 — content-contract over labeled-current trees in
+ * docs/ARCHITECTURE.md, docs/CONCEPTS.md (Wave 1a), and docs/FILES.md (Wave 1b).
+ * Same family as branch_gate.test.ts.
  *
  * Enforcement: FAIL-CLOSED. This vitest is in the packages/core check graph.
- * Covered surfaces: docs/ARCHITECTURE.md and docs/CONCEPTS.md only.
+ * Covered surfaces: the three orientation files named above.
  * Relationship to #514: does not take #514's markdown-link allowlist. This pin
- * is a separate current-tense retired-launcher check over labeled-current
- * prose in the two orientation files this slice owns.
+ * is a separate current-tense path check over labeled-current prose and
+ * labeled-current FILES.md fences.
  * Allowlist: none. An allowlist addition in the same diff as the path it
  * exempts is forbidden by the #4087 recut.
  * Does not generate FILES.md. Does not reimplement C3.
  * Read-only against the tree under test (this worktree), not origin/master.
+ * Path-class is declared in FILES.md comments, not in this test.
  */
 
 const COVERED = ["docs/ARCHITECTURE.md", "docs/CONCEPTS.md"] as const;
+const FILES_MD = "docs/FILES.md";
+const COVERED_ALL = [...COVERED, FILES_MD] as const;
 
 const HISTORICAL =
   /historical|legacy|retired|no longer|python\/run era|removed from the current tree|not current|not the current/i;
@@ -121,3 +128,323 @@ describe("docs orientation current-tense (#4087 Wave 1a) — FAIL-CLOSED", () =>
     expect(arch).toMatch(/agent-host/i);
   });
 });
+
+type PathClass = "repo-tracked" | "generated-on-demand" | "consumer-install" | "illustrative";
+
+interface TreeEntry {
+  path: string;
+  comment: string;
+  pathClass: PathClass;
+}
+
+const BOX_CHARS = /[│├└─┬┤┌┐┘┴]/;
+const ROOT_GUIDANCE = /^(coding|skills|vbrief|packs)\/?$/;
+const BANNED_ROOT_FILES = new Set([
+  "run",
+  "run.py",
+  "run.bat",
+  "pyproject.toml",
+  "uv.lock",
+  "LICENSE.md",
+  "QUICK-START.md",
+  "UPGRADING.md",
+  "commands.md",
+  "tasks/release.yml",
+]);
+
+function pathClassFromComment(comment: string): PathClass {
+  if (/generated-on-demand/i.test(comment)) return "generated-on-demand";
+  if (/consumer-install/i.test(comment)) return "consumer-install";
+  if (/illustrative/i.test(comment)) return "illustrative";
+  return "repo-tracked";
+}
+
+function labeledCurrentLines(markdown: string): { line: string; n: number }[] {
+  const out: { line: string; n: number }[] = [];
+  const lines = markdown.split("\n");
+  let skipHeading = false;
+  let skipHeadingLevel = 0;
+  let skipQuote = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      const level = heading[1].length;
+      const title = heading[2] ?? "";
+      if (HISTORICAL.test(title)) {
+        skipHeading = true;
+        skipHeadingLevel = level;
+        continue;
+      }
+      if (skipHeading && level <= skipHeadingLevel) {
+        skipHeading = false;
+      }
+    }
+    if (line.startsWith(">")) {
+      if (HISTORICAL.test(line) || skipQuote) {
+        skipQuote = true;
+        continue;
+      }
+    } else {
+      skipQuote = false;
+    }
+    if (skipHeading) continue;
+    out.push({ line, n: i + 1 });
+  }
+  return out;
+}
+
+function labeledCurrentTextFences(markdown: string): string[] {
+  const current = labeledCurrentLines(markdown)
+    .map((row) => row.line)
+    .join("\n");
+  const fences: string[] = [];
+  const re = /```text\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null = re.exec(current);
+  while (match) {
+    fences.push(match[1] ?? "");
+    match = re.exec(current);
+  }
+  return fences;
+}
+
+function splitComment(raw: string): { code: string; comment: string } {
+  const hash = raw.indexOf("#");
+  if (hash < 0) return { code: raw, comment: "" };
+  return { code: raw.slice(0, hash), comment: raw.slice(hash + 1) };
+}
+
+function lineToken(code: string): string {
+  return code.replace(/[│├└─┬┤┌┐┘┴]/g, " ").replace(/\s+/g, " ").trim().split(" ")[0] ?? "";
+}
+
+function normalizeTreePath(path: string): string {
+  let rel = path.replace(/\\/g, "/").replace(/^\.\//, "");
+  if (rel === "deft" || rel === "deft/") return "";
+  if (rel.startsWith("deft/")) rel = rel.slice("deft/".length);
+  return rel;
+}
+
+function extractTreeEntries(fence: string): TreeEntry[] {
+  const rows = fence.split("\n").map((raw) => {
+    const { code, comment } = splitComment(raw);
+    return { raw, code, comment, token: lineToken(code), nested: BOX_CHARS.test(code) };
+  });
+  const useful = rows.filter((row) => row.token.length > 0);
+  if (useful.length === 0) return [];
+
+  const isNested = useful.some((row) => row.nested);
+  if (!isNested) {
+    return useful
+      .map((row) => {
+        const path = normalizeTreePath(row.token);
+        return path
+          ? { path, comment: row.comment, pathClass: pathClassFromComment(row.comment) }
+          : null;
+      })
+      .filter((entry): entry is TreeEntry => entry !== null);
+  }
+
+  const entries: TreeEntry[] = [];
+  let prefix = "";
+  let seenRoot = false;
+  for (const row of useful) {
+    if (!seenRoot && !row.nested) {
+      seenRoot = true;
+      const root = normalizeTreePath(row.token);
+      prefix = root === "" ? "" : root.endsWith("/") ? root : `${root}/`;
+      if (root !== "") {
+        entries.push({
+          path: prefix,
+          comment: row.comment,
+          pathClass: pathClassFromComment(row.comment),
+        });
+      }
+      continue;
+    }
+    const child = row.token.replace(/^\//, "");
+    const path = normalizeTreePath(`${prefix}${child}`);
+    if (!path) continue;
+    entries.push({
+      path,
+      comment: row.comment,
+      pathClass: pathClassFromComment(row.comment),
+    });
+  }
+  return entries;
+}
+
+function isBannedCurrentPath(rel: string): boolean {
+  const trimmed = rel.replace(/\/$/, "");
+  if (BANNED_ROOT_FILES.has(rel) || BANNED_ROOT_FILES.has(trimmed)) return true;
+  if (ROOT_GUIDANCE.test(rel) || ROOT_GUIDANCE.test(trimmed)) return true;
+  if (/^(coding|skills|vbrief|packs)\//.test(rel) && !rel.startsWith("content/")) {
+    return true;
+  }
+  return false;
+}
+
+function currentTreeGhostHits(markdown: string): string[] {
+  const hits: string[] = [];
+  for (const fence of labeledCurrentTextFences(markdown)) {
+    for (const entry of extractTreeEntries(fence)) {
+      if (isBannedCurrentPath(entry.path)) {
+        hits.push(entry.path);
+      }
+    }
+  }
+  return hits;
+}
+
+let trackedFilesCache: Set<string> | null = null;
+
+function trackedFiles(): Set<string> {
+  if (trackedFilesCache) return trackedFilesCache;
+  const out = execFileSync("git", ["ls-files", "-z"], {
+    cwd: repoRoot(),
+    encoding: "utf8",
+  });
+  trackedFilesCache = new Set(out.split("\0").filter((p) => p.length > 0));
+  return trackedFilesCache;
+}
+
+function existsInTreeUnderTest(rel: string): boolean {
+  const root = repoRoot();
+  const abs = join(root, rel.replace(/\/$/, ""));
+  if (existsSync(abs)) return true;
+  const files = trackedFiles();
+  const exact = rel.replace(/\/$/, "");
+  if (files.has(exact) || files.has(rel)) return true;
+  const prefix = exact === "" ? "" : `${exact}/`;
+  if (prefix === "") return true;
+  for (const file of files) {
+    if (file.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function contentSkillNames(): string[] {
+  const dir = join(repoRoot(), "content/skills");
+  return readdirSync(dir)
+    .filter((name) => {
+      const abs = join(dir, name);
+      return statSync(abs).isDirectory() && name.startsWith("deft-directive-");
+    })
+    .sort();
+}
+
+describe("docs orientation current-tense (#4087 Wave 1b FILES.md) — FAIL-CLOSED", () => {
+  it("unlabeled run.py in a labeled-current FILES.md fence is a hit", () => {
+    const sample = ["## Top Level", "", "```text", "run.py", "```", ""].join("\n");
+    expect(currentTreeGhostHits(sample)).toContain("run.py");
+  });
+
+  it("historical-labeled run.py fence is not a hit", () => {
+    const sample = [
+      "## Historical Python/run era",
+      "",
+      "```text",
+      "run.py",
+      "run.bat",
+      "```",
+      "",
+    ].join("\n");
+    expect(currentTreeGhostHits(sample)).toEqual([]);
+  });
+
+  it("unlabeled root coding/ in a labeled-current fence is a hit", () => {
+    const sample = ["## Framework Guidance", "", "```text", "coding/", "```", ""].join("\n");
+    expect(currentTreeGhostHits(sample)).toContain("coding/");
+  });
+
+  it("content/coding/ in a labeled-current fence is not a ghost", () => {
+    const sample = ["## Framework Guidance", "", "```text", "content/coding/", "```", ""].join(
+      "\n",
+    );
+    expect(currentTreeGhostHits(sample)).toEqual([]);
+  });
+
+  it("FILES.md exists", () => {
+    expect(readText(FILES_MD).length).toBeGreaterThan(0);
+  });
+
+  it("labeled-current FILES.md does not name retired Python launchers", () => {
+    expect(retiredLauncherHits(readText(FILES_MD), FILES_MD)).toEqual([]);
+  });
+
+  it("labeled-current FILES.md trees do not list Python/run-era or root-guidance ghosts", () => {
+    expect(currentTreeGhostHits(readText(FILES_MD))).toEqual([]);
+  });
+
+  it("labeled-current FILES.md does not name tasks/release.yml", () => {
+    const current = labeledCurrentLines(readText(FILES_MD))
+      .map((row) => row.line)
+      .join("\n");
+    expect(current).not.toMatch(/tasks\/release\.yml/);
+  });
+
+  it("FILES.md states the path-class axis", () => {
+    const files = readText(FILES_MD);
+    expect(files).toMatch(/repo-tracked/);
+    expect(files).toMatch(/generated-on-demand/);
+    expect(files).toMatch(/consumer-install/);
+    expect(files).toMatch(/illustrative/);
+  });
+
+  it("repo-tracked paths in labeled-current FILES.md fences exist in the tree under test", () => {
+    const missing: string[] = [];
+    for (const fence of labeledCurrentTextFences(readText(FILES_MD))) {
+      for (const entry of extractTreeEntries(fence)) {
+        if (entry.pathClass !== "repo-tracked") continue;
+        if (!existsInTreeUnderTest(entry.path)) missing.push(entry.path);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("MAP.md, .deft/core/, and USER.md are classified, not implied repo-tracked", () => {
+    const files = readText(FILES_MD);
+    expect(files).toMatch(/MAP\.md[^\n]*generated-on-demand/i);
+    expect(files).toMatch(/\.deft\/core\/[^\n]*consumer-install/i);
+    expect(files).toMatch(/USER\.md[^\n]*consumer-install/i);
+  });
+
+  it("labeled-current skills census names every content/skills directory", () => {
+    const current = labeledCurrentLines(readText(FILES_MD))
+      .map((row) => row.line)
+      .join("\n");
+    const missing = contentSkillNames().filter(
+      (name) => !current.includes(`content/skills/${name}/`),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("labeled-current consumer artifacts use xbrief/ not vbrief/ as live write paths", () => {
+    const files = readText(FILES_MD);
+    const start = files.indexOf("## Consumer Project Artifacts");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const rest = files.slice(start);
+    const next = rest.slice(2).search(/\n## /);
+    const section = next >= 0 ? rest.slice(0, next + 2) : rest;
+    const current = labeledCurrentLines(section)
+      .map((row) => row.line)
+      .join("\n");
+    expect(current).toMatch(/xbrief\//);
+    expect(current).not.toMatch(/vbrief\//);
+    expect(current).not.toMatch(/skills\/deft-directive-/);
+  });
+
+  it("FILES.md does not present .planning/codebase STACK/CONVENTIONS as current authority", () => {
+    const files = readText(FILES_MD);
+    expect(files).toMatch(/STACK\.md[^\n]*residual/i);
+    expect(files).toMatch(/CONVENTIONS\.md[^\n]*residual/i);
+    expect(files).toMatch(/not current architecture authority/i);
+  });
+
+  it("covered orientation files including FILES.md exist", () => {
+    for (const rel of COVERED_ALL) {
+      expect(readText(rel).length).toBeGreaterThan(0);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary

Reconcile labeled-current `docs/FILES.md` trees to the TypeScript checkout after Wave 1a landed ARCHITECTURE/CONCEPTS.

- Guidance and skills live under `content/`; lifecycle state is `xbrief/`.
- Path classes: repo-tracked, generated-on-demand (MAP), consumer-install, illustrative.
- Skills census includes current `content/skills/` names.
- Fail-closed content-contract over labeled-current FILES.md fences (same family as Wave 1a).
- Does not generate FILES.md, reimplement C3, touch README, or author package topology.

Tracking: #4087
Refs #4085, #4088, #4132

## Test plan

- [x] `pnpm exec vitest run packages/core/src/content-contracts/docs-orientation-current.test.ts`
- [x] `task verify:encoding`
- [x] `task verify:ac -- xbrief/active/2026-09-02-4087-docsarchitecture-rebuild-architecture-concepts-and-file-maps.xbrief.json`
- [x] `task check`
