### PR TITLE
chore(xbrief): track completed #4137 ingest-paginate scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Land leftover completed-tracked artifact for #4137 (#3264 / #1358).** The #4137 xBRIEF stayed in `active/` after squash of PR 4223 (`c991046c`). Moved to `xbrief/completed/` via scope:complete. Does not recut that issue. Refs #2321, #3476.
 - **issue:ingest paginates comment fetch so threads over 30 comments keep synthesis (#4137).** `fetchIssueComments` walks `?per_page=100&page=N` on the same cached-get seam. Fail closed on spawn throw, non-zero, non-JSON, non-array pages, and cap exhaustion without a short terminal page. Does not call `restIssueComments` or `--paginate`. Closes #4137.
 - **parseOperatorRunPosture treats `directly` and `on github` as closed `direct` tokens (#4220).** `directive` and bare `arc N yolo` still ask. `on github` is a location synonym at the Stop 1 front door. Token array and regex stay twins. Closes #4220. Refs #4072.
 - **Land leftover completed-tracked artifact for #4203 (#3264 / #1358).** The #4203 xBRIEF stayed in `active/` after squash of PR 4214 (`c6e396a0`). Moved to `xbrief/completed/` via scope:complete. Does not recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-09-06-4137-bugintake-issueingest-comment-fetch-is-unpaginated-so-thread.xbrief.json
+++ b/xbrief/completed/2026-09-06-4137-bugintake-issueingest-comment-fetch-is-unpaginated-so-thread.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #4137",
-    "updated": "2026-09-06T15:36:51Z"
+    "updated": "2026-09-06T19:10:17Z"
   },
   "plan": {
     "title": "bug(intake): issue:ingest comment fetch is unpaginated so threads over 30 comments miss synthesis",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(intake): issue:ingest comment fetch is unpaginated so threads over 30 comments miss synthesis",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4137",
@@ -146,9 +146,34 @@
         "github_issue_id": 5329075719,
         "origin": "deftai/directive#4137",
         "id": "github.issue.5329075719"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4223,
+        "prBase": null,
+        "mergeCommit": "c991046c950d98c253a90e129a860320485488a9",
+        "deliveryBranch": "master",
+        "deliveryCommit": "c991046c950d98c253a90e129a860320485488a9",
+        "verifiedAt": "2026-09-06T19:10:17Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:grok:v1:MDFhMDc3OWEtMjc3YS03MDMyLWE5YzktNTc4MjliZmRhMzE3"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-06T19:10:17Z"
+      },
+      "completedAt": "2026-09-06T19:10:17Z",
+      "completedSessionId": "host:grok:v1:MDFhMDc3OWEtMjc3YS03MDMyLWE5YzktNTc4MjliZmRhMzE3",
+      "capacityBucket": "technical-debt"
     },
     "id": "github.issue.5329075719",
-    "updated": "2026-09-06T15:36:51Z"
+    "updated": "2026-09-06T19:10:17Z"
   }
 }


### PR DESCRIPTION
## Summary

Land leftover completed-tracked artifact for #4137. The xBRIEF stayed in `active/` after squash of PR 4223 (`c991046c`). Moved to `xbrief/completed/` via `scope:complete`. Does not recut that issue.

## Related Issues

Refs #4137, #2321, #3476, #3264.

## Documentation impact

change_class: none
surfaces: none
rationale: "Lifecycle leftover only: move an already-shipped xBRIEF from active/ to completed/ and record it in CHANGELOG."

## Checklist

- [x] `/deft:change <name>` — N/A: leftover lifecycle move, 2 files
- [x] `CHANGELOG.md` — leftover completed-tracked entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally — N/A lifecycle-only
