### PR TITLE
docs(architecture): publish four-package npm topology (#4093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **ARCHITECTURE publishes the four-package npm topology (#4093).** Manifest edges and the npm-publish.yml sequence are separate facts. TypeScript `directive init`/`update` is the happy-path deposit; frozen Go is a networked GitHub-release bridge, not bundled and not deleted. Does not prejudge #1979. Closes #4093. Refs #4085, #1912.
 - **Frozen two-hop migration runs `deft migrate:xbrief` as hop 2 (#4092).** UPGRADING no longer puts the unrelated `deft migrate` provenance stamp in that slot. Already-current xBRIEF 0.8 projects are told not to pin v0.59.0. Historical From-X-to-Y lists stay history. Closes #4092. Refs #4085, #2068, #2297.
 - **Consumer install copy keeps a Node 20+ floor separate from the maintainer Node 24 pin (#4089).** README and the public install pages no longer cite `.nvmrc` or send npm consumers through Corepack, Python, uv, Go, or `task toolchain:check`. Consumer confirmation is `directive toolchain:check --consumer`. CLI/doctor remedies stay on the consumer floor. CONTRIBUTING names Node 24 and pnpm for this repository. Does not add `engines` to `@deftai/directive`. Closes #4089. Refs #4085, #3610.
 - **Orientation file map matches the current checkout (#4087).** Labeled-current directory trees no longer teach deleted Python launchers or root guidance paths. Skills and consumer state use `content/skills/` and `xbrief/`. A fail-closed content-contract pin covers those trees. Partial of #4087. Refs #4085.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Deft Directive is a self-dogfooded framework for AI-assisted software work. It i
 - Taskfile as the repository command facade (`task --list`, `task check`, `task verify:*`).
 - `deft` / `directive` as the installed consumer CLI.
 - `deft-hook` and native CLI verbs as host and Git-hook entrypoints.
-- npm packages (`@deftai/directive` + `@deftai/directive-content`) with TS-native `directive init` / `directive update` resolve-and-copy deposit into gitignored `.deft/core/`, plus a frozen Go binary retained only as a legacy layout bridge and node-independent health gate. Canonical published package graph and install topology are owned by [#4093](https://github.com/deftai/directive/issues/4093); this document does not author that graph and must not be read as prejudging [#1979](https://github.com/deftai/directive/issues/1979).
+- Four published npm packages (`@deftai/directive-types`, `@deftai/directive-core`, `@deftai/directive-content`, `@deftai/directive`). TypeScript `directive init` / `directive update` is the happy-path consumer materialization into gitignored `.deft/core/`. A frozen Go installer remains a bounded networked-deposit bridge (not the happy path, not deleted). Package graph, publish sequence, and install topology are in [npm-Native Distribution](#npm-native-distribution-current). This document does not prejudge [#1979](https://github.com/deftai/directive/issues/1979).
 - xBRIEF files as durable project, specification, lifecycle, policy, and architecture metadata.
 - Local cache/audit surfaces for backlog triage and GitHub issue ingestion.
 - PR, release, swarm, branch-policy, and verification gates.
@@ -52,7 +52,7 @@ The loop is deliberate. Guidance tells agents how to behave, tasks make that beh
 - `~/.config/deft/USER.md` stores personal preferences, with its Personal section taking precedence for user-defined preferences.
 - `xbrief/PROJECT-DEFINITION.xbrief.json` stores project identity, policy, lifecycle registry, and authored architecture metadata.
 
-Consumer installs point agents at `.deft/core/main.md`. The canonical path is `npm i -g @deftai/directive` followed by `directive init` (greenfield) or `directive update` (refresh) — both resolve the locally installed `@deftai/directive-content` package and copy it into gitignored `.deft/core/`. Legacy Go-installer and git-clone layouts are migration inputs, not the preferred target state.
+Consumer installs point agents at `.deft/core/main.md`. TypeScript `directive init` (greenfield) or `directive update` (refresh) is the happy-path materialization: both resolve the locally installed `@deftai/directive-content` package and copy it into gitignored `.deft/core/`. Global and project-local npm installs are both current; install commands live in [README.md](../README.md). Legacy Go-installer and git-clone layouts are migration inputs, not the preferred target state.
 
 ## Rule Authority
 
@@ -98,7 +98,7 @@ flowchart LR
 | Framework content | `AGENTS.md`, `main.md`, `content/`, `docs/` | Agent guidance, skills, standards, and documentation. Shipped guidance lives under `content/`; `docs/` is repo-dev orientation. |
 | Task runner | `Taskfile.yml`, `tasks/*.yml` | Repository command facade: deterministic command contract and composable namespaces. |
 | TypeScript packages | `packages/`, `package.json`, `pnpm-workspace.yaml`, `tsconfig*.json`, `vitest.config.ts` | Implementation and runtime owner for gates, the `deft` / `directive` CLI, and `deft-hook`. |
-| Go installer (legacy bridge) | `cmd/deft-install/`, `go.mod` | Frozen cross-platform tarball deposit for offline/air-gapped and legacy layout migration; superseded by TS-native `directive init` / `directive update` for normal installs (#1942). |
+| Go installer (frozen bridge) | `cmd/deft-install/`, `go.mod` | Frozen GitHub-release binary: `deft-install gate`, legacy-layout reshape for inputs TypeScript init/update refuse, and networked tarball deposit. Not the happy-path consumer path. Not bundled in the npm package. Not deleted. [#1979](https://github.com/deftai/directive/issues/1979) is open. |
 | xBRIEF metadata | `xbrief/**/*.json`, `xbrief/**/*.md` | Project identity, scope lifecycle, schemas, policy, specification source, and authored `codeStructure`. |
 | Content packs | `content/packs/` | Curated agent memory packs rendered and checked through `task packs:*`. |
 | CI/release automation | `.github/`, `.githooks/`, `tasks/pr.yml` | Branch policy, PR readiness, release, publish, rollback, and local hook enforcement. |
@@ -108,29 +108,76 @@ flowchart LR
 
 ## npm-Native Distribution (current)
 
-Canonical published package graph, init/update ownership, and Go disposition are owned by [#4093](https://github.com/deftai/directive/issues/4093) and must not prejudge [#1979](https://github.com/deftai/directive/issues/1979). The sketch below is orientation, not the topology source of truth.
+This section is the canonical package and installation topology. Two labeled facts stay separate: **workspace dependency edges** come from `packages/*/package.json`; **publish sequence** comes from `.github/workflows/npm-publish.yml` and is an ordered list, not those edges. The sequence is not a topological sort of the workspace graph (core publishes before content, which it depends on). This document records the observed sequence; it does not change the workflow. Install commands live in [README.md](../README.md) (#1912). This topology does not prejudge [#1979](https://github.com/deftai/directive/issues/1979). Node run requirements for consumers versus maintainers are not this topology.
 
-Distribution splits into two npm packages and a thin local materialization step. Shipped in Wave 5 ([#1669](https://github.com/deftai/directive/issues/1669), [#1942](https://github.com/deftai/directive/issues/1942)); the frozen Go binary role is further constrained by [#1933](https://github.com/deftai/directive/issues/1933) and [#1912](https://github.com/deftai/directive/issues/1912).
+The repository publishes four npm packages. `@deftai/directive-types` is the supported public contract. `@deftai/directive-core` is published for npm dependency resolution but is not a supported library. `@deftai/directive-content` is the deposit payload. `@deftai/directive` is the consumer CLI (`directive`, `deft`).
 
-- **`@deftai/directive`** — the engine/CLI (Node 20+ required to *run* Deft). Binaries: `directive`, `deft`.
-- **`@deftai/directive-content`** — the framework content (skills, templates, schemas, standards) shipped from the repo `content/` tree via the content package prepack. It is a **dependency** of the engine, so npm resolves a version-coherent pair at install time.
+### Published workspace (manifest edges)
+
+| Package | Role | Support | Workspace dependencies |
+| --- | --- | --- | --- |
+| `@deftai/directive-types` | public contract | supported | (none) |
+| `@deftai/directive-content` | deposit payload | supported install material | (none) |
+| `@deftai/directive-core` | engine library | published, not a supported library | `@deftai/directive-types`, `@deftai/directive-content` |
+| `@deftai/directive` | consumer CLI | supported | `@deftai/directive-core`, `@deftai/directive-content` |
+
+Workspace dependency edges (from `packages/*/package.json`):
+
+- `@deftai/directive-types` -> `@deftai/directive-core`
+- `@deftai/directive-content` -> `@deftai/directive-core`
+- `@deftai/directive-content` -> `@deftai/directive`
+- `@deftai/directive-core` -> `@deftai/directive`
 
 ```mermaid
 flowchart LR
-    npm["npm i -g @deftai/directive"] --> Global["Global npm tree<br/>node_modules/@deftai/directive + @deftai/directive-content"]
-    Global -->|"directive init / update<br/>resolve-and-copy (no re-download)"| Proj["Project ./.deft/core/<br/>+ AGENTS.md, xbrief/, .githooks/"]
-    Global --> Gate["Frozen Go gate (bundled)<br/>node-independent pre-engine health probe"]
-    Gate -->|"health probe / legacy layout reshape"| Proj
+    Types["@deftai/directive-types"]
+    Content["@deftai/directive-content"]
+    Core["@deftai/directive-core"]
+    Cli["@deftai/directive"]
+    Types --> Core
+    Content --> Core
+    Content --> Cli
+    Core --> Cli
 ```
 
-Key properties of the current model:
+### Observed publish sequence
 
-- **Global install ≠ project deposit.** `npm i -g` only places versioned files in the global npm tree; it never touches a project directory. `directive init` is the materialization step that **resolves the locally-installed `@deftai/directive-content` and copies its tree** into this project's `./.deft/core/`, then renders `AGENTS.md`, scaffolds `xbrief/`, wires `.githooks/` when present in the content tree, deposits #1430 neutralization, and stamps provenance. `directive update` refreshes the same way. This is **resolve-and-copy, not re-download** — the on-machine content package is the source (the `node_modules` model).
+Observed publish sequence from `.github/workflows/npm-publish.yml` (ordered list, not dependency order, not a topological sort of the workspace graph):
+
+1. `@deftai/directive-types`
+2. `@deftai/directive-core`
+3. `@deftai/directive-content`
+4. `@deftai/directive`
+
+### Consumer install and deposit path
+
+TypeScript `directive init` / `directive update` is the happy-path consumer materialization. After `@deftai/directive` is installed (global or project-local; commands in README), those verbs resolve the locally installed `@deftai/directive-content` package and copy it into gitignored `./.deft/core/`. Types and core are transitive. Core is not a supported library. This is resolve-and-copy, not a re-download.
+
+```mermaid
+flowchart LR
+    Install["Install @deftai/directive<br/>global or project-local"] --> Tree["npm tree<br/>CLI + content; types and core transitive"]
+    Tree -->|"directive init / update<br/>resolve-and-copy"| Deposit["Project ./.deft/core/"]
+```
+
+Key properties:
+
+- **Global install ≠ project deposit.** Installing the CLI only places versioned files in the npm tree. `directive init` materializes `./.deft/core/`, then renders `AGENTS.md`, scaffolds `xbrief/`, wires `.githooks/` when present, deposits #1430 neutralization, and stamps provenance. `directive update` refreshes the same way.
 - **`.deft/core/` is gitignored** on greenfield installs and is reconstituted by `directive init` on fresh checkouts (like `node_modules`). Existing tracked deposits are migrated to hybrid by [#1941](https://github.com/deftai/directive/issues/1941).
 - **Per-project version pinning** via `devDependencies` + `npx` gives teams/CI a reproducible engine↔content pair.
-- **Frozen Go binary** stays bundled per-platform inside the npm package, but only as a **node-independent, read-only health gate** (every-session pre-engine probe) and a **legacy on-disk-layout reshaper**. It no longer fetches payloads or performs first-start installs (#1933).
-- **Offline** = sideload both package tarballs, then `directive init` copies locally — no network in the happy path.
-- **No surface bakes an install/upgrade command.** The engine, the Go gate, and `deft doctor` all point to the canonical install anchor in `README.md` rather than emitting a command that can go stale (#1912).
+- **Sideload** of the npm package tarballs still works: `directive init` copies locally with no extra network in that happy path.
+- **No surface bakes an install/upgrade command.** The engine, the frozen Go bridge, and `deft doctor` point at README rather than emitting a command that can go stale (#1912).
+
+### Frozen Go bridge
+
+The frozen Go binary is a **separate GitHub release asset**, not a file inside the `@deftai/directive` npm tarball. It is a bounded networked-deposit bridge, not the happy path, and not deleted. It is not an offline capability: deposit still fetches a release tarball. [#1979](https://github.com/deftai/directive/issues/1979) (whether to delete the Go source and build matrix) stays open.
+
+Current Go jobs:
+
+1. `deft-install gate` — node-independent health probe.
+2. Legacy-layout stage-1 reshape for on-disk layouts that TypeScript `directive init` / `directive update` refuse.
+3. Networked tarball deposit/migration — retained on the binary, not the happy-path consumer update.
+
+Shipped in Wave 5 ([#1669](https://github.com/deftai/directive/issues/1669), [#1942](https://github.com/deftai/directive/issues/1942)); freeze constraints: [#1933](https://github.com/deftai/directive/issues/1933), [#1912](https://github.com/deftai/directive/issues/1912).
 
 ## Command Surface
 

--- a/packages/core/src/content-contracts/architecture-package-topology.test.ts
+++ b/packages/core/src/content-contracts/architecture-package-topology.test.ts
@@ -1,0 +1,234 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./standards/_helpers.js";
+
+/**
+ * #4093 — package/install topology projection in docs/ARCHITECTURE.md.
+ *
+ * Authority: package.json files under packages/ owns membership and workspace edges;
+ * `.github/workflows/npm-publish.yml` owns the observed publish sequence
+ * (an ordered list, not those edges). The architecture page is a checked
+ * projection. Do not treat the document as authority over manifests.
+ *
+ * New file: do not edit docs-orientation-current.test.ts (#4087).
+ */
+
+type WorkspacePkg = {
+  dir: string;
+  name: string;
+  deps: string[];
+};
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, { encoding: "utf8" })) as Record<string, unknown>;
+}
+
+export function readWorkspacePackages(root: string): WorkspacePkg[] {
+  const packagesDir = join(root, "packages");
+  const dirs = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+  const pkgs: WorkspacePkg[] = [];
+  for (const dir of dirs) {
+    const pkgPath = join(packagesDir, dir, "package.json");
+    if (!existsSync(pkgPath)) continue;
+    const pkg = readJson(pkgPath);
+    if (pkg.private === true) continue;
+    const name = pkg.name;
+    if (typeof name !== "string" || !name.startsWith("@deftai/")) {
+      throw new Error(`packages/${dir}/package.json missing public @deftai name`);
+    }
+    const rawDeps = pkg.dependencies;
+    const depNames =
+      rawDeps && typeof rawDeps === "object" && !Array.isArray(rawDeps)
+        ? Object.keys(rawDeps as Record<string, unknown>)
+        : [];
+    pkgs.push({ dir, name, deps: depNames.sort() });
+  }
+  return pkgs;
+}
+
+export function workspaceEdges(pkgs: WorkspacePkg[]): Array<[string, string]> {
+  const names = new Set(pkgs.map((p) => p.name));
+  const edges: Array<[string, string]> = [];
+  for (const pkg of pkgs) {
+    for (const dep of pkg.deps) {
+      if (names.has(dep)) edges.push([dep, pkg.name]);
+    }
+  }
+  return edges.sort((a, b) => `${a[0]}>${a[1]}`.localeCompare(`${b[0]}>${b[1]}`));
+}
+
+export function parsePublishSteps(yml: string): Array<{ name: string; dir: string }> {
+  const steps: Array<{ name: string; dir: string }> = [];
+  const parts = yml.split(/^[ \t]*- name: Publish /m);
+  for (const part of parts.slice(1)) {
+    const name = /^(@deftai\/[A-Za-z0-9-]+)/.exec(part)?.[1];
+    const dir = /working-directory:\s*packages\/([A-Za-z0-9_-]+)/.exec(part)?.[1];
+    if (name && dir) steps.push({ name, dir });
+  }
+  return steps;
+}
+
+export function namesMissingFromProjection(markdown: string, names: string[]): string[] {
+  return names.filter((n) => !markdown.includes(n));
+}
+
+export function parseDocumentedEdges(markdown: string): Array<[string, string]> {
+  const blockStart = markdown.indexOf("Workspace dependency edges");
+  if (blockStart < 0) return [];
+  const blockEnd = markdown.indexOf("```mermaid", blockStart);
+  const block = markdown.slice(blockStart, blockEnd < 0 ? undefined : blockEnd);
+  const edges: Array<[string, string]> = [];
+  const re = /`(@deftai\/[^`]+)` -> `(@deftai\/[^`]+)`/g;
+  for (const m of block.matchAll(re)) {
+    const from = m[1];
+    const to = m[2];
+    if (from && to) edges.push([from, to]);
+  }
+  return edges.sort((a, b) => `${a[0]}>${a[1]}`.localeCompare(`${b[0]}>${b[1]}`));
+}
+
+export function parseDocumentedPublishSequence(markdown: string): string[] {
+  const heading = markdown.indexOf("### Observed publish sequence");
+  if (heading < 0) return [];
+  const nextHeading = markdown.indexOf("\n### ", heading + 1);
+  const block = markdown.slice(heading, nextHeading < 0 ? undefined : nextHeading);
+  const names: string[] = [];
+  const re = /^\d+\.\s+`(@deftai\/[^`]+)`/gm;
+  for (const m of block.matchAll(re)) {
+    if (m[1]) names.push(m[1]);
+  }
+  return names;
+}
+
+function architecture(): string {
+  return readFileSync(join(repoRoot(), "docs/ARCHITECTURE.md"), { encoding: "utf8" }).replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function workflowYml(): string {
+  return readFileSync(join(repoRoot(), ".github/workflows/npm-publish.yml"), {
+    encoding: "utf8",
+  }).replace(/\r\n/g, "\n");
+}
+
+describe("architecture package topology (#4093)", () => {
+  it("publish-step parser reads working-directory order from workflow YAML", () => {
+    const yml = [
+      "- name: Publish @deftai/directive-types",
+      "  working-directory: packages/types",
+      "  shell: bash",
+      "- name: Publish @deftai/directive-core",
+      "  extra: ignored",
+      "  working-directory: packages/core",
+    ].join("\n");
+    expect(parsePublishSteps(yml)).toEqual([
+      { name: "@deftai/directive-types", dir: "types" },
+      { name: "@deftai/directive-core", dir: "core" },
+    ]);
+  });
+
+  it("projection helpers detect a missing package and a dropped edge", () => {
+    const names = ["@deftai/directive-types", "@deftai/directive-core"];
+    expect(namesMissingFromProjection("only @deftai/directive-core", names)).toEqual([
+      "@deftai/directive-types",
+    ]);
+    const edges = parseDocumentedEdges(
+      [
+        "Workspace dependency edges (from package.json):",
+        "",
+        "- `@deftai/directive-types` -> `@deftai/directive-core`",
+        "",
+        "```mermaid",
+      ].join("\n"),
+    );
+    expect(edges).toEqual([["@deftai/directive-types", "@deftai/directive-core"]]);
+  });
+
+  it("workspace manifests are the four public @deftai packages", () => {
+    const pkgs = readWorkspacePackages(repoRoot());
+    expect(pkgs.map((p) => p.name).sort()).toEqual(
+      [
+        "@deftai/directive",
+        "@deftai/directive-content",
+        "@deftai/directive-core",
+        "@deftai/directive-types",
+      ].sort(),
+    );
+  });
+
+  it("ARCHITECTURE names every published package and is not a two-package current graph", () => {
+    const arch = architecture();
+    const pkgs = readWorkspacePackages(repoRoot());
+    expect(
+      namesMissingFromProjection(
+        arch,
+        pkgs.map((p) => p.name),
+      ),
+    ).toEqual([]);
+    expect(arch).not.toMatch(/two npm packages/i);
+    expect(arch).toMatch(/four published/i);
+  });
+
+  it("ARCHITECTURE workspace edges match packages/*/package.json (edge ≠ publish order)", () => {
+    const pkgs = readWorkspacePackages(repoRoot());
+    const expected = workspaceEdges(pkgs);
+    const documented = parseDocumentedEdges(architecture());
+    expect(documented).toEqual(expected);
+    expect(expected).toEqual([
+      ["@deftai/directive-content", "@deftai/directive"],
+      ["@deftai/directive-content", "@deftai/directive-core"],
+      ["@deftai/directive-core", "@deftai/directive"],
+      ["@deftai/directive-types", "@deftai/directive-core"],
+    ]);
+  });
+
+  it("ARCHITECTURE publish sequence matches npm-publish.yml order, labeled as observed not topological", () => {
+    const pkgs = readWorkspacePackages(repoRoot());
+    const byDir = new Map(pkgs.map((p) => [p.dir, p.name]));
+    const steps = parsePublishSteps(workflowYml());
+    expect(steps.map((s) => s.dir)).toEqual(["types", "core", "content", "cli"]);
+    const fromWorkflow = steps.map((s) => {
+      const name = byDir.get(s.dir);
+      if (!name) throw new Error(`publish step packages/${s.dir} is not a workspace package`);
+      if (name !== s.name) {
+        throw new Error(`publish step ${s.name} != package.json name ${name}`);
+      }
+      return name;
+    });
+    expect(parseDocumentedPublishSequence(architecture())).toEqual(fromWorkflow);
+    expect(architecture()).toMatch(/not a topological sort/i);
+    expect(architecture()).toMatch(/not dependency order/i);
+  });
+
+  it("TypeScript init/update is the happy-path materialization; core is not a supported library", () => {
+    const arch = architecture();
+    expect(arch).toMatch(/directive init/);
+    expect(arch).toMatch(/directive update/);
+    expect(arch).toMatch(/happy-path consumer materialization/i);
+    expect(arch).toMatch(/not a supported library/i);
+    expect(arch).toMatch(/supported public contract/i);
+  });
+
+  it("frozen Go is a networked GitHub-release bridge, not bundled, not deleted, not #1979", () => {
+    const arch = architecture();
+    expect(arch).toMatch(/frozen Go/i);
+    expect(arch).toMatch(/networked/i);
+    expect(arch).toMatch(/GitHub release asset/i);
+    expect(arch).toMatch(/deft-install gate/);
+    expect(arch).toMatch(/legacy-layout/i);
+    expect(arch).toMatch(/#1979/);
+    expect(arch).not.toMatch(/no longer fetches payloads/i);
+    expect(arch).not.toMatch(/bundled per-platform inside the npm package/i);
+    expect(arch).not.toMatch(/offline\/air-gapped/i);
+  });
+
+  it("ARCHITECTURE Node run-line does not cite .nvmrc as the consumer floor", () => {
+    expect(architecture()).not.toMatch(/\.nvmrc/);
+  });
+});

--- a/packages/core/src/content-contracts/architecture-package-topology.test.ts
+++ b/packages/core/src/content-contracts/architecture-package-topology.test.ts
@@ -91,6 +91,31 @@ export function parseDocumentedEdges(markdown: string): Array<[string, string]> 
   return edges.sort((a, b) => `${a[0]}>${a[1]}`.localeCompare(`${b[0]}>${b[1]}`));
 }
 
+export function parseMermaidWorkspaceEdges(markdown: string): Array<[string, string]> {
+  const blockStart = markdown.indexOf("Workspace dependency edges");
+  if (blockStart < 0) return [];
+  const fence = markdown.indexOf("```mermaid", blockStart);
+  if (fence < 0) return [];
+  const start = markdown.indexOf("\n", fence);
+  const end = markdown.indexOf("```", start + 1);
+  const body = markdown.slice(start < 0 ? fence : start, end < 0 ? undefined : end);
+  const idToName = new Map<string, string>();
+  const nodeRe = /([A-Za-z][A-Za-z0-9_]*)\["(@deftai\/[^"]+)"\]/g;
+  for (const m of body.matchAll(nodeRe)) {
+    const id = m[1];
+    const name = m[2];
+    if (id && name) idToName.set(id, name);
+  }
+  const edges: Array<[string, string]> = [];
+  const edgeRe = /^[ \t]*([A-Za-z][A-Za-z0-9_]*)\s*-->\s*([A-Za-z][A-Za-z0-9_]*)/gm;
+  for (const m of body.matchAll(edgeRe)) {
+    const from = idToName.get(m[1] ?? "");
+    const to = idToName.get(m[2] ?? "");
+    if (from && to) edges.push([from, to]);
+  }
+  return edges.sort((a, b) => `${a[0]}>${a[1]}`.localeCompare(`${b[0]}>${b[1]}`));
+}
+
 export function parseDocumentedPublishSequence(markdown: string): string[] {
   const heading = markdown.indexOf("### Observed publish sequence");
   if (heading < 0) return [];
@@ -148,6 +173,19 @@ describe("architecture package topology (#4093)", () => {
       ].join("\n"),
     );
     expect(edges).toEqual([["@deftai/directive-types", "@deftai/directive-core"]]);
+    const mermaid = parseMermaidWorkspaceEdges(
+      [
+        "Workspace dependency edges",
+        "",
+        "```mermaid",
+        "flowchart LR",
+        '    Types["@deftai/directive-types"]',
+        '    Core["@deftai/directive-core"]',
+        "    Types --> Core",
+        "```",
+      ].join("\n"),
+    );
+    expect(mermaid).toEqual([["@deftai/directive-types", "@deftai/directive-core"]]);
   });
 
   it("workspace manifests are the four public @deftai packages", () => {
@@ -180,6 +218,7 @@ describe("architecture package topology (#4093)", () => {
     const expected = workspaceEdges(pkgs);
     const documented = parseDocumentedEdges(architecture());
     expect(documented).toEqual(expected);
+    expect(parseMermaidWorkspaceEdges(architecture())).toEqual(expected);
     expect(expected).toEqual([
       ["@deftai/directive-content", "@deftai/directive"],
       ["@deftai/directive-content", "@deftai/directive-core"],


### PR DESCRIPTION
## Summary

Publish one accurate package and installation topology in docs/ARCHITECTURE.md.

- Four published packages from packages/*/package.json: @deftai/directive-types, @deftai/directive-core, @deftai/directive-content, @deftai/directive
- Workspace dependency edges and the npm-publish.yml sequence are labeled as separate facts (sequence is observed, not a topological sort)
- TypeScript directive init/update is the happy-path consumer materialization
- Frozen Go is a networked GitHub-release bridge, not bundled in npm, not deleted, not the happy path
- Does not prejudge #1979
- Node run-line does not cite .nvmrc as the consumer floor
- New content-contract test reads manifests and the publish workflow (does not edit docs-orientation-current.test.ts)

## Related Issues

Closes #4093
Refs #4085, #1912, #1979

## Checklist

- [x] `/deft:change <name>` — N/A (3 files; swarm-cohort remaining child of #4085)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally (topology + orientation content-contracts; isolated re-runs of suite files that timed out under swarm load)

## Post-Merge

- [ ] Verify issue auto-close for #4093 after squash
