### PR TITLE
chore: land leftover completed-tracked artifact for #4201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Land leftover completed-tracked artifact for #4201 (#3264 / #1358).** The #4201 xBRIEF stayed in `active/` after squash of PR 4209 (`78aaba66`). Moved to `xbrief/completed/` via scope:complete. Does not recut that issue. Refs #2321, #3476.
 - **Win32 git-fixture tests inherit a 240s suite cap under coverage contention (#3616).** `testTimeout` 120s→240s. The ingest lifecycle e2e 15s local cap is Linux-only so it does not lower the win32 cap (#4194). Does not lower `maxWorkers`. Refs #3480, #4194.
 - **Land leftover completed-tracked artifact for #4200 (#3264 / #1358).** The #4200 xBRIEF stayed in `active/` after squash of PR 4207 (`c1e038f8`). Moved to `xbrief/completed/` via scope:complete. Does not recut that issue. Refs #2321, #3476.
 - **Ingest lifecycle e2e no longer times out the merge-gate 5s default (#4194).** `preserves one minted id from ingest through promote activate complete` is 15s. Does not raise the suite default. Refs #4119, #4194.

--- a/xbrief/completed/2026-09-06-4201-rfcharness-host-grokbot-adapter-grok-botnative-consumer-faad.xbrief.json
+++ b/xbrief/completed/2026-09-06-4201-rfcharness-host-grokbot-adapter-grok-botnative-consumer-faad.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #4201",
-    "updated": "2026-09-06T02:11:35Z"
+    "updated": "2026-09-06T09:03:13Z"
   },
   "plan": {
     "title": "rfc(harness): host-grokbot adapter + Grok Bot–native consumer façade",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "rfc(harness): host-grokbot adapter + Grok Bot–native consumer façade",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4201",
@@ -16,35 +16,83 @@
     "items": [
       {
         "title": "`grok-bot` descriptor plus misclassification tests: unique signals before spawn_subagent.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — packages/core/src/review-monitor/tier-detection.test.ts + swarm/routing.test.ts grok-bot before spawn_subagent",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "`host-grokbot.md`.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — content/skills/deft-directive-swarm/references/host-grokbot.md",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "propose/launch/status docs.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — host-grokbot.md propose/launch/status facade",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "Consumer skill-pack slice points at #4202 for arc; no second arc router here.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — skills pack points arc router at #4202; no second arc skill",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "Doctor one-liner; CATEGORY.md note.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — docs/CATEGORY.md Grok Bot coding-host note",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "No normative contract bodies in thin routers.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "review",
+          "pointer": "https://github.com/deftai/directive/pull/4209 Greptile CLEAN 5/5; thin routers keep normative bodies out",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "Widgets used for Phase 0 gates preserve numbered Discuss and Back.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — host-grokbot.md Phase 0 widgets keep numbered Discuss and Back",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       },
       {
         "title": "CHANGELOG entry.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "merge",
+          "pointer": "https://github.com/deftai/directive/pull/4209 merge 78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337 — CHANGELOG.md [Unreleased] Grok Bot host entry",
+          "recorded_at": "2026-09-06T09:02:00Z",
+          "recorded_by": "agent/4201-grok-bot-adapter"
+        }
       }
     ],
     "tags": [
@@ -147,9 +195,34 @@
         "github_issue_id": 5354137174,
         "origin": "deftai/directive#4201",
         "id": "github.issue.5354137174"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4209,
+        "prBase": null,
+        "mergeCommit": "78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337",
+        "deliveryBranch": "master",
+        "deliveryCommit": "78aaba667cb61da7d0efa2f1e0ec2d7c2c5b8337",
+        "verifiedAt": "2026-09-06T09:03:13Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:grok:v1:MDFhMDc0NzQtZGMyNy03NDkzLTk0ZjYtZWRhMTQzMzY0Mzlm"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-06T09:03:13Z"
+      },
+      "completedAt": "2026-09-06T09:03:13Z",
+      "completedSessionId": "host:grok:v1:MDFhMDc0NzQtZGMyNy03NDkzLTk0ZjYtZWRhMTQzMzY0Mzlm",
+      "capacityBucket": "agentic-debt"
     },
     "id": "github.issue.5354137174",
-    "updated": "2026-09-06T02:11:35Z"
+    "updated": "2026-09-06T09:03:13Z"
   }
 }


### PR DESCRIPTION
## Summary

Land leftover completed-tracked xBRIEF for #4201 after squash of PR 4209. Does not recut that issue.

## Related Issues

Refs #4201, #3264, #3476

## Documentation impact

change_class: none
surfaces: none
rationale: "Lifecycle artifact move only; no user-facing command, skill, help, or docs-site change."

## Checklist

- [x] /deft:change <name> - N/A (post-merge lifecycle land)
- [x] CHANGELOG.md - leftover completed-tracked note under [Unreleased]
- [x] ROADMAP.md - N/A
- [x] Tests pass locally
