### PR TITLE
test(docs): validate commands.md snippets against Task and CLI registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. Refs #4085.
+- **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. `git log -p` is scored per commit so historical patches are not one candidate. Refs #4085.
 - **Command-snippet extraction skips runner flags after the launcher (#4094).** `task -t … verb` is no longer dropped before registry lookup. Refs #4085.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Shallow candidate-diff fallback fails closed when no usable base range exists (#4094).** A depth-one checkout no longer treats HEAD-only `git log -p` as the pull-request diff. Unresolved base fetch is a contract finding. Refs #4085.
 - **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. `git log -p` is scored per commit so historical patches are not one candidate. Shallow CI fetches `GITHUB_BASE_SHA` and two-dot diffs when merge-base is missing. Refs #4085.
 - **Command-snippet extraction skips runner flags after the launcher (#4094).** `task -t … verb` is no longer dropped before registry lookup. Refs #4085.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. `git log -p` is scored per commit so historical patches are not one candidate. Refs #4085.
+- **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. `git log -p` is scored per commit so historical patches are not one candidate. Shallow CI fetches `GITHUB_BASE_SHA` and two-dot diffs when merge-base is missing. Refs #4085.
 - **Command-snippet extraction skips runner flags after the launcher (#4094).** `task -t … verb` is no longer dropped before registry lookup. Refs #4085.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. Refs #4085.
+- **Command-snippet extraction skips runner flags after the launcher (#4094).** `task -t … verb` is no longer dropped before registry lookup. Refs #4085.
+
 ### Removed
 
 ## [0.111.0] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Current Task and CLI snippets in commands.md resolve against the Taskfile graph and dispatch/help registries (#4094).** Extends the live-procedure markdown walker. Classification is a closed set; same-diff exemptions fail. Lookup is verb/namespace only and does not execute fences. Does not rewrite Task descriptions. Closes #4094. Refs #4085.
 - **Doctor-first support hub at `content/docs/SUPPORT.md` (#4098).** Symptom index points at `directive doctor --full` or the README cold-start. README one-click links Support and getting-started. No second recovery ladder, no paste-JSON capture, no `doctor --redact`. Closes #4098. Refs #4085.
 - **RULE-MAP freshness fails closed on `task check` (#4095).** Regenerates `docs/RULE-MAP.md`. `task docs:rule-map:check` is wired into `FRAMEWORK_CHECK_GATES` and `check:framework-source`. The gate asserts byte-identical renderer output, filled grouping purposes, pack entries from named arrays, and Taskfile declaration counts. ROADMAP stays on `task roadmap:check` (residual [#4164](https://github.com/deftai/directive/issues/4164)). Closes #4095.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Shallow candidate-diff fallback fails closed when no usable base range exists (#4094).** A depth-one pull-request checkout no longer treats HEAD-only `git log -p` as the pull-request diff. Unresolved base fetch is a contract finding. Push-to-master CI keeps the log fallback so origin/master==HEAD does not fail the live tests. Refs #4085.
+- **Shallow candidate-diff fallback fails closed when no usable base range exists (#4094).** A depth-one pull-request checkout no longer treats HEAD-only `git log -p` as the pull-request diff. Unresolved base fetch is a contract finding. Push-to-master CI diffs `GITHUB_EVENT_PATH.before` so a multi-commit push cannot hide an earlier exemption. Refs #4085.
 - **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. `git log -p` is scored per commit so historical patches are not one candidate. Shallow CI fetches `GITHUB_BASE_SHA` and two-dot diffs when merge-base is missing. Refs #4085.
 - **Command-snippet extraction skips runner flags after the launcher (#4094).** `task -t … verb` is no longer dropped before registry lookup. Refs #4085.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Shallow candidate-diff fallback fails closed when no usable base range exists (#4094).** A depth-one checkout no longer treats HEAD-only `git log -p` as the pull-request diff. Unresolved base fetch is a contract finding. Refs #4085.
+- **Shallow candidate-diff fallback fails closed when no usable base range exists (#4094).** A depth-one pull-request checkout no longer treats HEAD-only `git log -p` as the pull-request diff. Unresolved base fetch is a contract finding. Push-to-master CI keeps the log fallback so origin/master==HEAD does not fail the live tests. Refs #4085.
 - **Same-diff exemption check keeps every candidate patch, not the oldest `git log -p` entry (#4094).** `splitUnifiedDiff` concatenates repeated path patches. Candidate diff prefers working-tree then merge-base, and only then the shallow log fallback. `git log -p` is scored per commit so historical patches are not one candidate. Shallow CI fetches `GITHUB_BASE_SHA` and two-dot diffs when merge-base is missing. Refs #4085.
 - **Command-snippet extraction skips runner flags after the launcher (#4094).** `task -t … verb` is no longer dropped before registry lookup. Refs #4085.
 

--- a/content/commands.md
+++ b/content/commands.md
@@ -107,8 +107,8 @@ On-demand **write + check** dense xBRIEF SoT artifacts at an explicit path. Thes
 
 | Verb | Meaning |
 |------|---------|
-| `deft xbrief:create` / `task xbrief:create` | Write json, md, or both at `--out` |
-| `deft xbrief:verify` / `task xbrief:verify` | Fail-closed check at `--out` |
+| `deft xbrief:create` | Write json, md, or both at `--out` |
+| `deft xbrief:verify` | Fail-closed check at `--out` |
 | `scope:*` / intake | Lifecycle birth and folder/status transitions |
 | `xbrief:preflight` | Implementation-intent gate (unchanged) |
 
@@ -146,7 +146,7 @@ Common commands:
 - `task scope:fail -- xbrief/active/<file>.xbrief.json` -- mark running work failed when the scope cannot complete.
 - `task scope:cancel -- <path>` -- move a scope to `cancelled/`.
 - `task scope:restore`, `task scope:block`, `task scope:unblock`, `task scope:demote`, and `task scope:undo:*` -- repair or reverse lifecycle transitions.
-- `task issue:sync-from-xbrief -- <path>` -- post a GitHub issue comment summarizing material AC/status changes for an origin-linked scope xBRIEF (`plan.references` with `x-xbrief/github-issue`). Supports `--dry-run` (print without posting), `--repo OWNER/NAME` when the reference URI lacks a repo slug, and `--allow-cross-repo` for intentional cross-repo sync (refused by default; #2633). Skips when no material changes since the last successful sync. Closes the reverse-sync gap after `task issue:ingest` (#2540).
+- `deft issue:sync-from-xbrief -- <path>` -- post a GitHub issue comment summarizing material AC/status changes for an origin-linked scope xBRIEF (`plan.references` with `x-xbrief/github-issue`). Supports `--dry-run` (print without posting), `--repo OWNER/NAME` when the reference URI lacks a repo slug, and `--allow-cross-repo` for intentional cross-repo sync (refused by default; #2633). Skips when no material changes since the last successful sync. Closes the reverse-sync gap after `task issue:ingest` (#2540).
 - `task issue:ingest -- <N>` / `task issue:ingest -- --all [--label L] [--status S] [--dry-run]` -- ingest GitHub issues as scope xBRIEFs (deduplicates via existing references).
 - `task reconcile:issues [-- --apply-lifecycle-fixes]` -- scan origin-linked xBRIEFs for stale or closed GitHub issues.
 
@@ -168,7 +168,7 @@ The implementation gate succeeds only for active scope xBRIEFs with `plan.status
 
 **Slash-command intent containment (#1193):** When a session is originated by a slash command, that command is the *only* authorized verb for the session. Set `DEFT_SESSION_SLASH_VERB` (e.g. `/github-issue`) so `task xbrief:preflight` and PreToolUse hooks enforce the ceiling. Non-implement verbs (`/github-issue`, `/triage`, `/refine`, `/discuss`, `/research`, …) MUST NOT authorize implement, push, PR, merge, or deploy — adjacent bugs noticed during RCA become a second filed issue, not a second PR. Implement verbs: `/build`, `/ship`, `/ship-hotfix`, `/swarm`, `/implement`.
 
-**Human merge gate (#1193):** Typed `plan.policy.requireHumanMerge` (defaults true when `plan.policy.autoDeployOnMerge` is true). Agents may open PRs but must not merge when the gate is ON. Surfaces: (1) `task pr:wait-mergeable-and-merge` refuses agent merge, (2) `task verify:branch` advisory note, (3) branch-protection / setup requiring ≥1 human reviewer. Session-start discloses when ON. Override: `task policy:allow-bot-merge -- --confirm` or `DEFT_ALLOW_BOT_MERGE=1`.
+**Human merge gate (#1193):** Typed `plan.policy.requireHumanMerge` (defaults true when `plan.policy.autoDeployOnMerge` is true). Agents may open PRs but must not merge when the gate is ON. Surfaces: (1) `task pr:wait-mergeable-and-merge` refuses agent merge, (2) `task verify:branch` advisory note, (3) branch-protection / setup requiring ≥1 human reviewer. Session-start discloses when ON. Override: `deft policy:allow-bot-merge -- --confirm` or `DEFT_ALLOW_BOT_MERGE=1`.
 
 **Hotfix classifier (#1193):** Typed `plan.policy.hotfixCriteria` + pure `evaluateHotfixEligibility`. Small fix / pure revert may propose label `hotfix-candidate` only; a human promotes to `hotfix`. Refactors, new exports/handlers, and forbidden paths (Dockerfile, fly.toml, workflows, migrations, auth/secrets) never qualify.
 
@@ -286,7 +286,6 @@ Current status: the validation, extractor, provider, registry, generated MAP, an
 - `task check:merge` -- explicit merge-chokepoint alias for `check:framework-source` in the framework source repo (#1704).
 - `task check:framework-source` -- framework-source lane.
 - `task check:consumer` -- consumer-shape lane.
-- `task check:slow` -- slower/full checks.
 
 ### Gate throughput — iteration fast lane (#1704)
 
@@ -302,7 +301,7 @@ Current status: the validation, extractor, provider, registry, generated MAP, an
 - `task verify:branch` -- enforce default-branch protection.
 - `task verify:hooks-installed` -- ensure local git hooks are configured; use `deft verify:hooks-installed --scope=agent --live` for fail-closed agent-host registration + command functionality.
 - `task verify:encoding` -- detect mojibake and BOM issues.
-- `task verify:xbrief-conformance` -- validate xBRIEF conformance surfaces.
+- `task verify:vbrief-conformance` -- validate xBRIEF conformance surfaces.
 - `task verify:cache-fresh` -- validate cache freshness where required.
 - `task verify:capacity`, `task verify:wip-cap`, and `task verify:judgment-gates` -- policy/capacity gates.
 - `task verify:orphan-active` -- fail closed when active/running xBRIEFs still point at closed issues or merged PRs (#2321). After merge, `task verify:orphan-active -- --issue N` scans briefs that reference that issue. Confirmed shipped prints `task scope:complete -- <path>`; unresolved lookup prints a retry remediation and still exits 1 (#3429). PR-only briefs stay on the unscoped scan or `task swarm:complete-cohort`.
@@ -403,7 +402,7 @@ After CLI/deposit upgrade, disk can show the new generation while a long-lived s
 
 - ! Successful `init` / payload `update` stamps a monotonic live generation at `.deft/GENERATION.json` (outside `.deft/core` so replace does not wipe the counter).
 - ! Mutation `session:start` (cold and re-arm) binds that generation into `.deft/session-bind.json` when payload surfaces load.
-- ! Query with `deft freshness:report` / `task freshness:report` / `task session:freshness` (`--json` supported). States: `current` | `stale_soft` | `stale_hard` | `unbound`. Exit `0` only when `current`.
+- ! Query with `deft freshness:report` / `deft session:freshness` (`--json` supported). States: `current` | `stale_soft` | `stale_hard` | `unbound`. Exit `0` only when `current`.
 - ! Rebind without restarting a shared host runtime: re-load surfaces into the session, then `deft freshness:bind` (or re-arm / `session:ready`).
 - ! Mid-mission: park and hand off before a hard refresh; an empty session after refresh is not work complete.
 - Soft vs hard meanings, surfaces, and API: `content/docs/freshness-contract.md`.
@@ -457,7 +456,7 @@ Cross-link: spawn three postures and deny recoveries live under § Agent-host di
 ### Mutable ritual (mutation posture)
 
 - ! On **mutation** session start, run `deft session:start` (or `task session:start` in framework source) after loading AGENTS.md. Records quick-tier ritual in `.deft/ritual-state.json`: alignment confirmation, branch-policy disclosure, `deft verify:tools` guidance, default-branch sync warnings, and `deft triage:welcome` one-liner. State is worktree- and HEAD-bound; stale after `plan.policy.sessionRitualStalenessHours` hours (default 4). Mutation start also claims the worktree occupancy lease (`.deft/occupancy.json`); see Session routing (#3433).
-- ! **Orientation compression Now (#3286):** mutation cold `session:start` composes `doctor` + #3282 toolchain preflight (and deposit-sha fast-paths for `agents:refresh` / `verify:cache-fresh`) as inline sections with per-section status lines — composition of existing steps, not a new monolith. When the deposit fingerprint (payload + templates + engine) is unchanged, refresh surfaces print one-line `unchanged - sha match` no-ops. Opt-in compact output: `deft session:start --compact` or `DEFT_SESSION_COMPACT=1` (verbose remains the default). #2176 read-only default is unchanged. Dual-path Later (`deft orient`) stays open until run-summary telemetry shows ritual+gate share ≥ 25% after Now ships (#2899).
+- ! **Orientation compression Now (#3286):** mutation cold `session:start` composes `doctor` + #3282 toolchain preflight (and deposit-sha fast-paths for `agents:refresh` / `verify:cache-fresh`) as inline sections with per-section status lines — composition of existing steps, not a new monolith. When the deposit fingerprint (payload + templates + engine) is unchanged, refresh surfaces print one-line `unchanged - sha match` no-ops. Opt-in compact output: `deft session:start --compact` or `DEFT_SESSION_COMPACT=1` (verbose remains the default). #2176 read-only default is unchanged. Dual-path Later (orient) stays open until run-summary telemetry shows ritual+gate share ≥ 25% after Now ships (#2899).
 - ! Cold `session:start` does **not** run the live agent-hook probe. Functional readiness belongs to the gated mutation path so cold ceremony retains the #2990/#2991 latency profile.
 - ! **Hot path latency (#2991):** by default, mutation `session:start` does **not** block ritual-state write on optional network. It skips the npm release-availability probe and triage cache empty-hydrate / self-heal (`ensureTriageCacheHydrated` / `maybeSelfHealCache`). Targets (operator-facing, not CI-hard): warm hot path typically under a few seconds once tools are on PATH; cold path dominated by local `verify:tools` and git, usually well under ~30s when optional network is off. Empty-cache GitHub fetch-all and npm `view` previously accounted for multi-minute hangs in the WWYSYDH pilot — those stay off the critical path unless opted in.
 - ! **Cold vs re-arm ceremony tiers (#2992):** default `session:start` is the **cold** (full) path. After age staleness or compact re-arm (#2113) on the **same worktree** with continuous HEAD and previously-passing quick steps, prefer `deft session:start --rearm` (alias `--tier=rearm`) to refresh the ritual clock + HEAD/worktree bind without `verify:tools`, triage welcome, release probe, or staleness tickler. Full cold remains required for missing/invalid state, worktree change, discontinuous HEAD, first install, or failed/missing quick steps. Compact marks `rearm_needed`; PreToolUse denial and inspect/verify messages prefer re-arm recovery when cold is unnecessary.
@@ -465,7 +464,7 @@ Cross-link: spawn three postures and deny recoveries live under § Agent-host di
 - ~ `session:start --json` includes `steps[]` with `name` + `duration_ms` for major phases (`alignment`, `branch_policy`, `verify_tools`, `triage_welcome`, `release_probe`, `ritual_write`), plus total `duration_ms`, `optional_network`, and `ceremony_tier` (`cold` | `rearm`). Skipped optional steps report `skipped: true` and `duration_ms: 0`. Use this for attribution when investigating ceremony wall-clock.
 - ~ **Process-cost events (#2994 / #3508):** on mutation `session:start` completion (cold or re-arm), Directive appends a local `session:start` behavioral event to `.deft-cache/events.jsonl` with `ceremony_tier`, `duration_ms`, `exit_code`, and optional `steps[]` (same labels as `--json`). Mutation `session:start` also prints one operator-visible `ceremony <tier> <ms>` line (hidden under `--compact` / `DEFT_SESSION_COMPACT`). When PreToolUse denies for `ritual-not-ready`, a local `session:ritual-blocked` event records `tool_name`, `code`, and optional `recovery_tier` / `detail`. Always-on best-effort (never blocks ceremony or deny path); not gated on `valueFeedback`; **no remote upload** (Product Insights #2603 is a separate opt-in). Pull the rollup with `task value:show` (composed reader; CLI process time, not agent-turn wall clock). See § Process-cost events below. ⊗ Do not use the printed CLI duration as #3286 Later graduation input.
 - ~ At safe idle points (clean tree, no in-flight story), mutation session start and `deft scope:complete` may also run the staleness tickler: an interactive, consent-based offer to upgrade Directive (`npm i -g @deftai/directive@latest`) and/or migrate xBRIEF (`deft migrate:xbrief`). Escalation tiers, snooze windows, and opt-out live under `plan.policy.stalenessTickler` — inspect with `deft policy:show --field=stalenessTickler`. State persists in `xbrief/.triage-cache/staleness-tickler-state.json`. Skips framework source checkouts, dirty trees, CI/headless (`DEFT_SESSION_RITUAL_SKIP=1`), and typed opt-out. Refs #2488 / #2489.
-- ! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. Gated tier fails closed unless quick-tier state is fresh; lazily records the non-deferrable `agent_hooks` readiness gate plus `deft doctor` and `deft verify:cache-fresh` entrypoints. Agent-hook correctness is independent of doctor warnings and throttling. Step 0 of the pre-`start_agent` gate stack.
+- ! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. Gated tier fails closed unless quick-tier state is fresh; lazily records the non-deferrable `agent_hooks` readiness gate plus `deft doctor` and `task verify:cache-fresh` entrypoints. Agent-hook correctness is independent of doctor warnings and throttling. Step 0 of the pre-`start_agent` gate stack.
 - ! **One-shot recovery (#2993 / #3100):** when PreToolUse denies writes for a stale/missing gated ritual, run `deft session:ready` (or `task session:ready`). It composes `session:start` (only when quick-tier is not green) + `verify:session-ritual -- --tier=gated` + `cache fetch-all --force` when `cache_fresh` is the remaining blocker, then re-verifies. Even when gated inspect is already fresh, the fast path forces one live `agent_hooks` check so later drift cannot hide behind cached ritual state; it still avoids unnecessary fetch-all. Flags: `--json`, `--repo OWNER/NAME`, `--with-network` (forwarded to session:start). Prefer this over juggling the multi-step recovery sequence under hook pressure.
 - ? Postpone with `deft session:start --defer step=reason` (`alignment`, `branch_policy`, `triage_welcome`, `doctor`, `cache_fresh`). `agent_hooks` is non-deferrable.
 - Headless workers / CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; verifier exits 0 but warns when bypass hides failure.
@@ -488,7 +487,7 @@ Agents use this signal to prefer portable syntax and quote zsh-sensitive data su
 - Credential bridging: host-gh (`gh auth login` in the execution env) or injected-token (`GH_TOKEN` / `GITHUB_TOKEN` / `GH_ENTERPRISE_TOKEN`). Never put token values in prompts or transcripts.
 - Contract: `content/contracts/scm-readiness.md`; operator docs: `content/scm/github.md` § Mismatched/headless SCM readiness.
 
-**Pre-`start_agent` gate stack (#1149/#1348):** (0) `deft verify:session-ritual -- --tier=gated` → (1) `deft verify:story-ready` → (2) `deft xbrief:preflight` → (3) `deft verify:cache-fresh` → (4) `deft verify:branch` + hooks → (5) `start_agent`.
+**Pre-`start_agent` gate stack (#1149/#1348):** (0) `deft verify:session-ritual -- --tier=gated` → (1) `deft verify:story-ready` → (2) `deft xbrief:preflight` → (3) `task verify:cache-fresh` → (4) `deft verify:branch` + hooks → (5) `start_agent`.
 
 ```mermaid
 flowchart TD

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -1,0 +1,301 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  COMMAND_SNIPPET_CLASSIFICATIONS,
+  COMMAND_SNIPPET_CORPUS,
+  COMMAND_SNIPPET_EXEMPTIONS,
+  COMMAND_SNIPPET_FROZEN_TASK_VERBS,
+  COMMAND_SNIPPET_KNOWN_FALSE_TASK_VERBS,
+  type CommandSnippetCorpusEntry,
+  type CommandSnippetExemption,
+  evaluateCommandSnippets,
+  evaluateMarkdownCommandSnippets,
+  extractCommandSnippets,
+  formatCommandSnippetFailure,
+  frameworkRepoRoot,
+  loadCommandRegistries,
+  resolveCommandSnippet,
+  sameDiffExemptionViolations,
+} from "../../deposit/live-procedure-targets.js";
+
+const MAINTAINER_CURRENT: CommandSnippetCorpusEntry = {
+  path: "content/commands.md",
+  audience: "maintainer",
+  defaultClassification: "current",
+  failClosed: true,
+  historicalHeadingPrefixes: ["## Command Lifecycle:", "## Historical "],
+};
+
+describe("command snippet contract (#4094)", () => {
+  const repoRoot = frameworkRepoRoot();
+  const registries = loadCommandRegistries(repoRoot);
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("names corpus, closed classification, registry set, and audience key", () => {
+    expect(COMMAND_SNIPPET_CLASSIFICATIONS).toEqual([
+      "current",
+      "historical",
+      "frozen",
+      "template",
+      "illustrative",
+    ]);
+    const commands = COMMAND_SNIPPET_CORPUS.find((e) => e.path === "content/commands.md");
+    expect(commands?.failClosed).toBe(true);
+    expect(commands?.audience).toBe("maintainer");
+    expect(
+      COMMAND_SNIPPET_CORPUS.some((e) => e.path === "README.md" && e.failClosed === false),
+    ).toBe(true);
+    expect(COMMAND_SNIPPET_CORPUS.some((e) => e.path === "content/QUICK-START.md")).toBe(true);
+    expect(COMMAND_SNIPPET_CORPUS.some((e) => e.path === "content/docs/getting-started.md")).toBe(
+      true,
+    );
+    expect(registries.publicTasks.size).toBeGreaterThan(50);
+    expect(registries.preferredCli.size).toBeGreaterThan(50);
+    expect(registries.includeNamespaces.has("verify")).toBe(true);
+  });
+
+  it("known false task verbs are absent from the public Task graph", () => {
+    for (const verb of COMMAND_SNIPPET_KNOWN_FALSE_TASK_VERBS) {
+      const resolution = resolveCommandSnippet(
+        {
+          file: "fixture.md",
+          line: 1,
+          family: "task",
+          verb,
+          raw: `task ${verb}`,
+          span: "backtick",
+          classification: "current",
+          audience: "maintainer",
+        },
+        registries,
+      );
+      expect(resolution.kind, verb).toBe("absent");
+      expect(resolution.publicCurrent, verb).toBe(false);
+    }
+  });
+
+  it("does not accept an internal Task target as a current public command", () => {
+    expect(registries.internalTasks.has("engine:_ts-build")).toBe(true);
+    expect(registries.publicTasks.has("engine:_ts-build")).toBe(false);
+    const resolution = resolveCommandSnippet(
+      {
+        file: "fixture.md",
+        line: 1,
+        family: "task",
+        verb: "engine:_ts-build",
+        raw: "task engine:_ts-build",
+        span: "backtick",
+        classification: "current",
+        audience: "maintainer",
+      },
+      registries,
+    );
+    expect(resolution.kind).toBe("taskfile-internal");
+    expect(resolution.publicCurrent).toBe(false);
+  });
+
+  it("CLI current snippets use preferred/help names, not deferred or alias-only stems", () => {
+    expect(
+      resolveCommandSnippet(
+        {
+          file: "fixture.md",
+          line: 1,
+          family: "cli",
+          verb: "policy:allow-bot-merge",
+          raw: "deft policy:allow-bot-merge",
+          span: "backtick",
+          classification: "current",
+          audience: "maintainer",
+        },
+        registries,
+      ).publicCurrent,
+    ).toBe(true);
+    expect(
+      resolveCommandSnippet(
+        {
+          file: "fixture.md",
+          line: 1,
+          family: "cli",
+          verb: "feature",
+          raw: "deft feature",
+          span: "backtick",
+          classification: "current",
+          audience: "maintainer",
+        },
+        registries,
+      ).kind,
+    ).toBe("cli-deferred");
+    expect(
+      resolveCommandSnippet(
+        {
+          file: "fixture.md",
+          line: 1,
+          family: "cli",
+          verb: "validate-links",
+          raw: "deft validate-links",
+          span: "backtick",
+          classification: "current",
+          audience: "maintainer",
+        },
+        registries,
+      ).publicCurrent,
+    ).toBe(false);
+  });
+
+  it("looks up verb/namespace only and skips globs, flags, and bare namespaces", () => {
+    const text = [
+      "`task --list`",
+      "`task architecture:*`",
+      "`task policy`",
+      "`task check`",
+      "`task verify:branch -- --allow-dirty`",
+    ].join("\n");
+    const snippets = extractCommandSnippets(text, "fixture.md", MAINTAINER_CURRENT);
+    const verbs = snippets.map((s) => s.verb).sort();
+    expect(verbs).toEqual(["check", "policy", "verify:branch"]);
+    const policy = snippets.find((s) => s.verb === "policy");
+    expect(policy).toBeDefined();
+    if (policy === undefined) return;
+    expect(resolveCommandSnippet(policy, registries).kind).toBe("skipped");
+  });
+
+  it("does not execute extracted fences", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmd-snippet-fence-"));
+    created.push(root);
+    const marker = join(root, "pwned");
+    const text = ["```bash", `touch ${marker}`, "task check:slow", "```"].join("\n");
+    const result = evaluateMarkdownCommandSnippets({
+      text,
+      file: "fixture.md",
+      entry: MAINTAINER_CURRENT,
+      registries,
+    });
+    expect(existsSync(marker)).toBe(false);
+    expect(result.findings.some((f) => f.snippet.verb === "check:slow")).toBe(true);
+  });
+
+  it("classifies historical headings and frozen verbs instead of rewriting them", () => {
+    const text = [
+      "`task check`",
+      "`task migrate:vbrief`",
+      "## Command Lifecycle: retired Python launcher vs `task`",
+      "`task doctor`",
+    ].join("\n");
+    const snippets = extractCommandSnippets(text, "content/commands.md", MAINTAINER_CURRENT);
+    expect(COMMAND_SNIPPET_FROZEN_TASK_VERBS.has("migrate:vbrief")).toBe(true);
+    expect(snippets.find((s) => s.verb === "migrate:vbrief")?.classification).toBe("frozen");
+    expect(snippets.find((s) => s.verb === "doctor" && s.family === "task")?.classification).toBe(
+      "historical",
+    );
+    expect(snippets.find((s) => s.verb === "check")?.classification).toBe("current");
+  });
+
+  it("fails a current snippet that names a retired verb", () => {
+    const result = evaluateMarkdownCommandSnippets({
+      text: "Run `task check:slow` now.\n",
+      file: "content/commands.md",
+      entry: MAINTAINER_CURRENT,
+      registries,
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]?.snippet.verb).toBe("check:slow");
+    expect(formatCommandSnippetFailure(result)).toContain("check:slow");
+  });
+
+  it("same-diff exemption additions fail; exemption-only diffs do not", () => {
+    const sameDiff = [
+      "diff --git a/packages/core/src/deposit/live-procedure-targets.ts b/packages/core/src/deposit/live-procedure-targets.ts",
+      "--- a/packages/core/src/deposit/live-procedure-targets.ts",
+      "+++ b/packages/core/src/deposit/live-procedure-targets.ts",
+      "@@ -1,0 +1,6 @@",
+      "+  {",
+      '+    family: "task",',
+      '+    verb: "check:slow",',
+      '+    path: "content/commands.md",',
+      '+    classification: "illustrative",',
+      '+    reason: "waive",',
+      "+  },",
+      "diff --git a/content/commands.md b/content/commands.md",
+      "--- a/content/commands.md",
+      "+++ b/content/commands.md",
+      "@@ -1,0 +1,1 @@",
+      "+- `task check:slow` -- slower/full checks.",
+    ].join("\n");
+    expect(sameDiffExemptionViolations(sameDiff)).toEqual([
+      { verb: "check:slow", path: "content/commands.md", family: "task" },
+    ]);
+
+    const exemptionOnly = [
+      "diff --git a/packages/core/src/deposit/live-procedure-targets.ts b/packages/core/src/deposit/live-procedure-targets.ts",
+      "--- a/packages/core/src/deposit/live-procedure-targets.ts",
+      "+++ b/packages/core/src/deposit/live-procedure-targets.ts",
+      "@@ -1,0 +1,6 @@",
+      "+  {",
+      '+    family: "task",',
+      '+    verb: "migrate:vbrief",',
+      '+    path: "content/commands.md",',
+      '+    classification: "frozen",',
+      '+    reason: "pinned v0.59.0",',
+      "+  },",
+    ].join("\n");
+    expect(sameDiffExemptionViolations(exemptionOnly)).toEqual([]);
+  });
+
+  it("does not rewrite Taskfile descriptions as a side effect", () => {
+    const taskfile = join(repoRoot, "Taskfile.yml");
+    const before = createHash("sha256").update(readFileSync(taskfile)).digest("hex");
+    evaluateCommandSnippets({ repoRoot, corpus: [MAINTAINER_CURRENT] });
+    const after = createHash("sha256").update(readFileSync(taskfile)).digest("hex");
+    expect(after).toBe(before);
+    expect(COMMAND_SNIPPET_EXEMPTIONS).toEqual([]);
+  });
+
+  it("fail-closed commands.md current snippets resolve on the named registries", () => {
+    const result = evaluateCommandSnippets({ repoRoot, corpus: [MAINTAINER_CURRENT] });
+    expect(result.snippets.length).toBeGreaterThan(20);
+    expect(result.snippets.some((s) => s.span === "backtick")).toBe(true);
+    expect(result.findings, formatCommandSnippetFailure(result)).toEqual([]);
+    expect(result.snippets.some((s) => s.classification === "current" && s.verb === "check")).toBe(
+      true,
+    );
+    expect(
+      result.snippets.some((s) => s.verb === "check:slow" && s.classification === "current"),
+    ).toBe(false);
+    expect(
+      result.snippets.some(
+        (s) => s.verb === "verify:xbrief-conformance" && s.classification === "current",
+      ),
+    ).toBe(false);
+  });
+
+  it("applies a typed exemption without executing or rewriting the verb", () => {
+    const exemptions: readonly CommandSnippetExemption[] = [
+      {
+        family: "task",
+        verb: "triage:foo",
+        path: "content/commands.md",
+        classification: "illustrative",
+        reason: "placeholder in a fixture",
+      },
+    ];
+    const result = evaluateMarkdownCommandSnippets({
+      text: "Example: `task triage:foo`\n",
+      file: "content/commands.md",
+      entry: MAINTAINER_CURRENT,
+      registries,
+      exemptions,
+    });
+    expect(result.findings).toEqual([]);
+    expect(result.snippets[0]?.classification).toBe("illustrative");
+    expect(result.snippets[0]?.verb).toBe("triage:foo");
+  });
+});

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -1,5 +1,6 @@
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -369,6 +370,65 @@ describe("command snippet contract (#4094)", () => {
       "+  },",
     ].join("\n");
     expect(sameDiffExemptionViolations(splitAcrossCommits)).toEqual([]);
+  });
+
+  it("shallow clone fetches GITHUB_BASE_SHA so same-diff still sees earlier PR commits", () => {
+    const origin = mkdtempSync(join(tmpdir(), "cmd-snippet-origin-"));
+    const shallow = join(tmpdir(), `cmd-snippet-shallow-${process.pid}`);
+    created.push(origin, shallow);
+    const git = (cwd: string, args: readonly string[]): string =>
+      execFileSync("git", args, { cwd, encoding: "utf8" });
+    git(origin, ["init"]);
+    git(origin, ["config", "user.email", "t@example.test"]);
+    git(origin, ["config", "user.name", "t"]);
+    const resolverRel = "packages/core/src/deposit/live-procedure-targets.ts";
+    mkdirSync(join(origin, "packages/core/src/deposit"), { recursive: true });
+    mkdirSync(join(origin, "content"), { recursive: true });
+    writeFileSync(join(origin, resolverRel), "export const start = true;\n");
+    writeFileSync(join(origin, "content/commands.md"), "# Commands\n");
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "base"]);
+    const baseSha = git(origin, ["rev-parse", "HEAD"]).trim();
+    writeFileSync(
+      join(origin, resolverRel),
+      [
+        "export const COMMAND_SNIPPET_EXEMPTIONS = [",
+        "  {",
+        '    family: "task",',
+        '    verb: "check:slow",',
+        '    path: "content/commands.md",',
+        '    classification: "illustrative",',
+        '    reason: "waive",',
+        "  },",
+        "];",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(origin, "content/commands.md"),
+      "- `task check:slow` -- slower/full checks.\n",
+    );
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "same-diff exemption"]);
+    writeFileSync(join(origin, "CHANGELOG.md"), "note\n");
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "changelog only"]);
+    execFileSync("git", ["clone", "--depth", "1", `file://${origin}`, shallow], {
+      encoding: "utf8",
+    });
+    expect(git(shallow, ["rev-parse", "--is-shallow-repository"]).trim()).toBe("true");
+    expect(git(shallow, ["rev-list", "--count", "HEAD"]).trim()).toBe("1");
+    const prev = process.env.GITHUB_BASE_SHA;
+    process.env.GITHUB_BASE_SHA = baseSha;
+    try {
+      const diff = readCommandSnippetCandidateDiff(shallow);
+      expect(sameDiffExemptionViolations(diff)).toEqual([
+        { verb: "check:slow", path: "content/commands.md", family: "task" },
+      ]);
+    } finally {
+      if (prev === undefined) delete process.env.GITHUB_BASE_SHA;
+      else process.env.GITHUB_BASE_SHA = prev;
+    }
   });
 
   it("does not rewrite Taskfile descriptions as a side effect", () => {

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -476,9 +476,11 @@ describe("command snippet contract (#4094)", () => {
     const prevSha = process.env.GITHUB_BASE_SHA;
     const prevRef = process.env.GITHUB_BASE_REF;
     const prevActions = process.env.GITHUB_ACTIONS;
+    const prevEvent = process.env.GITHUB_EVENT_NAME;
     delete process.env.GITHUB_BASE_SHA;
     delete process.env.GITHUB_BASE_REF;
     delete process.env.GITHUB_ACTIONS;
+    process.env.GITHUB_EVENT_NAME = "pull_request";
     try {
       const diff = readCommandSnippetCandidateDiff(shallow);
       expect(diff).toContain(UNRESOLVED_SHALLOW_CANDIDATE_DIFF);
@@ -500,6 +502,56 @@ describe("command snippet contract (#4094)", () => {
       else process.env.GITHUB_BASE_REF = prevRef;
       if (prevActions === undefined) delete process.env.GITHUB_ACTIONS;
       else process.env.GITHUB_ACTIONS = prevActions;
+      if (prevEvent === undefined) delete process.env.GITHUB_EVENT_NAME;
+      else process.env.GITHUB_EVENT_NAME = prevEvent;
+    }
+  });
+
+  it("shallow push-to-master does not emit the unresolved-shallow sentinel", () => {
+    const origin = mkdtempSync(join(tmpdir(), "cmd-snippet-origin-"));
+    const shallow = join(tmpdir(), `cmd-snippet-shallow-push-${process.pid}`);
+    created.push(origin, shallow);
+    const git = (cwd: string, args: readonly string[]): string =>
+      execFileSync("git", args, { cwd, encoding: "utf8" });
+    git(origin, ["init"]);
+    git(origin, ["config", "user.email", "t@example.test"]);
+    git(origin, ["config", "user.name", "t"]);
+    const resolverRel = "packages/core/src/deposit/live-procedure-targets.ts";
+    mkdirSync(join(origin, "packages/core/src/deposit"), { recursive: true });
+    mkdirSync(join(origin, "content"), { recursive: true });
+    writeFileSync(join(origin, resolverRel), "export const start = true;\n");
+    writeFileSync(join(origin, "content/commands.md"), "# Commands\n");
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "head"]);
+    execFileSync("git", ["clone", "--depth", "1", `file://${origin}`, shallow], {
+      encoding: "utf8",
+    });
+    const prevSha = process.env.GITHUB_BASE_SHA;
+    const prevRef = process.env.GITHUB_BASE_REF;
+    const prevEvent = process.env.GITHUB_EVENT_NAME;
+    delete process.env.GITHUB_BASE_SHA;
+    delete process.env.GITHUB_BASE_REF;
+    process.env.GITHUB_EVENT_NAME = "push";
+    try {
+      const diff = readCommandSnippetCandidateDiff(shallow);
+      expect(diff).not.toContain(UNRESOLVED_SHALLOW_CANDIDATE_DIFF);
+      const result = evaluateCommandSnippets({
+        repoRoot,
+        corpus: [MAINTAINER_CURRENT],
+        diffText: diff,
+      });
+      expect(
+        result.findings.some((finding) =>
+          finding.snippet.raw.includes("unresolved-shallow candidate-diff"),
+        ),
+      ).toBe(false);
+    } finally {
+      if (prevSha === undefined) delete process.env.GITHUB_BASE_SHA;
+      else process.env.GITHUB_BASE_SHA = prevSha;
+      if (prevRef === undefined) delete process.env.GITHUB_BASE_REF;
+      else process.env.GITHUB_BASE_REF = prevRef;
+      if (prevEvent === undefined) delete process.env.GITHUB_EVENT_NAME;
+      else process.env.GITHUB_EVENT_NAME = prevEvent;
     }
   });
 

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -297,7 +297,7 @@ describe("command snippet contract (#4094)", () => {
 
   it("same-diff keeps the newest git log -p patch instead of the oldest overwrite", () => {
     const newestFirstLog = [
-      "commit 111newest",
+      "commit 1111111111111111111111111111111111111111",
       "Author: test",
       "",
       "    add exemption and snippet",
@@ -318,7 +318,7 @@ describe("command snippet contract (#4094)", () => {
       "+++ b/content/commands.md",
       "@@ -1,0 +1,1 @@",
       "+- `task check:slow` -- slower/full checks.",
-      "commit 000oldest",
+      "commit 0000000000000000000000000000000000000000",
       "Author: test",
       "",
       "    earlier unrelated edit",
@@ -337,6 +337,38 @@ describe("command snippet contract (#4094)", () => {
     expect(sameDiffExemptionViolations(newestFirstLog)).toEqual([
       { verb: "check:slow", path: "content/commands.md", family: "task" },
     ]);
+  });
+
+  it("same-diff does not combine an exemption and snippet from different git log commits", () => {
+    const splitAcrossCommits = [
+      "commit 1111111111111111111111111111111111111111",
+      "Author: test",
+      "",
+      "    add snippet only",
+      "",
+      "diff --git a/content/commands.md b/content/commands.md",
+      "--- a/content/commands.md",
+      "+++ b/content/commands.md",
+      "@@ -1,0 +1,1 @@",
+      "+- `task check:slow` -- slower/full checks.",
+      "commit 0000000000000000000000000000000000000000",
+      "Author: test",
+      "",
+      "    add exemption only",
+      "",
+      "diff --git a/packages/core/src/deposit/live-procedure-targets.ts b/packages/core/src/deposit/live-procedure-targets.ts",
+      "--- a/packages/core/src/deposit/live-procedure-targets.ts",
+      "+++ b/packages/core/src/deposit/live-procedure-targets.ts",
+      "@@ -1,0 +1,6 @@",
+      "+  {",
+      '+    family: "task",',
+      '+    verb: "check:slow",',
+      '+    path: "content/commands.md",',
+      '+    classification: "illustrative",',
+      '+    reason: "waive",',
+      "+  },",
+    ].join("\n");
+    expect(sameDiffExemptionViolations(splitAcrossCommits)).toEqual([]);
   });
 
   it("does not rewrite Taskfile descriptions as a side effect", () => {

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -199,6 +199,27 @@ describe("command snippet contract (#4094)", () => {
     expect(snippets.find((s) => s.verb === "check")?.classification).toBe("current");
   });
 
+  it("resets historical classification on a later current heading", () => {
+    const text = [
+      "`task check`",
+      "## Command Lifecycle: retired Python launcher vs `task`",
+      "`task doctor`",
+      "## Anti-Patterns",
+      "`task check`",
+      "`task check:slow`",
+    ].join("\n");
+    const snippets = extractCommandSnippets(text, "content/commands.md", MAINTAINER_CURRENT);
+    const slow = snippets.find((s) => s.verb === "check:slow");
+    expect(slow?.classification).toBe("current");
+    const result = evaluateMarkdownCommandSnippets({
+      text,
+      file: "content/commands.md",
+      entry: MAINTAINER_CURRENT,
+      registries,
+    });
+    expect(result.findings.some((f) => f.snippet.verb === "check:slow")).toBe(true);
+  });
+
   it("fails a current snippet that names a retired verb", () => {
     const result = evaluateMarkdownCommandSnippets({
       text: "Run `task check:slow` now.\n",
@@ -248,6 +269,12 @@ describe("command snippet contract (#4094)", () => {
       "+  },",
     ].join("\n");
     expect(sameDiffExemptionViolations(exemptionOnly)).toEqual([]);
+    const gated = evaluateCommandSnippets({
+      repoRoot,
+      corpus: [MAINTAINER_CURRENT],
+      diffText: sameDiff,
+    });
+    expect(gated.findings.some((f) => f.snippet.raw.includes("same-diff exemption"))).toBe(true);
   });
 
   it("does not rewrite Taskfile descriptions as a side effect", () => {

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -555,6 +555,79 @@ describe("command snippet contract (#4094)", () => {
     }
   });
 
+  it("shallow multi-commit push uses GITHUB_EVENT_PATH before SHA as the candidate range", () => {
+    const origin = mkdtempSync(join(tmpdir(), "cmd-snippet-origin-"));
+    const shallow = join(tmpdir(), `cmd-snippet-shallow-push-range-${process.pid}`);
+    created.push(origin, shallow);
+    const git = (cwd: string, args: readonly string[]): string =>
+      execFileSync("git", args, { cwd, encoding: "utf8" });
+    git(origin, ["init"]);
+    git(origin, ["config", "user.email", "t@example.test"]);
+    git(origin, ["config", "user.name", "t"]);
+    const resolverRel = "packages/core/src/deposit/live-procedure-targets.ts";
+    mkdirSync(join(origin, "packages/core/src/deposit"), { recursive: true });
+    mkdirSync(join(origin, "content"), { recursive: true });
+    writeFileSync(join(origin, resolverRel), "export const start = true;\n");
+    writeFileSync(join(origin, "content/commands.md"), "# Commands\n");
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "base"]);
+    const beforeSha = git(origin, ["rev-parse", "HEAD"]).trim();
+    writeFileSync(
+      join(origin, resolverRel),
+      [
+        "export const COMMAND_SNIPPET_EXEMPTIONS = [",
+        "  {",
+        '    family: "task",',
+        '    verb: "check:slow",',
+        '    path: "content/commands.md",',
+        '    classification: "illustrative",',
+        '    reason: "waive",',
+        "  },",
+        "];",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(origin, "content/commands.md"),
+      "- `task check:slow` -- slower/full checks.\n",
+    );
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "same-diff exemption"]);
+    writeFileSync(join(origin, "CHANGELOG.md"), "note\n");
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "changelog only"]);
+    const afterSha = git(origin, ["rev-parse", "HEAD"]).trim();
+    execFileSync("git", ["clone", "--depth", "1", `file://${origin}`, shallow], {
+      encoding: "utf8",
+    });
+    const eventFile = join(shallow, "push-event.json");
+    writeFileSync(eventFile, JSON.stringify({ before: beforeSha, after: afterSha }));
+    const prevSha = process.env.GITHUB_BASE_SHA;
+    const prevRef = process.env.GITHUB_BASE_REF;
+    const prevEvent = process.env.GITHUB_EVENT_NAME;
+    const prevPath = process.env.GITHUB_EVENT_PATH;
+    delete process.env.GITHUB_BASE_SHA;
+    delete process.env.GITHUB_BASE_REF;
+    process.env.GITHUB_EVENT_NAME = "push";
+    process.env.GITHUB_EVENT_PATH = eventFile;
+    try {
+      const diff = readCommandSnippetCandidateDiff(shallow);
+      expect(diff).not.toContain(UNRESOLVED_SHALLOW_CANDIDATE_DIFF);
+      expect(sameDiffExemptionViolations(diff)).toEqual([
+        { verb: "check:slow", path: "content/commands.md", family: "task" },
+      ]);
+    } finally {
+      if (prevSha === undefined) delete process.env.GITHUB_BASE_SHA;
+      else process.env.GITHUB_BASE_SHA = prevSha;
+      if (prevRef === undefined) delete process.env.GITHUB_BASE_REF;
+      else process.env.GITHUB_BASE_REF = prevRef;
+      if (prevEvent === undefined) delete process.env.GITHUB_EVENT_NAME;
+      else process.env.GITHUB_EVENT_NAME = prevEvent;
+      if (prevPath === undefined) delete process.env.GITHUB_EVENT_PATH;
+      else process.env.GITHUB_EVENT_PATH = prevPath;
+    }
+  });
+
   it("does not rewrite Taskfile descriptions as a side effect", () => {
     const taskfile = join(repoRoot, "Taskfile.yml");
     const before = createHash("sha256").update(readFileSync(taskfile)).digest("hex");

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -169,6 +169,23 @@ describe("command snippet contract (#4094)", () => {
     expect(resolveCommandSnippet(policy, registries).kind).toBe("skipped");
   });
 
+  it("extracts the verb after runner flags that follow the launcher", () => {
+    const text = [
+      "`task -t Taskfile.yml check:slow`",
+      "`task --verbose check`",
+      "`FOO=1 task -d . verify:branch`",
+    ].join("\n");
+    const snippets = extractCommandSnippets(text, "fixture.md", MAINTAINER_CURRENT);
+    expect(snippets.map((s) => s.verb).sort()).toEqual(["check", "check:slow", "verify:branch"]);
+    const gated = evaluateMarkdownCommandSnippets({
+      text: "`task -t Taskfile.yml check:slow`\n",
+      file: "content/commands.md",
+      entry: MAINTAINER_CURRENT,
+      registries,
+    });
+    expect(gated.findings.some((f) => f.snippet.verb === "check:slow")).toBe(true);
+  });
+
   it("does not execute extracted fences", () => {
     const root = mkdtempSync(join(tmpdir(), "cmd-snippet-fence-"));
     created.push(root);
@@ -276,6 +293,50 @@ describe("command snippet contract (#4094)", () => {
       diffText: sameDiff,
     });
     expect(gated.findings.some((f) => f.snippet.raw.includes("same-diff exemption"))).toBe(true);
+  });
+
+  it("same-diff keeps the newest git log -p patch instead of the oldest overwrite", () => {
+    const newestFirstLog = [
+      "commit 111newest",
+      "Author: test",
+      "",
+      "    add exemption and snippet",
+      "",
+      "diff --git a/packages/core/src/deposit/live-procedure-targets.ts b/packages/core/src/deposit/live-procedure-targets.ts",
+      "--- a/packages/core/src/deposit/live-procedure-targets.ts",
+      "+++ b/packages/core/src/deposit/live-procedure-targets.ts",
+      "@@ -1,0 +1,6 @@",
+      "+  {",
+      '+    family: "task",',
+      '+    verb: "check:slow",',
+      '+    path: "content/commands.md",',
+      '+    classification: "illustrative",',
+      '+    reason: "waive",',
+      "+  },",
+      "diff --git a/content/commands.md b/content/commands.md",
+      "--- a/content/commands.md",
+      "+++ b/content/commands.md",
+      "@@ -1,0 +1,1 @@",
+      "+- `task check:slow` -- slower/full checks.",
+      "commit 000oldest",
+      "Author: test",
+      "",
+      "    earlier unrelated edit",
+      "",
+      "diff --git a/packages/core/src/deposit/live-procedure-targets.ts b/packages/core/src/deposit/live-procedure-targets.ts",
+      "--- a/packages/core/src/deposit/live-procedure-targets.ts",
+      "+++ b/packages/core/src/deposit/live-procedure-targets.ts",
+      "@@ -1,0 +1,1 @@",
+      "+export const unrelated = true;",
+      "diff --git a/content/commands.md b/content/commands.md",
+      "--- a/content/commands.md",
+      "+++ b/content/commands.md",
+      "@@ -1,0 +1,1 @@",
+      "+# Commands",
+    ].join("\n");
+    expect(sameDiffExemptionViolations(newestFirstLog)).toEqual([
+      { verb: "check:slow", path: "content/commands.md", family: "task" },
+    ]);
   });
 
   it("does not rewrite Taskfile descriptions as a side effect", () => {

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -21,6 +21,7 @@ import {
   readCommandSnippetCandidateDiff,
   resolveCommandSnippet,
   sameDiffExemptionViolations,
+  UNRESOLVED_SHALLOW_CANDIDATE_DIFF,
 } from "../../deposit/live-procedure-targets.js";
 
 const MAINTAINER_CURRENT: CommandSnippetCorpusEntry = {
@@ -428,6 +429,77 @@ describe("command snippet contract (#4094)", () => {
     } finally {
       if (prev === undefined) delete process.env.GITHUB_BASE_SHA;
       else process.env.GITHUB_BASE_SHA = prev;
+    }
+  });
+
+  it("shallow clone without a usable base fails closed instead of HEAD-only git log", () => {
+    const origin = mkdtempSync(join(tmpdir(), "cmd-snippet-origin-"));
+    const shallow = join(tmpdir(), `cmd-snippet-shallow-nobase-${process.pid}`);
+    created.push(origin, shallow);
+    const git = (cwd: string, args: readonly string[]): string =>
+      execFileSync("git", args, { cwd, encoding: "utf8" });
+    git(origin, ["init"]);
+    git(origin, ["config", "user.email", "t@example.test"]);
+    git(origin, ["config", "user.name", "t"]);
+    const resolverRel = "packages/core/src/deposit/live-procedure-targets.ts";
+    mkdirSync(join(origin, "packages/core/src/deposit"), { recursive: true });
+    mkdirSync(join(origin, "content"), { recursive: true });
+    writeFileSync(join(origin, resolverRel), "export const start = true;\n");
+    writeFileSync(join(origin, "content/commands.md"), "# Commands\n");
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "base"]);
+    writeFileSync(
+      join(origin, resolverRel),
+      [
+        "export const COMMAND_SNIPPET_EXEMPTIONS = [",
+        "  {",
+        '    family: "task",',
+        '    verb: "check:slow",',
+        '    path: "content/commands.md",',
+        '    classification: "illustrative",',
+        '    reason: "waive",',
+        "  },",
+        "];",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(origin, "content/commands.md"),
+      "- `task check:slow` -- slower/full checks.\n",
+    );
+    git(origin, ["add", "."]);
+    git(origin, ["commit", "-m", "same-diff exemption"]);
+    execFileSync("git", ["clone", "--depth", "1", `file://${origin}`, shallow], {
+      encoding: "utf8",
+    });
+    expect(git(shallow, ["rev-parse", "--is-shallow-repository"]).trim()).toBe("true");
+    const prevSha = process.env.GITHUB_BASE_SHA;
+    const prevRef = process.env.GITHUB_BASE_REF;
+    const prevActions = process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_BASE_SHA;
+    delete process.env.GITHUB_BASE_REF;
+    delete process.env.GITHUB_ACTIONS;
+    try {
+      const diff = readCommandSnippetCandidateDiff(shallow);
+      expect(diff).toContain(UNRESOLVED_SHALLOW_CANDIDATE_DIFF);
+      expect(sameDiffExemptionViolations(diff)).toEqual([]);
+      const result = evaluateCommandSnippets({
+        repoRoot,
+        corpus: [MAINTAINER_CURRENT],
+        diffText: diff,
+      });
+      expect(
+        result.findings.some((finding) =>
+          finding.snippet.raw.includes("unresolved-shallow candidate-diff"),
+        ),
+      ).toBe(true);
+    } finally {
+      if (prevSha === undefined) delete process.env.GITHUB_BASE_SHA;
+      else process.env.GITHUB_BASE_SHA = prevSha;
+      if (prevRef === undefined) delete process.env.GITHUB_BASE_REF;
+      else process.env.GITHUB_BASE_REF = prevRef;
+      if (prevActions === undefined) delete process.env.GITHUB_ACTIONS;
+      else process.env.GITHUB_ACTIONS = prevActions;
     }
   });
 

--- a/packages/core/src/content-contracts/standards/command_snippets.test.ts
+++ b/packages/core/src/content-contracts/standards/command_snippets.test.ts
@@ -17,6 +17,7 @@ import {
   formatCommandSnippetFailure,
   frameworkRepoRoot,
   loadCommandRegistries,
+  readCommandSnippetCandidateDiff,
   resolveCommandSnippet,
   sameDiffExemptionViolations,
 } from "../../deposit/live-procedure-targets.js";
@@ -284,6 +285,11 @@ describe("command snippet contract (#4094)", () => {
     const after = createHash("sha256").update(readFileSync(taskfile)).digest("hex");
     expect(after).toBe(before);
     expect(COMMAND_SNIPPET_EXEMPTIONS).toEqual([]);
+  });
+
+  it("candidate diff is non-empty so same-diff cannot vanish in git checkouts", () => {
+    const diff = readCommandSnippetCandidateDiff(repoRoot);
+    expect(diff.includes("diff --git")).toBe(true);
   });
 
   it("fail-closed commands.md current snippets resolve on the named registries", () => {

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -15,6 +15,7 @@
  * only — extracted fences are never executed.
  */
 
+import { execFileSync } from "node:child_process";
 import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -875,6 +876,33 @@ export function evaluateMarkdownCommandSnippets(options: {
   return { snippets, findings };
 }
 
+const COMMAND_SNIPPET_DIFF_PATHS = [
+  "packages/core/src/deposit/live-procedure-targets.ts",
+  "content/commands.md",
+] as const;
+
+function gitOut(repoRoot: string, args: readonly string[]): string {
+  try {
+    return execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+  } catch {
+    return "";
+  }
+}
+
+/** Candidate diff for same-diff exemption ownership (working tree + merge-base). */
+export function readCommandSnippetCandidateDiff(repoRoot: string): string {
+  const files = [...COMMAND_SNIPPET_DIFF_PATHS];
+  const parts = [
+    gitOut(repoRoot, ["diff", "HEAD", "--", ...files]),
+    gitOut(repoRoot, ["diff", "--cached", "--", ...files]),
+  ];
+  const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", "origin/master"]).trim();
+  if (mergeBase.length > 0) {
+    parts.push(gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]));
+  }
+  return parts.join("\n");
+}
+
 export function evaluateCommandSnippets(options: {
   readonly repoRoot: string;
   readonly corpus?: readonly CommandSnippetCorpusEntry[];
@@ -898,8 +926,12 @@ export function evaluateCommandSnippets(options: {
     snippets.push(...result.snippets);
     findings.push(...result.findings);
   }
-  if (options.diffText !== undefined && options.diffText.length > 0) {
-    for (const violation of sameDiffExemptionViolations(options.diffText)) {
+  const diffText =
+    options.diffText !== undefined
+      ? options.diffText
+      : readCommandSnippetCandidateDiff(options.repoRoot);
+  if (diffText.length > 0) {
+    for (const violation of sameDiffExemptionViolations(diffText)) {
       findings.push({
         snippet: {
           file: violation.path,

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -889,16 +889,26 @@ function gitOut(repoRoot: string, args: readonly string[]): string {
   }
 }
 
-/** Candidate diff for same-diff exemption ownership (working tree + merge-base). */
+/** Candidate diff for same-diff exemption ownership. */
 export function readCommandSnippetCandidateDiff(repoRoot: string): string {
   const files = [...COMMAND_SNIPPET_DIFF_PATHS];
   const parts = [
     gitOut(repoRoot, ["diff", "HEAD", "--", ...files]),
     gitOut(repoRoot, ["diff", "--cached", "--", ...files]),
+    // Shallow CI checkouts often lack origin/master; log -p still has PR commits.
+    gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]),
   ];
-  const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", "origin/master"]).trim();
-  if (mergeBase.length > 0) {
+  const bases = [
+    process.env.GITHUB_BASE_SHA?.trim() ?? "",
+    process.env.GITHUB_BASE_REF?.trim() ? `origin/${process.env.GITHUB_BASE_REF.trim()}` : "",
+    "origin/master",
+    "origin/main",
+  ].filter((base) => base.length > 0);
+  for (const base of bases) {
+    const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", base]).trim();
+    if (mergeBase.length === 0) continue;
     parts.push(gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]));
+    break;
   }
   return parts.join("\n");
 }

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -682,8 +682,8 @@ function classifyByHeadings(
   state: { historical: boolean },
 ): CommandSnippetClassification {
   const trimmed = line.trim();
-  if (trimmed.startsWith("#") && historicalPrefixes.some((prefix) => trimmed.startsWith(prefix))) {
-    state.historical = true;
+  if (trimmed.startsWith("## ")) {
+    state.historical = historicalPrefixes.some((prefix) => trimmed.startsWith(prefix));
   }
   if (state.historical) return "historical";
   return defaultClassification;
@@ -879,6 +879,7 @@ export function evaluateCommandSnippets(options: {
   readonly repoRoot: string;
   readonly corpus?: readonly CommandSnippetCorpusEntry[];
   readonly exemptions?: readonly CommandSnippetExemption[];
+  readonly diffText?: string;
 }): CommandSnippetEvaluation {
   const registries = loadCommandRegistries(options.repoRoot);
   const snippets: CommandSnippet[] = [];
@@ -896,6 +897,23 @@ export function evaluateCommandSnippets(options: {
     });
     snippets.push(...result.snippets);
     findings.push(...result.findings);
+  }
+  if (options.diffText !== undefined && options.diffText.length > 0) {
+    for (const violation of sameDiffExemptionViolations(options.diffText)) {
+      findings.push({
+        snippet: {
+          file: violation.path,
+          line: 0,
+          family: violation.family,
+          verb: violation.verb,
+          raw: `same-diff exemption ${violation.family} ${violation.verb}`,
+          span: "backtick",
+          classification: "current",
+          audience: "maintainer",
+        },
+        resolution: { kind: "absent", publicCurrent: false },
+      });
+    }
   }
   return { snippets, findings };
 }

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -638,7 +638,6 @@ export function loadCommandRegistries(repoRoot: string): CommandRegistries {
 }
 
 function skipRunnerPrefix(parts: readonly string[]): string[] {
-  const out: string[] = [];
   let i = 0;
   while (i < parts.length) {
     const token = parts[i];
@@ -647,6 +646,16 @@ function skipRunnerPrefix(parts: readonly string[]): string[] {
       i += 1;
       continue;
     }
+    break;
+  }
+  const launcher = parts[i];
+  if (launcher !== "task" && launcher !== "deft" && launcher !== "directive") {
+    return parts.slice(i);
+  }
+  i += 1;
+  while (i < parts.length) {
+    const token = parts[i];
+    if (token === undefined) break;
     if (token === "--") {
       i += 1;
       break;
@@ -655,10 +664,9 @@ function skipRunnerPrefix(parts: readonly string[]): string[] {
       i += TASK_RUNNER_FLAGS_WITH_ARG.has(token) ? 2 : 1;
       continue;
     }
-    out.push(...parts.slice(i));
     break;
   }
-  return out;
+  return [launcher, ...parts.slice(i)];
 }
 
 function shouldSkipVerb(verb: string): boolean {
@@ -892,12 +900,11 @@ function gitOut(repoRoot: string, args: readonly string[]): string {
 /** Candidate diff for same-diff exemption ownership. */
 export function readCommandSnippetCandidateDiff(repoRoot: string): string {
   const files = [...COMMAND_SNIPPET_DIFF_PATHS];
-  const parts = [
+  const working = [
     gitOut(repoRoot, ["diff", "HEAD", "--", ...files]),
     gitOut(repoRoot, ["diff", "--cached", "--", ...files]),
-    // Shallow CI checkouts often lack origin/master; log -p still has PR commits.
-    gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]),
-  ];
+  ].join("\n");
+  if (working.includes("diff --git")) return working;
   const bases = [
     process.env.GITHUB_BASE_SHA?.trim() ?? "",
     process.env.GITHUB_BASE_REF?.trim() ? `origin/${process.env.GITHUB_BASE_REF.trim()}` : "",
@@ -907,10 +914,10 @@ export function readCommandSnippetCandidateDiff(repoRoot: string): string {
   for (const base of bases) {
     const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", base]).trim();
     if (mergeBase.length === 0) continue;
-    parts.push(gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]));
-    break;
+    return gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]);
   }
-  return parts.join("\n");
+  // Shallow CI: no merge-base. Per-commit patches are combined in splitUnifiedDiff.
+  return gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]);
 }
 
 export function evaluateCommandSnippets(options: {
@@ -973,7 +980,8 @@ function splitUnifiedDiff(diffText: string): Map<string, string> {
     const header = /^(?:a\/)?(\S+)\s+b\/(\S+)/.exec(part);
     const path = header?.[2]?.replace(/^b\//, "");
     if (!path) continue;
-    files.set(path, part);
+    const existing = files.get(path);
+    files.set(path, existing === undefined ? part : `${existing}\n${part}`);
   }
   return files;
 }

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -916,7 +916,7 @@ export function readCommandSnippetCandidateDiff(repoRoot: string): string {
     if (mergeBase.length === 0) continue;
     return gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]);
   }
-  // Shallow CI: no merge-base. Per-commit patches are combined in splitUnifiedDiff.
+  // Shallow CI: no merge-base. sameDiffExemptionViolations splits git-log commits.
   return gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]);
 }
 
@@ -993,13 +993,28 @@ function addedLines(fileDiff: string): string[] {
     .map((line) => line.slice(1));
 }
 
-/**
- * Same-diff exemption ownership (#4094): adding an allowlist row in the same
- * diff as the snippet it exempts fails.
- */
-export function sameDiffExemptionViolations(
-  diffText: string,
-): readonly SameDiffExemptionViolation[] {
+const GIT_LOG_COMMIT_RE = /^commit [0-9a-f]{7,40}\b/;
+
+/** Split `git log -p` into per-commit patches. Range/working diffs stay one chunk. */
+function candidateDiffChunks(diffText: string): string[] {
+  const lines = diffText.split("\n");
+  const hasCommit = lines.some((line) => GIT_LOG_COMMIT_RE.test(line));
+  if (!hasCommit) return [diffText];
+  const chunks: string[] = [];
+  let current: string[] = [];
+  for (const line of lines) {
+    if (GIT_LOG_COMMIT_RE.test(line) && current.length > 0) {
+      chunks.push(current.join("\n"));
+      current = [line];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) chunks.push(current.join("\n"));
+  return chunks;
+}
+
+function sameDiffExemptionViolationsOne(diffText: string): readonly SameDiffExemptionViolation[] {
   const files = splitUnifiedDiff(diffText);
   const resolverDiff = files.get("packages/core/src/deposit/live-procedure-targets.ts") ?? "";
   const added = addedLines(resolverDiff).join("\n");
@@ -1022,6 +1037,26 @@ export function sameDiffExemptionViolations(
     );
     if (snippetAdded) {
       violations.push({ verb, path, family });
+    }
+  }
+  return violations;
+}
+
+/**
+ * Same-diff exemption ownership (#4094): adding an allowlist row in the same
+ * diff as the snippet it exempts fails. `git log -p` is scored per commit.
+ */
+export function sameDiffExemptionViolations(
+  diffText: string,
+): readonly SameDiffExemptionViolation[] {
+  const seen = new Set<string>();
+  const violations: SameDiffExemptionViolation[] = [];
+  for (const chunk of candidateDiffChunks(diffText)) {
+    for (const violation of sameDiffExemptionViolationsOne(chunk)) {
+      const key = `${violation.family}\0${violation.verb}\0${violation.path}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      violations.push(violation);
     }
   }
   return violations;

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -923,17 +923,34 @@ function maybeFetchBase(repoRoot: string, spec: string): void {
   gitOut(repoRoot, ["fetch", "--depth", "1", "origin", token]);
 }
 
+function headSha(repoRoot: string): string {
+  return gitOut(repoRoot, ["rev-parse", "HEAD"]).trim();
+}
+
 function diffAgainstBase(repoRoot: string, base: string, files: readonly string[]): string | null {
   maybeFetchBase(repoRoot, base);
+  const head = headSha(repoRoot);
   const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", base]).trim();
   if (mergeBase.length > 0) {
+    // Depth-one clones point origin/<default> at HEAD, so merge-base==HEAD is
+    // not a PR base and would hide earlier commits as an empty range.
+    if (isShallowRepo(repoRoot) && mergeBase === head) return null;
     return gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]);
   }
   if (commitExists(repoRoot, base)) {
+    const baseSha = gitOut(repoRoot, ["rev-parse", `${base}^{commit}`]).trim();
+    if (isShallowRepo(repoRoot) && baseSha === head) return null;
     return gitOut(repoRoot, ["diff", base, "HEAD", "--", ...files]);
   }
   return null;
 }
+
+function isShallowRepo(repoRoot: string): boolean {
+  return gitOut(repoRoot, ["rev-parse", "--is-shallow-repository"]).trim() === "true";
+}
+
+/** Sentinel: depth-one checkout could not obtain a usable base-range diff. */
+export const UNRESOLVED_SHALLOW_CANDIDATE_DIFF = "UNRESOLVED_SHALLOW_CANDIDATE_DIFF";
 
 /** Candidate diff for same-diff exemption ownership. */
 export function readCommandSnippetCandidateDiff(repoRoot: string): string {
@@ -953,7 +970,9 @@ export function readCommandSnippetCandidateDiff(repoRoot: string): string {
     const ranged = diffAgainstBase(repoRoot, base, files);
     if (ranged !== null) return ranged;
   }
-  // Last resort: per-commit log. Depth-1 HEAD-only clones may miss earlier PR commits.
+  // Depth-one clones only have HEAD. A `git log -p` fallback would hide
+  // exemption + snippet additions from earlier PR commits (fail-open).
+  if (isShallowRepo(repoRoot)) return `${UNRESOLVED_SHALLOW_CANDIDATE_DIFF}\n`;
   return gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]);
 }
 
@@ -984,7 +1003,21 @@ export function evaluateCommandSnippets(options: {
     options.diffText !== undefined
       ? options.diffText
       : readCommandSnippetCandidateDiff(options.repoRoot);
-  if (diffText.length > 0) {
+  if (diffText.trim() === UNRESOLVED_SHALLOW_CANDIDATE_DIFF) {
+    findings.push({
+      snippet: {
+        file: "packages/core/src/deposit/live-procedure-targets.ts",
+        line: 0,
+        family: "task",
+        verb: "candidate-diff",
+        raw: "unresolved-shallow candidate-diff: depth-one checkout has no usable base range",
+        span: "backtick",
+        classification: "current",
+        audience: "maintainer",
+      },
+      resolution: { kind: "absent", publicCurrent: false },
+    });
+  } else if (diffText.length > 0) {
     for (const violation of sameDiffExemptionViolations(diffText)) {
       findings.push({
         snippet: {

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -1,5 +1,6 @@
 /**
- * C3 live-procedure target validation (#3602 / #3899).
+ * C3 live-procedure target validation (#3602 / #3899) and command-snippet
+ * registry lookup (#4094).
  *
  * A shipped live procedure must not name a helper the deposit does not
  * contain. Python helpers are identified via python-free; markdown is
@@ -8,10 +9,19 @@
  *
  * Metric: unique live-invalid helper targets (not occurrences, not matching
  * lines). Prefer a zero unique-target assertion; do not freeze raw counts.
+ *
+ * Command snippets reuse this markdown walker (backticks + fences). Registry
+ * lookup is static Taskfile parse plus dispatch.ts / CLI help. Verb/namespace
+ * only — extracted fences are never executed.
  */
 
 import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  parseTaskfileIncludes,
+  taskDefinedInTaskfileYaml,
+} from "../check/consumer-gate-integrity.js";
 import { NON_PRODUCT_DIRS } from "../fs/non-product-dirs.js";
 import { extractLinkTargets, shouldSkipLinkTarget } from "../validate-content/link-parser.js";
 import { isDeclaredLiveProcedureExclusion } from "./live-procedure-exclusions.js";
@@ -132,6 +142,18 @@ function isPathChar(ch: string | undefined): boolean {
   return PATH_CHAR.test(ch) || ch === "/" || ch === "\\";
 }
 
+function forEachBacktickSpan(line: string, visit: (inner: string) => void): void {
+  let tick = 0;
+  while (tick < line.length) {
+    const open = line.indexOf("`", tick);
+    if (open < 0) break;
+    const close = line.indexOf("`", open + 1);
+    if (close < 0) break;
+    visit(line.slice(open + 1, close).trim());
+    tick = close + 1;
+  }
+}
+
 function extractBacktickPythonHelpers(line: string): string[] {
   const out: string[] = [];
   const suffixes = [".pyc", ".py"] as const;
@@ -159,13 +181,7 @@ function extractBacktickPythonHelpers(line: string): string[] {
       if (normalized) out.push(normalized);
     }
   }
-  let tick = 0;
-  while (tick < line.length) {
-    const open = line.indexOf("`", tick);
-    if (open < 0) break;
-    const close = line.indexOf("`", open + 1);
-    if (close < 0) break;
-    const inner = line.slice(open + 1, close).trim();
+  forEachBacktickSpan(line, (inner) => {
     const parts = inner.split(/\s+/).filter((p) => p.length > 0);
     const first = (parts[0] ?? "").replace(/^\.\//, "");
     const arg = parts[1];
@@ -183,8 +199,7 @@ function extractBacktickPythonHelpers(line: string): string[] {
       const normalized = normalizePythonHelperTarget("run");
       if (normalized) out.push(normalized);
     }
-    tick = close + 1;
-  }
+  });
   return out;
 }
 
@@ -287,6 +302,675 @@ export function formatLiveProcedureFailure(result: LiveProcedureEvaluation): str
   }
   if (result.hits.length > 40) {
     lines.push(`  ... ${result.hits.length - 40} more occurrence(s)`);
+  }
+  return lines.join("\n");
+}
+
+/** Closed classification set for command snippets (#4094). */
+export const COMMAND_SNIPPET_CLASSIFICATIONS = [
+  "current",
+  "historical",
+  "frozen",
+  "template",
+  "illustrative",
+] as const;
+
+export type CommandSnippetClassification = (typeof COMMAND_SNIPPET_CLASSIFICATIONS)[number];
+
+/** Audience/context key: which registry a snippet is judged against (#4094). */
+export const COMMAND_SNIPPET_AUDIENCES = ["consumer", "maintainer", "frozen"] as const;
+
+export type CommandSnippetAudience = (typeof COMMAND_SNIPPET_AUDIENCES)[number];
+
+export type CommandSnippetFamily = "task" | "cli";
+
+export type CommandSnippetSpan = "backtick" | "fence";
+
+export type CommandSnippetRegistryKind =
+  | "taskfile-public"
+  | "taskfile-internal"
+  | "cli-preferred"
+  | "cli-registered"
+  | "cli-deferred"
+  | "cli-stubbed"
+  | "cli-help"
+  | "skipped"
+  | "absent";
+
+export interface CommandSnippetCorpusEntry {
+  readonly path: string;
+  readonly audience: CommandSnippetAudience;
+  readonly defaultClassification: CommandSnippetClassification;
+  readonly failClosed: boolean;
+  readonly historicalHeadingPrefixes?: readonly string[];
+}
+
+/**
+ * Enumerated corpus (#4094). failClosed is this story's commands.md surface.
+ * Sibling owners (README, QUICK-START, getting-started, doctor) are named
+ * and not fail-closed here. Historical trees are default-historical by path.
+ */
+export const COMMAND_SNIPPET_CORPUS: readonly CommandSnippetCorpusEntry[] = [
+  {
+    path: "content/commands.md",
+    audience: "maintainer",
+    defaultClassification: "current",
+    failClosed: true,
+    historicalHeadingPrefixes: ["## Command Lifecycle:", "## Historical "],
+  },
+  {
+    path: "README.md",
+    audience: "consumer",
+    defaultClassification: "current",
+    failClosed: false,
+  },
+  {
+    path: "content/QUICK-START.md",
+    audience: "consumer",
+    defaultClassification: "current",
+    failClosed: false,
+  },
+  {
+    path: "content/docs/getting-started.md",
+    audience: "consumer",
+    defaultClassification: "current",
+    failClosed: false,
+  },
+  {
+    path: "CHANGELOG.md",
+    audience: "frozen",
+    defaultClassification: "historical",
+    failClosed: false,
+  },
+  {
+    path: "SPECIFICATION.md",
+    audience: "frozen",
+    defaultClassification: "historical",
+    failClosed: false,
+  },
+];
+
+/** Path prefixes that are historical without per-snippet annotation. */
+export const COMMAND_SNIPPET_HISTORICAL_PREFIXES = [
+  "history/",
+  "docs/analysis/",
+  "xbrief/completed/",
+] as const;
+
+/** Retired verbs kept as regression fixtures; they must not resolve public. */
+export const COMMAND_SNIPPET_KNOWN_FALSE_TASK_VERBS = [
+  "check:slow",
+  "verify:xbrief-conformance",
+  "ci:local",
+  "validate-links",
+] as const;
+
+/** Live verbs that current guidance may name only as frozen, never as public-current. */
+export const COMMAND_SNIPPET_FROZEN_TASK_VERBS = new Set(["migrate:vbrief"]);
+
+export interface CommandSnippetExemption {
+  readonly family: CommandSnippetFamily;
+  readonly verb: string;
+  readonly path: string;
+  readonly classification: Exclude<CommandSnippetClassification, "current">;
+  readonly reason: string;
+}
+
+/**
+ * Closed exemption allowlist. Empty at first ship. An addition in the same
+ * diff as the snippet it exempts fails (#4094).
+ */
+export const COMMAND_SNIPPET_EXEMPTIONS: readonly CommandSnippetExemption[] = [];
+
+export interface CommandSnippet {
+  readonly file: string;
+  readonly line: number;
+  readonly family: CommandSnippetFamily;
+  readonly verb: string;
+  readonly raw: string;
+  readonly span: CommandSnippetSpan;
+  readonly classification: CommandSnippetClassification;
+  readonly audience: CommandSnippetAudience;
+}
+
+export interface CommandSnippetResolution {
+  readonly kind: CommandSnippetRegistryKind;
+  readonly publicCurrent: boolean;
+}
+
+export interface CommandSnippetFinding {
+  readonly snippet: CommandSnippet;
+  readonly resolution: CommandSnippetResolution;
+}
+
+export interface CommandSnippetEvaluation {
+  readonly snippets: readonly CommandSnippet[];
+  readonly findings: readonly CommandSnippetFinding[];
+}
+
+export interface CommandRegistries {
+  readonly publicTasks: ReadonlySet<string>;
+  readonly internalTasks: ReadonlySet<string>;
+  readonly includeNamespaces: ReadonlySet<string>;
+  readonly preferredCli: ReadonlySet<string>;
+  readonly registeredCli: ReadonlySet<string>;
+  readonly helpCli: ReadonlySet<string>;
+  readonly deferredCli: ReadonlySet<string>;
+  readonly stubbedCli: ReadonlySet<string>;
+}
+
+const TASK_RUNNER_FLAGS_WITH_ARG = new Set([
+  "-t",
+  "--taskfile",
+  "-d",
+  "--dir",
+  "-o",
+  "--output",
+  "--concurrency",
+]);
+
+const CONSUMER_INCLUDE_PREFIX = "deft:";
+
+export function frameworkRepoRoot(): string {
+  return resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
+}
+
+function normalizeYaml(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function taskBlockIsInternal(text: string, localName: string): boolean {
+  const escaped = localName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const header = new RegExp(`^ {2}${escaped}\\s*:`, "m");
+  const match = header.exec(text);
+  if (match === null || match.index === undefined) return false;
+  const after = text.slice(match.index + match[0].length);
+  const next = after.search(/^ {2}[A-Za-z_][\w:-]*\s*:/m);
+  const body = next < 0 ? after : after.slice(0, next);
+  return /^\s+internal:\s*true\s*$/m.test(body);
+}
+
+function collectTaskKeys(text: string): string[] {
+  const keys: string[] = [];
+  const lines = normalizeYaml(text).split("\n");
+  let inTasks = false;
+  for (const line of lines) {
+    if (line.startsWith("tasks:")) {
+      inTasks = true;
+      continue;
+    }
+    if (inTasks && line.length > 0 && !line.startsWith(" ") && line.trim() !== "tasks:") {
+      inTasks = false;
+    }
+    if (!inTasks) continue;
+    const m = /^ {2}([A-Za-z_][\w:-]*)\s*:/.exec(line);
+    if (m?.[1]) keys.push(m[1]);
+  }
+  return keys;
+}
+
+function quotedStrings(block: string): string[] {
+  return [...block.matchAll(/"([^"]+)"/g)]
+    .map((m) => m[1])
+    .filter((s): s is string => s !== undefined);
+}
+
+function sliceAssignment(source: string, name: string): string {
+  const match = new RegExp(`(?:export )?const ${name}\\b[^=]*=`).exec(source);
+  if (match === null || match.index === undefined) return "";
+  const after = source.slice(match.index + match[0].length);
+  const openRel = after.search(/[[{]/);
+  if (openRel < 0) return "";
+  const origin = match.index + match[0].length + openRel;
+  const openCh = source[origin];
+  const closeCh = openCh === "[" ? "]" : "}";
+  let depth = 0;
+  let inString: string | null = null;
+  for (let i = origin; i < source.length; i += 1) {
+    const ch = source[i];
+    const prev = i > 0 ? source[i - 1] : "";
+    if (inString !== null) {
+      if (ch === inString && prev !== "\\") inString = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = ch;
+      continue;
+    }
+    if (ch === openCh) depth += 1;
+    else if (ch === closeCh) {
+      depth -= 1;
+      if (depth === 0) return source.slice(origin, i + 1);
+    }
+  }
+  return "";
+}
+
+function parseStringArrayExport(source: string, name: string): string[] {
+  return quotedStrings(sliceAssignment(source, name));
+}
+
+function parseRecordKeys(source: string, name: string): string[] {
+  return [...sliceAssignment(source, name).matchAll(/"([^"]+)"\s*:/g)]
+    .map((m) => m[1])
+    .filter((s): s is string => s !== undefined);
+}
+
+export function loadCommandRegistries(repoRoot: string): CommandRegistries {
+  const rootText = normalizeYaml(readFileSync(join(repoRoot, "Taskfile.yml"), "utf8"));
+  const publicTasks = new Set<string>();
+  const internalTasks = new Set<string>();
+  for (const key of collectTaskKeys(rootText)) {
+    if (!taskDefinedInTaskfileYaml(rootText, key)) continue;
+    if (taskBlockIsInternal(rootText, key)) internalTasks.add(key);
+    else publicTasks.add(key);
+  }
+  const includes = parseTaskfileIncludes(rootText);
+  const includeNamespaces = new Set(includes.keys());
+  for (const [namespace, include] of includes) {
+    const includePath = resolve(repoRoot, include.taskfile);
+    if (!existsSync(includePath)) continue;
+    const fragment = normalizeYaml(readFileSync(includePath, "utf8"));
+    for (const local of collectTaskKeys(fragment)) {
+      if (!taskDefinedInTaskfileYaml(fragment, local)) continue;
+      const full = `${namespace}:${local}`;
+      if (taskBlockIsInternal(fragment, local)) internalTasks.add(full);
+      else publicTasks.add(full);
+    }
+  }
+
+  const dispatch = readFileSync(join(repoRoot, "packages/cli/src/dispatch.ts"), "utf8");
+  const router = readFileSync(join(repoRoot, "packages/cli/src/cli-router/route-argv.ts"), "utf8");
+  const moduleVerbs = parseStringArrayExport(dispatch, "CLI_MODULE_VERBS");
+  const coreVerbs = parseStringArrayExport(dispatch, "CORE_MODULE_VERBS");
+  const aliasKeys = parseRecordKeys(dispatch, "VERB_ALIASES");
+  const aliasValues = [...sliceAssignment(dispatch, "VERB_ALIASES").matchAll(/:\s*"([^"]+)"/g)].map(
+    (m) => m[1],
+  );
+  const colonAliasKeys = [
+    ...parseRecordKeys(dispatch, "TRIAGE_ACTION_ALIAS_SUBCOMMANDS"),
+    ...parseRecordKeys(dispatch, "POLICY_ACTION_ALIAS_SUBCOMMANDS"),
+    ...parseRecordKeys(dispatch, "AUTHZ_ACTION_ALIAS_SUBCOMMANDS"),
+    ...parseRecordKeys(dispatch, "ESCALATION_ACTION_ALIAS_SUBCOMMANDS"),
+    ...parseRecordKeys(dispatch, "PLAN_SEQUENCE_ALIAS_SUBCOMMANDS"),
+    ...parseRecordKeys(dispatch, "PRODUCT_SIGNAL_ALIAS_SUBCOMMANDS"),
+    ...parseRecordKeys(dispatch, "FRESHNESS_ALIAS_SUBCOMMANDS"),
+  ];
+  const helpCli = new Set(
+    [...sliceAssignment(dispatch, "CURATED_HELP_GROUPS").matchAll(/name:\s*"([^"]+)"/g)]
+      .map((m) => m[1])
+      .filter((s): s is string => s !== undefined),
+  );
+  const topLevel = parseStringArrayExport(router, "TOP_LEVEL_UX_VERBS");
+  const deferredCli = new Set(quotedStrings(sliceAssignment(router, "DEFERRED_TOP_LEVEL_VERBS")));
+  const stubbedCli = new Set(quotedStrings(sliceAssignment(router, "STUBBED_TOP_LEVEL_VERBS")));
+  const scopeLocals = quotedStrings(sliceAssignment(router, "SCOPE_LIFECYCLE_VERBS"));
+  const aliasedCanonicals = new Set(aliasValues.filter((s): s is string => s !== undefined));
+  const registeredCli = new Set<string>([
+    ...moduleVerbs,
+    ...coreVerbs,
+    ...aliasKeys,
+    ...colonAliasKeys,
+    ...topLevel,
+    ...scopeLocals.map((local) => `scope:${local}`),
+    ...helpCli,
+  ]);
+  const preferredCli = new Set<string>([
+    ...topLevel.filter((verb) => !deferredCli.has(verb) && !stubbedCli.has(verb)),
+    ...aliasKeys,
+    ...colonAliasKeys,
+    ...[...moduleVerbs, ...coreVerbs].filter((verb) => !aliasedCanonicals.has(verb)),
+    ...scopeLocals.map((local) => `scope:${local}`),
+    ...[...helpCli].filter((name) => registeredCli.has(name) && !deferredCli.has(name)),
+  ]);
+
+  return {
+    publicTasks,
+    internalTasks,
+    includeNamespaces,
+    preferredCli,
+    registeredCli,
+    helpCli,
+    deferredCli,
+    stubbedCli,
+  };
+}
+
+function skipRunnerPrefix(parts: readonly string[]): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < parts.length) {
+    const token = parts[i];
+    if (token === undefined) break;
+    if (/^[A-Za-z_][\w]*=/.test(token) && !token.includes(":")) {
+      i += 1;
+      continue;
+    }
+    if (token === "--") {
+      i += 1;
+      break;
+    }
+    if (token.startsWith("-")) {
+      i += TASK_RUNNER_FLAGS_WITH_ARG.has(token) ? 2 : 1;
+      continue;
+    }
+    out.push(...parts.slice(i));
+    break;
+  }
+  return out;
+}
+
+function shouldSkipVerb(verb: string): boolean {
+  if (verb.length === 0) return true;
+  if (verb.startsWith("-")) return true;
+  if (
+    verb.endsWith(":") ||
+    verb.includes("*") ||
+    verb.includes("|") ||
+    verb.includes("<") ||
+    verb.includes(">")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function classifyByHeadings(
+  line: string,
+  defaultClassification: CommandSnippetClassification,
+  historicalPrefixes: readonly string[],
+  state: { historical: boolean },
+): CommandSnippetClassification {
+  const trimmed = line.trim();
+  if (trimmed.startsWith("#") && historicalPrefixes.some((prefix) => trimmed.startsWith(prefix))) {
+    state.historical = true;
+  }
+  if (state.historical) return "historical";
+  return defaultClassification;
+}
+
+function exemptionFor(
+  file: string,
+  family: CommandSnippetFamily,
+  verb: string,
+  exemptions: readonly CommandSnippetExemption[],
+): CommandSnippetExemption | undefined {
+  return exemptions.find(
+    (entry) => entry.path === file && entry.family === family && entry.verb === verb,
+  );
+}
+
+interface ExtractedCommand {
+  readonly family: CommandSnippetFamily;
+  readonly verb: string;
+  readonly raw: string;
+}
+
+function commandsFromTokens(parts: readonly string[]): ExtractedCommand[] {
+  const found: ExtractedCommand[] = [];
+  const rest = skipRunnerPrefix(parts);
+  const launcher = rest[0];
+  if (launcher !== "task" && launcher !== "deft" && launcher !== "directive") return found;
+  const verbToken = rest[1];
+  if (verbToken === undefined) return found;
+  let verb = verbToken;
+  if (launcher === "task" && verb.startsWith(CONSUMER_INCLUDE_PREFIX)) {
+    verb = verb.slice(CONSUMER_INCLUDE_PREFIX.length);
+  }
+  if (shouldSkipVerb(verb)) return found;
+  if (launcher === "task") {
+    found.push({ family: "task", verb, raw: `task ${verbToken}` });
+  } else {
+    found.push({ family: "cli", verb, raw: `${launcher} ${verbToken}` });
+  }
+  return found;
+}
+
+/**
+ * Extract `task` / `deft` / `directive` verbs from backtick spans and fenced
+ * lines. Same walker as C3 backticks; fences are parsed, never executed.
+ */
+export function extractCommandSnippets(
+  text: string,
+  file: string,
+  entry: Pick<
+    CommandSnippetCorpusEntry,
+    "audience" | "defaultClassification" | "historicalHeadingPrefixes"
+  >,
+  exemptions: readonly CommandSnippetExemption[] = COMMAND_SNIPPET_EXEMPTIONS,
+): CommandSnippet[] {
+  const snippets: CommandSnippet[] = [];
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const headingState = { historical: false };
+  const historicalPrefixes = entry.historicalHeadingPrefixes ?? [];
+  let inFence = false;
+
+  const push = (
+    extracted: ExtractedCommand,
+    line: number,
+    span: CommandSnippetSpan,
+    classification: CommandSnippetClassification,
+  ): void => {
+    let nextClassification = classification;
+    if (COMMAND_SNIPPET_FROZEN_TASK_VERBS.has(extracted.verb) && extracted.family === "task") {
+      nextClassification = "frozen";
+    }
+    const exempt = exemptionFor(file, extracted.family, extracted.verb, exemptions);
+    if (exempt) nextClassification = exempt.classification;
+    snippets.push({
+      file,
+      line,
+      family: extracted.family,
+      verb: extracted.verb,
+      raw: extracted.raw,
+      span,
+      classification: nextClassification,
+      audience: entry.audience,
+    });
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    const classification = classifyByHeadings(
+      line,
+      entry.defaultClassification,
+      historicalPrefixes,
+      headingState,
+    );
+    const trimmed = line.trim();
+    if (trimmed.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      const parts = trimmed
+        .replace(/^[$]\s+/, "")
+        .split(/\s+/)
+        .filter((p) => p.length > 0);
+      for (const extracted of commandsFromTokens(parts)) {
+        push(extracted, i + 1, "fence", classification);
+      }
+      continue;
+    }
+    forEachBacktickSpan(line, (inner) => {
+      const parts = inner.split(/\s+/).filter((p) => p.length > 0);
+      for (const extracted of commandsFromTokens(parts)) {
+        push(extracted, i + 1, "backtick", classification);
+      }
+    });
+  }
+  return snippets;
+}
+
+export function resolveCommandSnippet(
+  snippet: CommandSnippet,
+  registries: CommandRegistries,
+): CommandSnippetResolution {
+  if (snippet.family === "task") {
+    if (
+      !snippet.verb.includes(":") &&
+      registries.includeNamespaces.has(snippet.verb) &&
+      !registries.publicTasks.has(snippet.verb) &&
+      !registries.internalTasks.has(snippet.verb)
+    ) {
+      return { kind: "skipped", publicCurrent: false };
+    }
+    if (registries.internalTasks.has(snippet.verb)) {
+      return { kind: "taskfile-internal", publicCurrent: false };
+    }
+    if (registries.publicTasks.has(snippet.verb)) {
+      return { kind: "taskfile-public", publicCurrent: true };
+    }
+    return { kind: "absent", publicCurrent: false };
+  }
+  const hyphen = snippet.verb.replace(/:/g, "-");
+  const cliNames = snippet.verb.includes(":") ? [snippet.verb, hyphen] : [snippet.verb];
+  if (cliNames.some((name) => registries.deferredCli.has(name))) {
+    return { kind: "cli-deferred", publicCurrent: false };
+  }
+  if (cliNames.some((name) => registries.stubbedCli.has(name))) {
+    return { kind: "cli-stubbed", publicCurrent: false };
+  }
+  if (cliNames.some((name) => registries.preferredCli.has(name))) {
+    return { kind: "cli-preferred", publicCurrent: true };
+  }
+  if (cliNames.some((name) => registries.helpCli.has(name))) {
+    return {
+      kind: "cli-help",
+      publicCurrent: cliNames.some((name) => registries.registeredCli.has(name)),
+    };
+  }
+  if (cliNames.some((name) => registries.registeredCli.has(name))) {
+    return { kind: "cli-registered", publicCurrent: false };
+  }
+  return { kind: "absent", publicCurrent: false };
+}
+
+export function evaluateMarkdownCommandSnippets(options: {
+  readonly text: string;
+  readonly file: string;
+  readonly entry: CommandSnippetCorpusEntry;
+  readonly registries: CommandRegistries;
+  readonly exemptions?: readonly CommandSnippetExemption[];
+}): CommandSnippetEvaluation {
+  const snippets = extractCommandSnippets(
+    options.text,
+    options.file,
+    options.entry,
+    options.exemptions ?? COMMAND_SNIPPET_EXEMPTIONS,
+  );
+  const findings: CommandSnippetFinding[] = [];
+  for (const snippet of snippets) {
+    const resolution = resolveCommandSnippet(snippet, options.registries);
+    if (
+      options.entry.failClosed &&
+      snippet.classification === "current" &&
+      snippet.audience !== "frozen" &&
+      !resolution.publicCurrent &&
+      resolution.kind !== "skipped"
+    ) {
+      findings.push({ snippet, resolution });
+    }
+  }
+  return { snippets, findings };
+}
+
+export function evaluateCommandSnippets(options: {
+  readonly repoRoot: string;
+  readonly corpus?: readonly CommandSnippetCorpusEntry[];
+  readonly exemptions?: readonly CommandSnippetExemption[];
+}): CommandSnippetEvaluation {
+  const registries = loadCommandRegistries(options.repoRoot);
+  const snippets: CommandSnippet[] = [];
+  const findings: CommandSnippetFinding[] = [];
+  for (const entry of options.corpus ?? COMMAND_SNIPPET_CORPUS) {
+    const abs = join(options.repoRoot, entry.path);
+    if (!existsSync(abs)) continue;
+    const text = readFileSync(abs, "utf8");
+    const result = evaluateMarkdownCommandSnippets({
+      text,
+      file: entry.path,
+      entry,
+      registries,
+      exemptions: options.exemptions,
+    });
+    snippets.push(...result.snippets);
+    findings.push(...result.findings);
+  }
+  return { snippets, findings };
+}
+
+export interface SameDiffExemptionViolation {
+  readonly verb: string;
+  readonly path: string;
+  readonly family: CommandSnippetFamily;
+}
+
+function splitUnifiedDiff(diffText: string): Map<string, string> {
+  const files = new Map<string, string>();
+  const parts = diffText.split(/^diff --git /m);
+  for (const part of parts) {
+    const header = /^(?:a\/)?(\S+)\s+b\/(\S+)/.exec(part);
+    const path = header?.[2]?.replace(/^b\//, "");
+    if (!path) continue;
+    files.set(path, part);
+  }
+  return files;
+}
+
+function addedLines(fileDiff: string): string[] {
+  return fileDiff
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+/**
+ * Same-diff exemption ownership (#4094): adding an allowlist row in the same
+ * diff as the snippet it exempts fails.
+ */
+export function sameDiffExemptionViolations(
+  diffText: string,
+): readonly SameDiffExemptionViolation[] {
+  const files = splitUnifiedDiff(diffText);
+  const resolverDiff = files.get("packages/core/src/deposit/live-procedure-targets.ts") ?? "";
+  const added = addedLines(resolverDiff).join("\n");
+  const verbs = [...added.matchAll(/verb:\s*"([^"]+)"/g)].map((m) => m[1]);
+  const paths = [...added.matchAll(/path:\s*"([^"]+)"/g)].map((m) => m[1]);
+  const families = [...added.matchAll(/family:\s*"(task|cli)"/g)].map((m) => m[1]);
+  const violations: SameDiffExemptionViolation[] = [];
+  const count = Math.max(verbs.length, paths.length, families.length);
+  for (let i = 0; i < count; i += 1) {
+    const verb = verbs[i] ?? verbs[0];
+    const path = paths[i] ?? paths[0];
+    const family = (families[i] ?? families[0] ?? "task") as CommandSnippetFamily;
+    if (!verb || !path) continue;
+    const targetDiff = files.get(path) ?? "";
+    const snippetAdded = addedLines(targetDiff).some(
+      (line) =>
+        line.includes(`task ${verb}`) ||
+        line.includes(`deft ${verb}`) ||
+        line.includes(`directive ${verb}`),
+    );
+    if (snippetAdded) {
+      violations.push({ verb, path, family });
+    }
+  }
+  return violations;
+}
+
+export function formatCommandSnippetFailure(result: CommandSnippetEvaluation): string {
+  const lines = [
+    `Command-snippet contract failed: ${result.findings.length} current snippet(s) do not resolve as public commands.`,
+  ];
+  for (const finding of result.findings.slice(0, 40)) {
+    const s = finding.snippet;
+    lines.push(
+      `  ${s.file}:${s.line} ${s.raw} audience=${s.audience} span=${s.span} -> ${finding.resolution.kind}`,
+    );
+  }
+  if (result.findings.length > 40) {
+    lines.push(`  ... ${result.findings.length - 40} more`);
   }
   return lines.join("\n");
 }

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -897,6 +897,44 @@ function gitOut(repoRoot: string, args: readonly string[]): string {
   }
 }
 
+function gitOk(repoRoot: string, args: readonly string[]): boolean {
+  try {
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commitExists(repoRoot: string, spec: string): boolean {
+  return gitOk(repoRoot, ["cat-file", "-e", `${spec}^{commit}`]);
+}
+
+function maybeFetchBase(repoRoot: string, spec: string): void {
+  if (commitExists(repoRoot, spec)) return;
+  const ci = process.env.GITHUB_ACTIONS === "true" || Boolean(process.env.GITHUB_BASE_SHA?.trim());
+  if (!ci) return;
+  const token = spec.replace(/^origin\//, "");
+  if (token.length === 0) return;
+  gitOut(repoRoot, ["fetch", "--depth", "1", "origin", token]);
+}
+
+function diffAgainstBase(repoRoot: string, base: string, files: readonly string[]): string | null {
+  maybeFetchBase(repoRoot, base);
+  const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", base]).trim();
+  if (mergeBase.length > 0) {
+    return gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]);
+  }
+  if (commitExists(repoRoot, base)) {
+    return gitOut(repoRoot, ["diff", base, "HEAD", "--", ...files]);
+  }
+  return null;
+}
+
 /** Candidate diff for same-diff exemption ownership. */
 export function readCommandSnippetCandidateDiff(repoRoot: string): string {
   const files = [...COMMAND_SNIPPET_DIFF_PATHS];
@@ -912,11 +950,10 @@ export function readCommandSnippetCandidateDiff(repoRoot: string): string {
     "origin/main",
   ].filter((base) => base.length > 0);
   for (const base of bases) {
-    const mergeBase = gitOut(repoRoot, ["merge-base", "HEAD", base]).trim();
-    if (mergeBase.length === 0) continue;
-    return gitOut(repoRoot, ["diff", `${mergeBase}...HEAD`, "--", ...files]);
+    const ranged = diffAgainstBase(repoRoot, base, files);
+    if (ranged !== null) return ranged;
   }
-  // Shallow CI: no merge-base. sameDiffExemptionViolations splits git-log commits.
+  // Last resort: per-commit log. Depth-1 HEAD-only clones may miss earlier PR commits.
   return gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]);
 }
 

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -970,9 +970,16 @@ export function readCommandSnippetCandidateDiff(repoRoot: string): string {
     const ranged = diffAgainstBase(repoRoot, base, files);
     if (ranged !== null) return ranged;
   }
-  // Depth-one clones only have HEAD. A `git log -p` fallback would hide
+  // Depth-one PR checkouts only have HEAD. A `git log -p` fallback would hide
   // exemption + snippet additions from earlier PR commits (fail-open).
-  if (isShallowRepo(repoRoot)) return `${UNRESOLVED_SHALLOW_CANDIDATE_DIFF}\n`;
+  // Push-to-master CI also has origin/<default>==HEAD and no PR base metadata;
+  // failing closed there would red the live command-snippet tests on every push.
+  if (isShallowRepo(repoRoot)) {
+    if (process.env.GITHUB_EVENT_NAME?.trim() === "push") {
+      return gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]);
+    }
+    return `${UNRESOLVED_SHALLOW_CANDIDATE_DIFF}\n`;
+  }
   return gitOut(repoRoot, ["log", "-p", "-n", "50", "--", ...files]);
 }
 

--- a/packages/core/src/deposit/live-procedure-targets.ts
+++ b/packages/core/src/deposit/live-procedure-targets.ts
@@ -916,11 +916,27 @@ function commitExists(repoRoot: string, spec: string): boolean {
 
 function maybeFetchBase(repoRoot: string, spec: string): void {
   if (commitExists(repoRoot, spec)) return;
-  const ci = process.env.GITHUB_ACTIONS === "true" || Boolean(process.env.GITHUB_BASE_SHA?.trim());
+  const ci =
+    process.env.GITHUB_ACTIONS === "true" ||
+    Boolean(process.env.GITHUB_BASE_SHA?.trim()) ||
+    process.env.GITHUB_EVENT_NAME?.trim() === "push";
   if (!ci) return;
   const token = spec.replace(/^origin\//, "");
   if (token.length === 0) return;
   gitOut(repoRoot, ["fetch", "--depth", "1", "origin", token]);
+}
+
+function pushBeforeSha(): string {
+  const path = process.env.GITHUB_EVENT_PATH?.trim();
+  if (!path || !existsSync(path)) return "";
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { before?: unknown };
+    const before = typeof parsed.before === "string" ? parsed.before.trim() : "";
+    if (/^[0-9a-f]{40}$/i.test(before) && before !== "0".repeat(40)) return before;
+  } catch {
+    return "";
+  }
+  return "";
 }
 
 function headSha(repoRoot: string): string {
@@ -962,6 +978,7 @@ export function readCommandSnippetCandidateDiff(repoRoot: string): string {
   if (working.includes("diff --git")) return working;
   const bases = [
     process.env.GITHUB_BASE_SHA?.trim() ?? "",
+    pushBeforeSha(),
     process.env.GITHUB_BASE_REF?.trim() ? `origin/${process.env.GITHUB_BASE_REF.trim()}` : "",
     "origin/master",
     "origin/main",


### PR DESCRIPTION
## Summary

Current Task and CLI snippets in `content/commands.md` are checked against the live Taskfile graph and `dispatch.ts` / CLI help registries. The existing live-procedure markdown walker is extended (backticks and fences). Lookup is verb/namespace only; extracted fences are not executed. Classification is a closed set (current / historical / frozen / template / illustrative) with a maintainer vs consumer vs frozen audience key. Same-diff exemption additions fail. Task descriptions are not rewritten.

Known false examples (`check:slow`, `verify:xbrief-conformance`) are corrected in commands.md and retained as regression fixtures.

## Bound contract

Bound lean 5514050213 on #4094 (not the pass-1 issue body). Parent #4085 Wave 3.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/content-contracts`
- [x] `task verify:encoding`
- [x] Focused `command_snippets.test.ts` + existing live-procedure tests

Tracking: #4094
Refs: #4085
