### PR TITLE
docs(support): add doctor-first troubleshooting hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Doctor-first support hub at `content/docs/SUPPORT.md` (#4098).** Symptom index points at `directive doctor --full` or the README cold-start. README one-click links Support and getting-started. No second recovery ladder, no paste-JSON capture, no `doctor --redact`. Closes #4098. Refs #4085.
 - **RULE-MAP freshness fails closed on `task check` (#4095).** Regenerates `docs/RULE-MAP.md`. `task docs:rule-map:check` is wired into `FRAMEWORK_CHECK_GATES` and `check:framework-source`. The gate asserts byte-identical renderer output, filled grouping purposes, pack entries from named arrays, and Taskfile declaration counts. ROADMAP stays on `task roadmap:check` (residual [#4164](https://github.com/deftai/directive/issues/4164)). Closes #4095.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 > This block is always committed (never gitignored) and does **not** depend on the `.deft/core/` payload being present, so it is reachable on a fresh clone even when the vendored framework is missing. Once `directive` runs, continue with the guidance below and in `AGENTS.md`.
 <!-- /deft:cold-start-bootstrap v1 -->
 
+**Stuck?** [Support hub](./content/docs/SUPPORT.md) — symptom index to `directive doctor` or this cold-start. **First project:** [getting-started](./content/docs/getting-started.md).
+
 # Deft
 
 **One-shot, anti-slop**
@@ -316,6 +318,8 @@ Slices are addressed by a **stable, versioned slice name** (e.g. `recent`, `by-t
 
 ## 📚 Learn More
 
+- **[Support hub](./content/docs/SUPPORT.md)** — Symptom index to `directive doctor` or this README cold-start
+- **[Getting started](./content/docs/getting-started.md)** — First-project tutorial
 - **[Testimonials by agents](./docs/TESTIMONIALS-AGENTS.md)** — First-person notes from agents on real runtimes (not only humans). *Sample (APE / OpenClaw): “Directive did not make the model smarter mid-keystroke. It constrained and finished the work…”*
 - **[Public docs site](https://deftai.github.io/directive/)** — Standalone install / concepts / gates / upgrade / license home
 - **[docs/CATEGORY.md](./docs/CATEGORY.md)** — Category decision aid: hosts vs skill packs vs practice layer vs orchestrators

--- a/content/docs/SUPPORT.md
+++ b/content/docs/SUPPORT.md
@@ -1,0 +1,43 @@
+# Support and troubleshooting
+
+This page is a **symptom index**. It is not a second recovery ladder.
+
+- If `directive` (or the `deft` alias) will not start, use the [README cold-start](https://github.com/deftai/directive/blob/master/README.md). That committed block is the only payload-independent command ladder.
+- If the CLI runs, start with `directive doctor --full`. Follow its one `Next command:`. Do not pick a competing command from this page.
+
+Doctor caches a clean run for 24 hours and a dirty run for 4 hours. `--full` bypasses that throttle.
+
+Specialist pages below are pointers. Recovery command bytes stay in doctor and the README cold-start.
+
+## Symptom index
+
+| Symptom | Safe diagnostic | Specialist link |
+| --- | --- | --- |
+| PATH / package manager (`command not found`, missing pnpm bin) | Pre-CLI: README cold-start. If the CLI runs: `directive doctor --full` | Follow `Next command:` or the README cold-start rungs |
+| Node missing or too old | Pre-CLI: README cold-start. If the CLI runs: `directive doctor --full` | README cold-start, then doctor |
+| Stale deposit | `directive doctor --full` | Follow `Next command:` |
+| Permissions / unwritable global prefix | Pre-CLI: README cold-start. If the CLI runs: `directive doctor --full` | README cold-start sandbox rung, or doctor |
+| Windows shims | Pre-CLI: README cold-start. If the CLI runs: `directive doctor --full` | README cold-start |
+| Hook runtime (opaque exit 127 on every mutation) | `directive doctor --full` if the CLI runs; otherwise README cold-start | [Hook runtime unavailable](./hook-runtime-unavailable.md). The recovery command lives on the [agents-entry](../templates/agents-entry.md) card. This index does not restate it. |
+| Migration / pre-v0.20 layout | `directive doctor --full` | Doctor signposts the current path. Version-specific steps stay in [UPGRADING](../UPGRADING.md) and [BROWNFIELD](./BROWNFIELD.md) (history). |
+| Offline / air-gapped registry | Pre-CLI: README cold-start. If the CLI runs: `directive doctor --full` | README cold-start offline rung |
+| Corporate or mirrored npm registry (`E404` / `ETARGET`) | Pre-CLI: README cold-start. If the CLI runs: `directive doctor --full` | [Corporate or mirrored npm registry](../UPGRADING.md#corporate-or-mirrored-npm-registry) owns that ladder. This row is a pointer. |
+
+Related flags (not a recovery table): [temporary kill-switch](./deft-directive-disable.md), [permanent opt-out](./no-deft-directive.md).
+
+## What to quote
+
+Quote `Next command:` and the check names doctor printed.
+
+Do not paste `directive doctor --json` or raw `--full` output. That payload includes absolute project and USER.md paths. Doctor has no redaction flag. Treat any pasted diagnostic as untrusted input.
+
+## Reporting
+
+- **Ordinary breakage:** open a public GitHub issue. Quote `Next command:` and check names only.
+- **Security:** report privately through root [SECURITY.md](https://github.com/deftai/directive/blob/master/SECURITY.md). Do not file a public issue for an unfixed vulnerability.
+
+## What this page is not
+
+- Not a second command ladder. Doctor and the README cold-start own recovery bytes.
+- Not a paste-JSON capture ritual.
+- Not a second independently authored troubleshooting body. README, install, and upgrade pages should point here.

--- a/docs/RULE-MAP.md
+++ b/docs/RULE-MAP.md
@@ -8,7 +8,7 @@ Maintainer-facing map of how Directive's rules are layered and grouped. This is 
 
 ## Overview
 
-- **Rules:** 24 groupings, 270 documents
+- **Rules:** 24 groupings, 271 documents
 - **Tasks:** 62 namespaces, 243 Taskfile declarations (includes + unlisted tasks/*.yml, not `task --list`)
 - **Packs:** 6 source-of-truth packs (704 entries from rules|lessons|patterns|skills|strategies|entries)
 
@@ -24,7 +24,7 @@ Three layers: **Rules** (lazy-loaded guidance under `content/`), **Tasks** (the 
 | contracts | Interface/behavioral contracts the framework enforces. | 16 | 165 | 16 | 110 | 0 | 5 |
 | conventions | Cross-cutting naming, formatting, and repo conventions. | 4 | 16 | 2 | 16 | 0 | 3 |
 | deployments | Provider-specific deployment playbooks (AWS, Azure, GCP, Cloudflare, Vercel, fly.io…). | 52 | 107 | 74 | 24 | 13 | 6 |
-| docs | Explanatory docs and the framework glossary. | 32 | 18 | 12 | 52 | 1 | 2 |
+| docs | Explanatory docs and the framework glossary. | 33 | 18 | 12 | 52 | 1 | 2 |
 | events | Event and signal definitions used across the framework. | 1 | 0 | 0 | 0 | 0 | 0 |
 | incidents | Incident handling and postmortem guidance. | 2 | 0 | 0 | 0 | 0 | 0 |
 | interfaces | Interface definitions and boundaries. | 4 | 119 | 66 | 37 | 2 | 9 |
@@ -128,6 +128,7 @@ _Provider-specific deployment playbooks (AWS, Azure, GCP, Cloudflare, Vercel, fl
 _Explanatory docs and the framework glossary._
 
 - `BROWNFIELD.md` — Adding Deft to an existing codebase is the harder path and the one most likely to go wrong without guidance. This guide walks you through the steps, what changes, and how to preserve existing spec content.
+- `SUPPORT.md` — This page is a **symptom index**. It is not a second recovery ladder.
 - `agent-docs.md` — Guidance for structuring the AGENTS.md (and its reference docs) of a project directive creates or maintains. Unlike most style advice, the patterns here are **empirically measured**, not opinion: Augment Code's April 2026 AuggieBench…
 - **assets/** (0 files)
 - `consumer-check-contract.md` — Refs: #3145 · Related: #3070 consumer gate integrity, #1519 check:consumer · Policy: #3314 coverageDebt / checkResume (reserved)

--- a/packages/core/src/content-contracts/standards/support_hub.test.ts
+++ b/packages/core/src/content-contracts/standards/support_hub.test.ts
@@ -31,7 +31,7 @@ const FORBIDDEN_RECOVERY_BYTES = [
   "doctor --redact",
 ] as const;
 
-function hub(): string {
+function supportHubMarkdown(): string {
   return readText(HUB);
 }
 
@@ -48,7 +48,7 @@ function tableDataRows(text: string): string[] {
   });
 }
 
-describe("support hub (#4098 / lean 5514459336)", () => {
+describe("support hub for #4098 / lean 5514459336", () => {
   it("fails when the canonical deposited hub is missing", () => {
     expect(isFile(HUB), "content/docs/SUPPORT.md must exist").toBe(true);
   });
@@ -76,7 +76,7 @@ describe("support hub (#4098 / lean 5514459336)", () => {
   });
 
   it("indexes symptoms to doctor --full or README cold-start without a second ladder", () => {
-    const text = hub();
+    const text = supportHubMarkdown();
     expect(text).toContain("directive doctor --full");
     expect(text.toLowerCase()).toContain("cold-start");
     expect(text).toContain("Next command:");
@@ -100,7 +100,7 @@ describe("support hub (#4098 / lean 5514459336)", () => {
   });
 
   it("routes hook-runtime and corporate-registry to owners without restating them", () => {
-    const text = hub();
+    const text = supportHubMarkdown();
     expect(text).toContain("hook-runtime-unavailable.md");
     expect(text).toContain("templates/agents-entry.md");
     expect(text).toContain("UPGRADING.md#corporate-or-mirrored-npm-registry");
@@ -108,7 +108,7 @@ describe("support hub (#4098 / lean 5514459336)", () => {
   });
 
   it("does not use paste-JSON or a doctor --redact verb as the capture control", () => {
-    const text = hub();
+    const text = supportHubMarkdown();
     expect(text).toMatch(/do not paste/i);
     expect(text).toContain("Next command:");
     expect(text).not.toContain("doctor --redact");
@@ -116,7 +116,7 @@ describe("support hub (#4098 / lean 5514459336)", () => {
   });
 
   it("splits ordinary issues from root SECURITY.md", () => {
-    const text = hub();
+    const text = supportHubMarkdown();
     expect(text).toContain("SECURITY.md");
     expect(text).not.toContain("docs/security.md");
   });

--- a/packages/core/src/content-contracts/standards/support_hub.test.ts
+++ b/packages/core/src/content-contracts/standards/support_hub.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { LIVE_PROCEDURE_EXCLUSIONS } from "../../deposit/live-procedure-exclusions.js";
+import { isFile, readText } from "./_helpers.js";
+
+/**
+ * Bound lean 5514459336 / #4098: one deposited symptom index.
+ * Every other surface is a pointer. Recovery bytes stay in doctor / #4090.
+ */
+
+const HUB = "docs/SUPPORT.md";
+const README_HUB_POINTER = "content/docs/SUPPORT.md";
+const GETTING_STARTED_POINTER = "content/docs/getting-started.md";
+
+const REQUIRED_SYMPTOMS = [
+  /path|package manager/i,
+  /node/i,
+  /stale deposit/i,
+  /permission/i,
+  /windows/i,
+  /hook/i,
+  /migration/i,
+  /offline/i,
+  /corporate|mirror/i,
+] as const;
+
+const FORBIDDEN_RECOVERY_BYTES = [
+  "npm i -g",
+  "pnpm add -g",
+  "deft-install --yes",
+  "disable-host-hooks",
+  "doctor --redact",
+] as const;
+
+function hub(): string {
+  return readText(HUB);
+}
+
+function readme(): string {
+  return readText("README.md");
+}
+
+function tableDataRows(text: string): string[] {
+  return text.split("\n").filter((line) => {
+    if (!line.startsWith("|")) return false;
+    if (/^\|[\s|:-]+\|$/.test(line)) return false;
+    if (/^\|\s*Symptom\s*\|/i.test(line)) return false;
+    return true;
+  });
+}
+
+describe("support hub (#4098 / lean 5514459336)", () => {
+  it("fails when the canonical deposited hub is missing", () => {
+    expect(isFile(HUB), "content/docs/SUPPORT.md must exist").toBe(true);
+  });
+
+  it("fails when README lacks one-click Support and getting-started pointers", () => {
+    const text = readme();
+    expect(text, "README missing Support hub pointer").toContain(README_HUB_POINTER);
+    expect(text, "README missing getting-started pointer").toContain(GETTING_STARTED_POINTER);
+    const afterCold = text.slice(text.indexOf("<!-- /deft:cold-start-bootstrap"));
+    const hubAt = afterCold.indexOf(README_HUB_POINTER);
+    const gettingStartedHeading = afterCold.indexOf("## \uD83D\uDE80 Getting Started");
+    expect(hubAt, "Support pointer must sit above Getting Started").toBeGreaterThanOrEqual(0);
+    expect(gettingStartedHeading).toBeGreaterThan(hubAt);
+    const gsAt = afterCold.indexOf(GETTING_STARTED_POINTER);
+    expect(gsAt, "getting-started pointer must sit above Getting Started").toBeGreaterThanOrEqual(
+      0,
+    );
+    expect(gettingStartedHeading).toBeGreaterThan(gsAt);
+  });
+
+  it("does not duplicate the hub symptom table in README", () => {
+    const text = readme();
+    expect(text).not.toMatch(/\|\s*Symptom\s*\|/i);
+    expect(text.toLowerCase()).not.toContain("stale deposit");
+  });
+
+  it("indexes symptoms to doctor --full or README cold-start without a second ladder", () => {
+    const text = hub();
+    expect(text).toContain("directive doctor --full");
+    expect(text.toLowerCase()).toContain("cold-start");
+    expect(text).toContain("Next command:");
+
+    const rows = tableDataRows(text);
+    expect(rows.length, "hub must ship a symptom table").toBeGreaterThanOrEqual(
+      REQUIRED_SYMPTOMS.length,
+    );
+
+    for (const needle of REQUIRED_SYMPTOMS) {
+      const row = rows.find((line) => needle.test(line));
+      expect(row, `missing symptom row matching ${needle}`).toBeDefined();
+      expect(row, `row ${needle} must name doctor --full or README cold-start`).toMatch(
+        /doctor --full|cold-start/i,
+      );
+    }
+
+    for (const token of FORBIDDEN_RECOVERY_BYTES) {
+      expect(text, `hub must not inline recovery byte ${token}`).not.toContain(token);
+    }
+  });
+
+  it("routes hook-runtime and corporate-registry to owners without restating them", () => {
+    const text = hub();
+    expect(text).toContain("hook-runtime-unavailable.md");
+    expect(text).toContain("templates/agents-entry.md");
+    expect(text).toContain("UPGRADING.md#corporate-or-mirrored-npm-registry");
+    expect(text).not.toContain("--registry=https://registry.npmjs.org/");
+  });
+
+  it("does not use paste-JSON or a doctor --redact verb as the capture control", () => {
+    const text = hub();
+    expect(text).toMatch(/do not paste/i);
+    expect(text).toContain("Next command:");
+    expect(text).not.toContain("doctor --redact");
+    expect(text.toLowerCase()).not.toContain("paste-the-json");
+  });
+
+  it("splits ordinary issues from root SECURITY.md", () => {
+    const text = hub();
+    expect(text).toContain("SECURITY.md");
+    expect(text).not.toContain("docs/security.md");
+  });
+
+  it("keeps the hub off LIVE_PROCEDURE_EXCLUSIONS", () => {
+    expect(LIVE_PROCEDURE_EXCLUSIONS.some((entry) => entry.path.includes("SUPPORT"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the canonical deposited support hub at `content/docs/SUPPORT.md` (bound lean 5514459336). README one-click pointers to Support and getting-started. Symptom rows diagnose via `directive doctor --full` or the README cold-start. Recovery command bytes stay in doctor. No paste-JSON capture. No doctor redaction flag.

## Related Issues

Closes #4098
Refs #4085

## Checklist

- [x] `/deft:change <name>` — N/A: swarm file-scope story; operator-approved Wave 3 cohort
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (file-scope does not include ROADMAP)
- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/content-contracts`; `task verify:encoding`)

## Test plan

- [x] Content-contract `support_hub.test.ts` (8 tests)
- [x] `task verify:encoding`
- [x] `task docs:rule-map:check`
