### PR TITLE
fix(hooks): Grok-applied spawn_subagent keeps Grok dest under vendor-compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Grok-applied spawn_subagent keeps the Grok dest contract when vendor-compat handlers run (#4272).** GROK hook-process env or the `spawn_subagent` tool applies cwd-only dest and emits no envelope rewrite even if argv `--host` is cursor or claude. Matcher-split is not the isolation. Vendor-compat handlers do not persist dest-lock; leftover-release stays on retry. Default-on vendor compat must work; `[compat.cursor] hooks = false` is not the product fix. Rewrite-shape (tool-arg `prompt` + dest `cwd`) is a backstop. Closes #4272.
+
 ### Removed
 
 ## [0.113.0] - 2026-09-08

--- a/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
+++ b/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyWorktreeOccupancy } from "../session/occupancy.js";
 import { readSpawnReservationIncarnation } from "../session/spawn-occupancy.js";
-import { decideHook, type HookPolicySeams } from "./index.js";
+import { decideHook, type HookPolicySeams, spawnToolArgUpdatedInput } from "./index.js";
 
 const temps: string[] = [];
 afterEach(() => {
@@ -321,5 +321,218 @@ describe("dest-proven implement spawn (#4215)", () => {
     );
     expect(decision).toMatchObject({ verdict: "deny", code: "read-only-deny" });
     expect(readSpawnReservationIncarnation(root, dest)).toBeNull();
+  });
+});
+
+describe("Grok-applied spawn_subagent handler-runtime identity (#4272)", () => {
+  it("applies Grok dest and emits no envelope rewrite when --host is cursor", () => {
+    const { root, dest } = destFixture();
+    const inspectRitual = vi.fn(() => STALE_RITUAL);
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: root,
+        payload: {
+          toolName: "spawn_subagent",
+          tool_input: { cwd: dest, prompt: "implement the story" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams({ inspectRitual }),
+    );
+    expect(decision).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(decision.updatedInput).toBeUndefined();
+    expect(decision.message).toContain("cannot re-root");
+    expect(inspectRitual).not.toHaveBeenCalled();
+  });
+
+  it("applies Grok dest and emits no envelope rewrite when --host is claude and GROK_HOOK_EVENT is set", () => {
+    const { root, dest } = destFixture();
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: root,
+        payload: {
+          tool_name: "spawn_subagent",
+          tool_input: { cwd: dest, prompt: "implement the story" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_HOOK_EVENT: "PreToolUse" },
+      },
+      readySeams(),
+    );
+    expect(decision).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(decision.updatedInput).toBeUndefined();
+  });
+
+  it("applies Grok dest from the spawn_subagent tool even without Grok env", () => {
+    const { root, dest } = destFixture();
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: root,
+        payload: {
+          toolName: "spawn_subagent",
+          tool_input: { cwd: dest, prompt: "implement the story" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1" },
+      },
+      readySeams(),
+    );
+    expect(decision).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(decision.updatedInput).toBeUndefined();
+  });
+
+  it("denies missing dest with Grok cwd text, not Cursor reroot text", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: { toolName: "spawn_subagent", tool_input: { prompt: "implement the story" } },
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams(),
+    );
+    expect(decision).toMatchObject({ verdict: "deny", code: "spawn-not-ready" });
+    expect(decision.message).toContain("tool_input.cwd");
+    expect(decision.message).not.toMatch(/isolation=worktree/);
+    expect(decision.message).not.toContain("worktree_path");
+  });
+
+  it("does not persist dest-lock from a vendor-compat handler on Grok-applied spawn", () => {
+    const { root, dest } = destFixture();
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: root,
+        payload: {
+          toolName: "spawn_subagent",
+          tool_input: { cwd: dest, prompt: "implement the story" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams(),
+    );
+    expect(decision).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(readSpawnReservationIncarnation(root, dest)).toBeNull();
+  });
+
+  it("leftover-releases a prior dest-lock then allows the applying Grok host", () => {
+    const { root, dest } = destFixture();
+    const payload = {
+      toolName: "spawn_subagent",
+      tool_input: { cwd: dest, prompt: "implement the story" },
+    };
+    const vendor = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: root,
+        payload,
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams(),
+    );
+    const applying = decideHook(
+      {
+        host: "grok",
+        event: "tool.before",
+        projectRoot: root,
+        payload,
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams(),
+    );
+    expect(vendor).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(applying).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(applying.updatedInput).toBeUndefined();
+    expect(readSpawnReservationIncarnation(root, dest)).not.toBeNull();
+  });
+
+  it("does not leftover-release an applying-host dest-lock from a later vendor-compat handler", () => {
+    const { root, dest } = destFixture();
+    const payload = {
+      toolName: "spawn_subagent",
+      tool_input: { cwd: dest, prompt: "implement the story" },
+    };
+    const applying = decideHook(
+      {
+        host: "grok",
+        event: "tool.before",
+        projectRoot: root,
+        payload,
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams(),
+    );
+    const firstIncarnation = readSpawnReservationIncarnation(root, dest);
+    const vendor = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: root,
+        payload,
+        environ: { DEFT_SESSION_ID: "parent-1", GROK_SESSION_ID: "grok-session-a" },
+      },
+      readySeams(),
+    );
+    expect(applying).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(vendor).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    expect(readSpawnReservationIncarnation(root, dest)).toBe(firstIncarnation);
+  });
+
+  it("keeps Cursor Task dest occupancy and envelope rewrite", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Task",
+          tool_input: { subagent_type: "generalPurpose", isolation: "worktree" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1" },
+      },
+      readySeams(),
+    );
+    expect(decision).toMatchObject({ verdict: "allow", code: "spawn-ready" });
+    const rewritten = decision.updatedInput as {
+      tool_input?: { isolation?: string; incarnation?: string };
+    };
+    expect(rewritten?.tool_input?.isolation).toBe("worktree");
+    expect(typeof rewritten?.tool_input?.incarnation).toBe("string");
+  });
+
+  it("backstop rewrite is the tool-arg object with prompt and dest cwd, not an envelope", () => {
+    const rewritten = spawnToolArgUpdatedInput(
+      {
+        tool_name: "spawn_subagent",
+        tool_input: { cwd: "/wt", prompt: "implement the story" },
+      },
+      "/wt",
+      "inc-1",
+    );
+    expect(rewritten).toMatchObject({
+      prompt: "implement the story",
+      cwd: "/wt",
+      incarnation: "inc-1",
+    });
+    expect(rewritten).not.toHaveProperty("tool_input");
+    expect(rewritten).not.toHaveProperty("tool_name");
+  });
+
+  it("backstop rewrite is undefined when prompt is missing", () => {
+    expect(
+      spawnToolArgUpdatedInput(
+        { tool_name: "spawn_subagent", tool_input: { cwd: "/wt" } },
+        "/wt",
+        "inc-1",
+      ),
+    ).toBeUndefined();
+    expect(spawnToolArgUpdatedInput(null, "/wt", "inc-1")).toBeUndefined();
   });
 });

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -1984,6 +1984,7 @@ describe("direct-write hook policy", () => {
           tool_name: "Task",
           tool_input: { subagent_type: "generalPurpose", isolation: "worktree" },
         },
+        environ: {},
       },
       readySeams(),
     );
@@ -2004,6 +2005,7 @@ describe("direct-write hook policy", () => {
           tool_name: "Task",
           tool_input: { subagent_type: "generalPurpose", isolation: "worktree" },
         },
+        environ: {},
       },
       readySeams(),
     );
@@ -2166,6 +2168,7 @@ describe("ephemeral spawn posture (#3080)", () => {
             prompt: "implement feature",
           },
         },
+        environ: {},
       },
       emptyScopeSeams(),
     );
@@ -2705,6 +2708,7 @@ describe("runtime authority policy (#1394)", () => {
           tool_name: "Task",
           tool_input: { subagent_type: "generalPurpose", isolation: "worktree" },
         },
+        environ: {},
       },
       policySeams({ ...ENABLED_POLICY, scopes: { edits: false, push: false, merge: false } }),
     );
@@ -3577,6 +3581,7 @@ describe("provider codecs", () => {
           tool_name: "Task",
           tool_input: { subagent_type: "generalPurpose", isolation: "worktree" },
         },
+        environ: {},
       },
       readySeams(),
     );
@@ -3615,6 +3620,7 @@ describe("shared hooks fixture corpus (Phase B of #2950)", () => {
         event: "tool.before",
         projectRoot: "/project",
         payload: task?.payload,
+        environ: {},
       },
       readySeams(),
     );

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -110,6 +110,7 @@ import {
   restampOwnerLivenessOnHookEvent,
 } from "./owner-liveness.js";
 import {
+  appliesGrokSpawnDestContract,
   isAssistPosture,
   isEphemeralSpawn,
   isExploreSpawn,
@@ -129,10 +130,13 @@ import { isDirectWriteTool, isMcpTool, isShellTool, isSpawnTool } from "./tools.
 
 export {
   ASSIST_SESSION_POSTURE_ENV,
+  appliesGrokSpawnDestContract,
   hookReadOnlyFromPayload,
   isAssistPosture,
   isEphemeralSpawn,
   isExploreSpawn,
+  isGrokHookProcess,
+  isGrokSpawnToolName,
   isProcessOnlyCriticSpawn,
   isReadOnlyHookContext,
 } from "./readonly.js";
@@ -1351,7 +1355,7 @@ function inspectMutationGates(
       payload: input.payload,
       payloadRoot,
       host: input.host,
-      environ,
+      environ: input.environ,
       runGit: dispatchGit,
     });
     if (!consult.allow) {
@@ -1708,15 +1712,11 @@ function inspectMutationGates(
         `Directive denied ${toolName}: spawn destination consult was missing.`,
       );
     }
-    const leftover = consult.leftoverIncarnation?.trim() ?? "";
-    if (leftover.length > 0 && consult.destPath !== null) {
-      releaseLeftoverSpawnReservation(payloadRoot, consult.destPath, leftover);
-    }
     const spawnReservation = mintImplementSpawnReservation(consult, {
       payload: input.payload,
       payloadRoot,
       host: input.host,
-      environ,
+      environ: input.environ,
       runGit: dispatchGit,
     });
     const reservation = spawnReservation.reservation;
@@ -1728,27 +1728,44 @@ function inspectMutationGates(
         `Directive denied ${toolName}: implement spawn produced no destination reservation.`,
       );
     }
-    const persisted = persistSpawnReservation(payloadRoot, reservation);
-    if (!persisted.ok) {
-      const dest = reservation.worktreePath;
-      const occupied = persisted.reason === "occupied";
-      return deny(
-        input,
-        "spawn-not-ready",
-        toolName,
-        occupied
-          ? `Directive denied spawn: destination ${dest} became occupied after consult. ` +
-              "Use another worktree."
-          : `Directive denied spawn: destination ${dest} ` +
-              "is already reserved. Own worktree means a unique reservation.",
-      );
-    }
+    const grokDest = appliesGrokSpawnDestContract({
+      host: input.host,
+      toolName,
+      payload: input.payload,
+      environ: input.environ,
+    });
     const updatedInput = spawnUpdatedInput(
       input,
       spawnReservation.reRootPath,
       spawnReservation.hostCanReroot,
       spawnReservation.incarnation ?? "",
     );
+    // Persist only on the applying host (#4272). A vendor-compat --host cursor/claude
+    // handler that rewrites can schema-fail after persist; leftover dest-lock then
+    // ghosts a retry. Do not leftover-release unless this handler will persist —
+    // otherwise a later vendor-compat pass would drop the applying host's lock.
+    const persistThisHandler = !grokDest || !hostAcceptsUpdatedInput(input.host);
+    if (persistThisHandler) {
+      const leftover = consult.leftoverIncarnation?.trim() ?? "";
+      if (leftover.length > 0 && consult.destPath !== null) {
+        releaseLeftoverSpawnReservation(payloadRoot, consult.destPath, leftover);
+      }
+      const persisted = persistSpawnReservation(payloadRoot, reservation);
+      if (!persisted.ok) {
+        const dest = reservation.worktreePath;
+        const occupied = persisted.reason === "occupied";
+        return deny(
+          input,
+          "spawn-not-ready",
+          toolName,
+          occupied
+            ? `Directive denied spawn: destination ${dest} became occupied after consult. ` +
+                "Use another worktree."
+            : `Directive denied spawn: destination ${dest} ` +
+                "is already reserved. Own worktree means a unique reservation.",
+        );
+      }
+    }
     return {
       verdict: "allow",
       code: allowCode,
@@ -1786,12 +1803,49 @@ function spawnIncarnationFromPayload(payload: unknown): string {
   return fromTop !== null ? fromTop.trim() : "";
 }
 
+/**
+ * Backstop rewrite shape for a Grok-applied spawn (#4272): the tool-arg object
+ * with required `prompt` and dest `cwd`, not a PreToolUse envelope. Host
+ * identity is "emit no rewrite"; this shape is only used if a reroot host still
+ * asks for updatedInput.
+ */
+export function spawnToolArgUpdatedInput(
+  payload: unknown,
+  reRootPath: string | null,
+  incarnation: string,
+): Readonly<Record<string, unknown>> | undefined {
+  const input = record(payload);
+  if (input === null) return undefined;
+  const toolInput = toolInputRecord(input) ?? {};
+  const prompt = fieldString(toolInput, "prompt") ?? fieldString(input, "prompt");
+  if (prompt === null) return undefined;
+  const cwd =
+    reRootPath ?? fieldString(toolInput, "cwd") ?? fieldString(toolInput, "working_directory");
+  const token = incarnation.trim();
+  const next: Record<string, unknown> = { ...toolInput, prompt };
+  if (cwd !== null) {
+    next.cwd = cwd;
+    next.working_directory = cwd;
+  }
+  if (token.length > 0) next.incarnation = token;
+  return next;
+}
+
 function spawnUpdatedInput(
   input: HookDispatchInput,
   reRootPath: string | null,
   hostCanReroot: boolean,
   incarnation: string,
 ): Readonly<Record<string, unknown>> | undefined {
+  const grokDest = appliesGrokSpawnDestContract({
+    host: input.host,
+    payload: input.payload,
+    environ: input.environ,
+  });
+  if (grokDest) {
+    if (!hostCanReroot || !hostAcceptsUpdatedInput(input.host)) return undefined;
+    return spawnToolArgUpdatedInput(input.payload, reRootPath, incarnation);
+  }
   if (!hostCanReroot || !hostAcceptsUpdatedInput(input.host)) return undefined;
   const token = incarnation.trim();
   if (token.length === 0) return undefined;
@@ -2478,7 +2532,11 @@ function routeHookDecision(
     if (
       readOnly &&
       !isExploreSpawn(input.payload) &&
-      !isProcessOnlyCriticSpawn(input.payload, { host: input.host, toolName })
+      !isProcessOnlyCriticSpawn(input.payload, {
+        host: input.host,
+        toolName,
+        environ: input.environ,
+      })
     ) {
       return deny(
         input,
@@ -2503,7 +2561,13 @@ function routeHookDecision(
     }
     // Process-only critic (`subagent_type` plan): dest consult, worktree, ritual,
     // and active-xBRIEF skip. Not the explore tool allowlist. Prompt text is not a class (#4241).
-    if (isProcessOnlyCriticSpawn(input.payload, { host: input.host, toolName })) {
+    if (
+      isProcessOnlyCriticSpawn(input.payload, {
+        host: input.host,
+        toolName,
+        environ: input.environ,
+      })
+    ) {
       return {
         verdict: "allow",
         code: "spawn-process-only-ready",

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -1355,7 +1355,7 @@ function inspectMutationGates(
       payload: input.payload,
       payloadRoot,
       host: input.host,
-      environ: input.environ,
+      environ,
       runGit: dispatchGit,
     });
     if (!consult.allow) {
@@ -1716,7 +1716,7 @@ function inspectMutationGates(
       payload: input.payload,
       payloadRoot,
       host: input.host,
-      environ: input.environ,
+      environ,
       runGit: dispatchGit,
     });
     const reservation = spawnReservation.reservation;
@@ -1732,7 +1732,7 @@ function inspectMutationGates(
       host: input.host,
       toolName,
       payload: input.payload,
-      environ: input.environ,
+      environ,
     });
     const updatedInput = spawnUpdatedInput(
       input,
@@ -1840,12 +1840,11 @@ function spawnUpdatedInput(
   const grokDest = appliesGrokSpawnDestContract({
     host: input.host,
     payload: input.payload,
-    environ: input.environ,
+    environ: input.environ ?? process.env,
   });
-  if (grokDest) {
-    if (!hostCanReroot || !hostAcceptsUpdatedInput(input.host)) return undefined;
-    return spawnToolArgUpdatedInput(input.payload, reRootPath, incarnation);
-  }
+  // Host identity: no rewrite. spawnToolArgUpdatedInput is the backstop shape
+  // if a future reroot path emits updatedInput for Grok-applied spawn.
+  if (grokDest) return undefined;
   if (!hostCanReroot || !hostAcceptsUpdatedInput(input.host)) return undefined;
   const token = incarnation.trim();
   if (token.length === 0) return undefined;
@@ -2535,7 +2534,7 @@ function routeHookDecision(
       !isProcessOnlyCriticSpawn(input.payload, {
         host: input.host,
         toolName,
-        environ: input.environ,
+        environ,
       })
     ) {
       return deny(
@@ -2565,7 +2564,7 @@ function routeHookDecision(
       isProcessOnlyCriticSpawn(input.payload, {
         host: input.host,
         toolName,
-        environ: input.environ,
+        environ,
       })
     ) {
       return {

--- a/packages/core/src/hooks/readonly.test.ts
+++ b/packages/core/src/hooks/readonly.test.ts
@@ -285,6 +285,7 @@ describe("process-only critic spawn (#4241)", () => {
     expect(isGrokHookProcess({ GROK_SESSION_ID: "grok-session-a" })).toBe(true);
     expect(isGrokHookProcess({ GROK_HOOK_EVENT: "PreToolUse" })).toBe(true);
     expect(isGrokHookProcess({})).toBe(false);
+    expect(isGrokHookProcess({ GROK_SESSION_ID: " " })).toBe(false);
     expect(
       appliesGrokSpawnDestContract({
         host: "cursor",

--- a/packages/core/src/hooks/readonly.test.ts
+++ b/packages/core/src/hooks/readonly.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   ASSIST_SESSION_POSTURE_ENV,
+  appliesGrokSpawnDestContract,
   hookReadOnlyFromPayload,
   isAssistPosture,
   isEphemeralSpawn,
   isExploreSpawn,
+  isGrokHookProcess,
   isProcessOnlyCriticSpawn,
   isReadOnlyHookContext,
 } from "./readonly.js";
@@ -277,6 +279,52 @@ describe("process-only critic spawn (#4241)", () => {
         { host: "grok", toolName: "Task" },
       ),
     ).toBe(false);
+  });
+
+  it("treats GROK_SESSION_ID on the hook environ and spawn_subagent as Grok dest identity (#4272)", () => {
+    expect(isGrokHookProcess({ GROK_SESSION_ID: "grok-session-a" })).toBe(true);
+    expect(isGrokHookProcess({ GROK_HOOK_EVENT: "PreToolUse" })).toBe(true);
+    expect(isGrokHookProcess({})).toBe(false);
+    expect(
+      appliesGrokSpawnDestContract({
+        host: "cursor",
+        toolName: "spawn_subagent",
+        environ: {},
+      }),
+    ).toBe(true);
+    expect(
+      appliesGrokSpawnDestContract({
+        host: "cursor",
+        toolName: "Task",
+        environ: {},
+      }),
+    ).toBe(false);
+    expect(
+      appliesGrokSpawnDestContract({
+        host: "cursor",
+        toolName: "Task",
+        environ: { GROK_SESSION_ID: "grok-session-a" },
+      }),
+    ).toBe(true);
+  });
+
+  it("skips dest occupancy for Grok-applied spawn_subagent plan even when argv host is cursor (#4272)", () => {
+    expect(
+      isProcessOnlyCriticSpawn(
+        { tool_name: "spawn_subagent", tool_input: { subagent_type: "plan" } },
+        {
+          host: "cursor",
+          toolName: "spawn_subagent",
+          environ: { GROK_SESSION_ID: "grok-session-a" },
+        },
+      ),
+    ).toBe(true);
+    expect(
+      isProcessOnlyCriticSpawn(
+        { tool_name: "spawn_subagent", tool_input: { subagent_type: "plan" } },
+        { host: "claude", toolName: "spawn_subagent" },
+      ),
+    ).toBe(true);
   });
 });
 

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -271,25 +271,65 @@ const GROK_SPAWN_TOOL_NORMALIZED = "spawnsubagent";
 export interface ProcessOnlyCriticSpawnContext {
   readonly host: string;
   readonly toolName?: string | null;
+  readonly environ?: NodeJS.ProcessEnv;
 }
 
 function normalizedHookToolName(toolName: string): string {
   return toolName.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+export function isGrokSpawnToolName(toolName: string | null | undefined): boolean {
+  if (typeof toolName !== "string" || toolName.trim().length === 0) return false;
+  return normalizedHookToolName(toolName) === GROK_SPAWN_TOOL_NORMALIZED;
+}
+
+/**
+ * Grok hook-process identity (#4272). `GROK_HOOK_EVENT` is injected into every
+ * Grok hook process. `GROK_SESSION_ID` is read from the hook environ object
+ * when the caller supplied one — not from ambient `process.env`, so a Grok
+ * TUI test runner does not flip Cursor Task dest occupancy.
+ */
+export function isGrokHookProcess(environ?: NodeJS.ProcessEnv): boolean {
+  if (environ == null) {
+    return Boolean(process.env.GROK_HOOK_EVENT?.trim());
+  }
+  return Boolean(environ.GROK_HOOK_EVENT?.trim() || environ.GROK_SESSION_ID?.trim());
+}
+
+export interface GrokSpawnDestContractInput {
+  readonly host: string;
+  readonly toolName?: string | null;
+  readonly payload?: unknown;
+  readonly environ?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Handler-runtime identity for Grok dest occupancy (#4272).
+ * True when argv host is grok, the hook process is Grok, or the tool is
+ * `spawn_subagent` (Grok aliases Task onto the shared Cursor/Claude deposit).
+ */
+export function appliesGrokSpawnDestContract(input: GrokSpawnDestContractInput): boolean {
+  if (input.host === "grok") return true;
+  if (isGrokHookProcess(input.environ)) return true;
+  if (isGrokSpawnToolName(input.toolName)) return true;
+  const payload = record(input.payload);
+  if (payload === null) return false;
+  return isGrokSpawnToolName(fieldString(payload, "tool_name") ?? fieldString(payload, "toolName"));
+}
+
 /**
  * Process-only critic spawn: dest occupancy skip without the explore tool allowlist (#4241).
- * True only on the verified Grok `spawn_subagent` surface when structural
+ * True on the verified Grok `spawn_subagent` surface when structural
  * `subagent_type`/`subagentType` === `plan` (the field Grok PreToolUse stdin
- * actually contains). Other hosts and other spawn tools stay implement-class.
- * Prompt text is never a class. Implement envelope signals win, so a parent
- * cannot opt an implement worker in.
+ * actually contains). Handler-runtime identity (#4272) applies this skip when
+ * argv `--host` is cursor or claude and the tool is still `spawn_subagent`.
+ * Other spawn tools stay implement-class. Prompt text is never a class.
+ * Implement envelope signals win, so a parent cannot opt an implement worker in.
  */
 export function isProcessOnlyCriticSpawn(
   payload: unknown,
   context: ProcessOnlyCriticSpawnContext,
 ): boolean {
-  if (context.host !== "grok") return false;
   const input = record(payload);
   if (input === null) return false;
   const toolName =
@@ -298,7 +338,15 @@ export function isProcessOnlyCriticSpawn(
       : null) ??
     fieldString(input, "tool_name") ??
     fieldString(input, "toolName");
-  if (toolName === null || normalizedHookToolName(toolName) !== GROK_SPAWN_TOOL_NORMALIZED) {
+  if (!isGrokSpawnToolName(toolName)) return false;
+  if (
+    !appliesGrokSpawnDestContract({
+      host: context.host,
+      toolName,
+      payload,
+      environ: context.environ,
+    })
+  ) {
     return false;
   }
   const toolInput = toolInputRecord(input) ?? input;

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -290,10 +290,8 @@ export function isGrokSpawnToolName(toolName: string | null | undefined): boolea
  * TUI test runner does not flip Cursor Task dest occupancy.
  */
 export function isGrokHookProcess(environ?: NodeJS.ProcessEnv): boolean {
-  if (environ == null) {
-    return Boolean(process.env.GROK_HOOK_EVENT?.trim());
-  }
-  return Boolean(environ.GROK_HOOK_EVENT?.trim() || environ.GROK_SESSION_ID?.trim());
+  const env = environ ?? process.env;
+  return Boolean(env.GROK_HOOK_EVENT?.trim() || env.GROK_SESSION_ID?.trim());
 }
 
 export interface GrokSpawnDestContractInput {

--- a/packages/core/src/session/spawn-occupancy.test.ts
+++ b/packages/core/src/session/spawn-occupancy.test.ts
@@ -102,6 +102,7 @@ describe("evaluateImplementSpawnOccupancy (#4066)", () => {
       payload: { tool_name: "Task", tool_input: { isolation: "worktree", prompt: "build" } },
       payloadRoot: root,
       host: "claude",
+      environ: {},
     });
     expect(decision.allow).toBe(true);
     if (decision.allow) {
@@ -118,6 +119,7 @@ describe("evaluateImplementSpawnOccupancy (#4066)", () => {
         payload: { tool_name: "Task", tool_input: { isolation: "worktree", prompt: "build" } },
         payloadRoot: root,
         host: "claude",
+        environ: {},
       });
       expect(second.allow).toBe(true);
       if (second.allow && second.reservation !== null) {
@@ -821,6 +823,7 @@ describe("consultImplementSpawnOccupancy (#4215)", () => {
       payloadRoot: root,
       host: "claude",
       parentId: "parent-1",
+      environ: {},
     });
     expect(decision.allow).toBe(true);
     if (decision.allow) expect(decision.destProven).toBe(false);

--- a/packages/core/src/session/spawn-occupancy.test.ts
+++ b/packages/core/src/session/spawn-occupancy.test.ts
@@ -9,6 +9,7 @@ import {
   allocatedWorktreeMatches,
   consultImplementSpawnOccupancy,
   evaluateImplementSpawnOccupancy,
+  GROK_VENDOR_COMPAT_HOOKS_DISABLE_REFUSE,
   inspectSpawnDestination,
   mintImplementSpawnReservation,
   persistSpawnReservation,
@@ -823,6 +824,78 @@ describe("consultImplementSpawnOccupancy (#4215)", () => {
     });
     expect(decision.allow).toBe(true);
     if (decision.allow) expect(decision.destProven).toBe(false);
+  });
+});
+
+describe("Grok dest contract under vendor-compat argv host (#4272)", () => {
+  it("uses cwd-only dest when argv host is cursor and the tool is spawn_subagent", () => {
+    const root = mkdtempSync(join(tmpdir(), "spawn-occ-4272-cursor-"));
+    temps.push(root);
+    gitInit(root);
+    const dest = join(root, "wt");
+    addLinkedWorktree(root, dest);
+    const decision = consultImplementSpawnOccupancy({
+      payload: {
+        tool_name: "spawn_subagent",
+        tool_input: { cwd: dest, prompt: "implement" },
+      },
+      payloadRoot: root,
+      host: "cursor",
+      parentId: "parent-1",
+      environ: { GROK_SESSION_ID: "grok-session-a" },
+    });
+    expect(decision.allow).toBe(true);
+    if (decision.allow) {
+      expect(decision.hostCanReroot).toBe(false);
+      expect(decision.destProven).toBe(true);
+      expect(decision.message).toContain("cannot re-root");
+    }
+  });
+
+  it("occupancy-denies extra dest keys on spawn_subagent even when argv host is cursor", () => {
+    const root = mkdtempSync(join(tmpdir(), "spawn-occ-4272-extra-"));
+    temps.push(root);
+    gitInit(root);
+    const dest = join(root, "wt");
+    addLinkedWorktree(root, dest);
+    const decision = consultImplementSpawnOccupancy({
+      payload: {
+        tool_name: "spawn_subagent",
+        tool_input: { cwd: dest, worktree_path: dest, prompt: "implement" },
+      },
+      payloadRoot: root,
+      host: "cursor",
+      parentId: "parent-1",
+    });
+    expect(decision.allow).toBe(false);
+    if (!decision.allow) {
+      expect(decision.reason).toBe("invalid-extra-destination");
+      expect(decision.message).toContain("cwd");
+      expect(decision.message).toContain("invalid on Grok");
+    }
+  });
+
+  it("keeps Cursor Task isolation=worktree reroot when Grok dest does not apply", () => {
+    const root = mkdtempSync(join(tmpdir(), "spawn-occ-4272-task-"));
+    temps.push(root);
+    const decision = consultImplementSpawnOccupancy({
+      payload: { tool_name: "Task", tool_input: { isolation: "worktree", prompt: "build" } },
+      payloadRoot: root,
+      host: "cursor",
+      parentId: "parent-1",
+      environ: {},
+    });
+    expect(decision.allow).toBe(true);
+    if (decision.allow) expect(decision.hostCanReroot).toBe(true);
+  });
+
+  it("recuts the vendor-compat disable refuse: default-on compat must work", () => {
+    expect(GROK_VENDOR_COMPAT_HOOKS_DISABLE_REFUSE.toLowerCase()).toContain(
+      "default-on vendor compat must work",
+    );
+    expect(GROK_VENDOR_COMPAT_HOOKS_DISABLE_REFUSE.toLowerCase()).not.toContain(
+      "drop cursor hooks",
+    );
   });
 });
 

--- a/packages/core/src/session/spawn-occupancy.ts
+++ b/packages/core/src/session/spawn-occupancy.ts
@@ -20,7 +20,7 @@ import {
   containedWrite,
 } from "../fs/contained-write.js";
 import { fieldPresent, fieldString, record, toolInputRecord } from "../hooks/classify/payload.js";
-import { isProcessOnlyCriticSpawn } from "../hooks/readonly.js";
+import { appliesGrokSpawnDestContract, isProcessOnlyCriticSpawn } from "../hooks/readonly.js";
 import {
   type ChildOccupancyDispatchInput,
   type ChildOccupancyRecord,
@@ -100,6 +100,14 @@ export type SpawnOccupancyConsult = SpawnOccupancyConsultAllow | SpawnOccupancyC
 
 const HOSTS_THAT_REROOT = new Set(["claude", "cursor", "codex"]);
 const GROK_EXTRA_DEST_KEYS = ["worktree_path", "worktreePath", "worktree"] as const;
+
+/**
+ * #4272: `[compat.cursor] hooks = false` is not the product fix. That flag
+ * only stops Grok from scanning Cursor hook files; Cursor IDE still loads
+ * them. Refuse it because default-on vendor compat must work.
+ */
+export const GROK_VENDOR_COMPAT_HOOKS_DISABLE_REFUSE =
+  "Default-on vendor compat must work; do not set [compat.cursor] hooks = false as the product fix.";
 
 function looksLikePath(value: string): boolean {
   if (value.length === 0) return false;
@@ -320,8 +328,13 @@ export function consultImplementSpawnOccupancy(
   const environ = input.environ ?? process.env;
   const runGit = input.runGit ?? defaultGitRunner;
   const parentId = (input.parentId?.trim() || parentIdFromEnv(environ)).trim() || "none";
-  const hostCanReroot = HOSTS_THAT_REROOT.has(input.host);
-  if (isProcessOnlyCriticSpawn(input.payload, { host: input.host })) {
+  const grokHost = appliesGrokSpawnDestContract({
+    host: input.host,
+    payload: input.payload,
+    environ: input.environ,
+  });
+  const hostCanReroot = HOSTS_THAT_REROOT.has(input.host) && !grokHost;
+  if (isProcessOnlyCriticSpawn(input.payload, { host: input.host, environ: input.environ })) {
     return {
       allow: true,
       destProven: false,
@@ -336,7 +349,6 @@ export function consultImplementSpawnOccupancy(
       leftoverIncarnation: null,
     };
   }
-  const grokHost = input.host === "grok";
   const grokCwd = grokHost ? grokCwdPath(input.payload) : null;
 
   if (grokHost) {
@@ -523,7 +535,13 @@ export function mintImplementSpawnReservation(
     parentId,
     occupancyOwner: parentId,
     worktreePath: destPath ?? join(payloadRoot, ".deft", "spawn-pending", incarnation),
-    identitySourceKind: input.host === "grok" ? "host-env" : "payload",
+    identitySourceKind: appliesGrokSpawnDestContract({
+      host: input.host,
+      payload: input.payload,
+      environ: input.environ,
+    })
+      ? "host-env"
+      : "payload",
     incarnation,
     provenance: "dispatch",
   };
@@ -556,7 +574,7 @@ export function evaluateImplementSpawnOccupancy(
       message: consult.message,
     };
   }
-  if (isProcessOnlyCriticSpawn(input.payload, { host: input.host })) {
+  if (isProcessOnlyCriticSpawn(input.payload, { host: input.host, environ: input.environ })) {
     return {
       allow: true,
       destination: consult.destination,

--- a/packages/core/src/session/spawn-occupancy.ts
+++ b/packages/core/src/session/spawn-occupancy.ts
@@ -221,7 +221,8 @@ function grokMissingDestMessage(): string {
     "Directive denied implement-class spawn: no worktree destination on the spawn payload " +
     "(tool_input.cwd). Spawned mutating work takes its own worktree; do not inherit the " +
     "parent checkout. Grok spawn_subagent cannot rewrite input -- pass cwd to a reserved " +
-    "linked worktree before the spawn primitive."
+    "linked worktree before the spawn primitive. " +
+    GROK_VENDOR_COMPAT_HOOKS_DISABLE_REFUSE
   );
 }
 

--- a/xbrief/active/2026-09-08-4272-bughooks-harness-grok-build-spawn-subagent-hits-cursor-compat.xbrief.json
+++ b/xbrief/active/2026-09-08-4272-bughooks-harness-grok-build-spawn-subagent-hits-cursor-compat.xbrief.json
@@ -1,0 +1,187 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Handwritten Recut ingest from successor lean 5591348099 for GitHub issue #4272 (#4258 harvest hole)",
+    "updated": "2026-09-08T20:38:59Z"
+  },
+  "plan": {
+    "title": "bug(hooks,harness): Grok Build spawn_subagent hits Cursor-compat rewrite; updated_input drops required prompt",
+    "status": "running",
+    "narratives": {
+      "Description": "Grok-applied spawn_subagent still runs Cursor dest occupancy and envelope rewrite under default vendor-compat. Isolation is handler-runtime identity, not matcher-split.",
+      "Origin": "Handwritten Recut ingest from https://github.com/deftai/directive/issues/4272 successor lean 5591348099. Not issue:ingest (#4258).",
+      "Overview": "## Recut of the filed body\n\nHandwritten ingest from the bound successor-lean Bound-remedy. Not issue:ingest. #4258: Recut harvest still maps plan.items and stated acceptance from the GitHub body; extractPlanItems cannot see a Bound-remedy numbered list. Body PATCH as the ingest path is the #4254 trap and is rejected on #4258. Do not restamp design-critique:mechanism-shaped.\n\nBound by successor lean 5591348099, verified-claims table 5591394437, and synthesis 5591397893 (dispatch SHA 37c306e8c223d0eb5231acc400ac4a07b64b4521). That arc accepted all four classified headings. The filed matcher-split-as-root repair is withdrawn.\n\n## Problem\n\nOn Grok Build TUI, implement-class spawn_subagent into a dest-proven linked worktree does not start. Grok merges Cursor and Claude hook files by default. Directive deposits one SPAWN_HOOK_MATCHER including spawn_subagent onto those files. Cursor occupancy and rewrite then run against Grok spawn_subagent. Cursor updated_input is a PreToolUse envelope; Grok applies it as tool args and schema-fails missing field prompt.\n\nRound-1 critic 5591333464: matcher-split-as-root does not isolate, because Grok aliases Task to spawn_subagent on the shared deposit file. Isolation is inside the handler.\n\n## Field instance\n\nGrok Build TUI, deftai/directive, 2026-09-08, origin/master 37c306e8, @deftai/directive@0.113.0. Native spawn_subagent with cwd to a dest-proven worktree: Hook denied, updatedInput failed the tool schema, missing field prompt. Same fail re-measured when dispatching this arc critic.\n\n## What to build\n\nThe next-build contract is the Bound-remedy of lean 5591348099 (plan.items below). Not the filed Product repair numbered list.\n\n## Rejected\n\n- Matcher-split-as-root (literal spawn_subagent removed from Cursor/Claude matchers) as the isolation\n- issue:ingest of the GitHub body (#4258 harvest hole)\n- GitHub body PATCH as the ingest path (#4254 trap)\n- [compat.cursor] hooks = false as the product fix\n- Teaching Grok isolation=worktree\n- Folding #4219 CLI grok --cwd classification\n\n## Related\n\n- #4066 #4215 (closed) dest cwd-only\n- #4241 (closed) plan skip is grok-host-only\n- #4219 (open) CLI classification; do not fold\n- #4254 (closed) dest-lock after first allow; leftover lock is in scope here\n- #3987 (closed) matcher cousin\n- #4258 Recut harvest mapper; why this ingest is handwritten",
+      "Labels": "bug, swarm, agent-experience, process, grok-build, harness, design-critique:recut-needed",
+      "UserStory": "As a Grok Build orchestrator, I want dest-proven cwd-only spawn_subagent to start a child under default Cursor/Claude hook compat, so that through-merge workers dispatch without an envelope rewrite dropping required prompt.",
+      "ImplementationPlan": "In dispatcher and spawn occupancy, when GROK_SESSION_ID or GROK_HOOK_EVENT is present or the tool is spawn_subagent, apply the Grok dest contract and do not emit envelope updatedInput even if argv --host is cursor or claude. Persist dest-lock only after the applying host accepted the input, or clean leftover locks. Keep rewrite-shape as a backstop (tool-arg object with prompt and cwd). Tests at packages/core/src/hooks and spawn-occupancy. CHANGELOG [Unreleased]. Do not treat matcher token subtraction as the close."
+    },
+    "items": [
+      {
+        "title": "When the hook process is Grok (GROK_SESSION_ID / GROK_HOOK_EVENT) or the tool is spawn_subagent, apply the Grok dest contract and emit no envelope rewrite, even if argv --host is cursor or claude. Do not bind matcher-split-as-root.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Observable: When the hook process is Grok (GROK_SESSION_ID / GROK_HOOK_EVENT) or the tool is spawn_subagent, apply the Grok dest contract and emit no envelope rewrite, even if argv --host is cursor or claude. Do not bind matcher-split-as-root. A failing test or named refuse proves the gap; a passing fixture proves the close.",
+          "Traces": "accepted successor lean 5591348099"
+        }
+      },
+      {
+        "title": "Drop the literal-token AC disjunct. The test is behavioral: Grok-applied spawn_subagent does not run Cursor dest occupancy and does not emit an envelope rewrite.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Observable: Drop the literal-token AC disjunct. The test is behavioral: Grok-applied spawn_subagent does not run Cursor dest occupancy and does not emit an envelope rewrite. A failing test or named refuse proves the gap; a passing fixture proves the close.",
+          "Traces": "accepted successor lean 5591348099"
+        }
+      },
+      {
+        "title": "This repair owns leftover dest-lock cleanup, or persist-only after the host that applies the tool has accepted the input. Do not bind the not-4254 exclusion as a scope cut.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Observable: This repair owns leftover dest-lock cleanup, or persist-only after the host that applies the tool has accepted the input. Do not bind the not-4254 exclusion as a scope cut. A failing test or named refuse proves the gap; a passing fixture proves the close.",
+          "Traces": "accepted successor lean 5591348099"
+        }
+      },
+      {
+        "title": "Recut the [compat.cursor] hooks = false blast-radius sentence. The refuse reason is that default-on vendor compat must work.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Observable: Recut the [compat.cursor] hooks = false blast-radius sentence. The refuse reason is that default-on vendor compat must work. A failing test or named refuse proves the gap; a passing fixture proves the close.",
+          "Traces": "accepted successor lean 5591348099"
+        }
+      },
+      {
+        "title": "Rewrite-shape (updatedInput as the tool-arg object with prompt and dest cwd) stays a backstop, not host identity.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Observable: Rewrite-shape (updatedInput as the tool-arg object with prompt and dest cwd) stays a backstop, not host identity. A failing test or named refuse proves the gap; a passing fixture proves the close.",
+          "Traces": "accepted successor lean 5591348099"
+        }
+      },
+      {
+        "title": "CHANGELOG [Unreleased] entry",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Observable: CHANGELOG [Unreleased] entry A failing test or named refuse proves the gap; a passing fixture proves the close.",
+          "Traces": "accepted successor lean 5591348099"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "swarm",
+      "agent-experience",
+      "process",
+      "grok-build",
+      "harness",
+      "design-critique:recut-needed"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/4272",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #4272"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/4272#issuecomment-5591348099",
+        "type": "x-xbrief/refs",
+        "title": "successor lean 5591348099"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/4258",
+        "type": "x-xbrief/refs",
+        "title": "Issue #4258 Recut harvest hole"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [],
+      "literal_acceptance_rejected": [],
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/hooks/dispatcher.test.ts packages/core/src/hooks/dispatcher-spawn-dest.test.ts packages/core/src/session/spawn-occupancy.test.ts packages/core/src/hooks/readonly.test.ts"
+        ],
+        "expected_outputs": [
+          "Grok-applied spawn_subagent uses Grok dest contract despite --host cursor/claude",
+          "no envelope updated_input on that path",
+          "CHANGELOG #4272"
+        ],
+        "depends_on": [],
+        "conflict_group": "4272-spawn-host-identity",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "Handwritten Recut ingest; AC traces the accepted successor lean rather than a specification FR id."
+      },
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [
+          "packages/core/src/hooks/dispatcher.ts",
+          "packages/core/src/session/spawn-occupancy.ts",
+          "packages/core/src/hooks/readonly.ts"
+        ],
+        "module_boundary": "packages/core/src/hooks"
+      },
+      "x-directive/plan-id": {
+        "version": 1,
+        "source": "github-rest-id",
+        "github_issue_id": 5391354959,
+        "origin": "deftai/directive#4272",
+        "id": "github.issue.5391354959"
+      },
+      "kind": "story"
+    },
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 6 independently testable clauses from the Bound-remedy task statement before product edit (#3323); handwritten because #4258 Recut harvest is not landed",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "When the hook process is Grok (GROK_SESSION_ID / GROK_HOOK_EVENT) or the tool is spawn_subagent, apply the Grok dest contract and emit no envelope rewrite, even if argv --host is cursor or claude. Do not bind matcher-split-as-root.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "Drop the literal-token AC disjunct. The test is behavioral: Grok-applied spawn_subagent does not run Cursor dest occupancy and does not emit an envelope rewrite.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "This repair owns leftover dest-lock cleanup, or persist-only after the host that applies the tool has accepted the input. Do not bind the not-4254 exclusion as a scope cut.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 4,
+          "text": "Recut the [compat.cursor] hooks = false blast-radius sentence. The refuse reason is that default-on vendor compat must work.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 5,
+          "text": "Rewrite-shape (updatedInput as the tool-arg object with prompt and dest cwd) stays a backstop, not host identity.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 6,
+          "text": "CHANGELOG [Unreleased] entry",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "id": "github.issue.5391354959",
+    "updated": "2026-09-08T20:38:59Z"
+  }
+}


### PR DESCRIPTION
## Summary

Grok-applied spawn_subagent was hitting Cursor-compat occupancy and envelope rewrite when Grok loaded .cursor/hooks.json / .claude/settings.json (default vendor-compat on). Isolation is handler-runtime identity, not matcher-split.

- When the hook process is Grok (GROK_SESSION_ID / GROK_HOOK_EVENT) or the tool is spawn_subagent, apply the Grok dest contract (cwd-only) and emit no envelope rewrite, even if argv --host is cursor or claude.
- Behavioral tests: that path does not run Cursor dest occupancy and does not emit updatedInput.
- Vendor-compat handlers do not persist dest-lock; leftover-release stays on the applying host. Cursor Task reroot rewrite is unchanged.
- [compat.cursor] hooks = false is not the product fix; default-on vendor compat must work.
- Rewrite-shape (tool-arg prompt + dest cwd) is a backstop, not host identity.

## Related Issues

Closes #4272

## Documentation impact

change_class: none
surfaces: none
rationale: "Hook-runtime dest identity; operator-visible CHANGELOG Unreleased only. No command, skill-trigger, help, or docs-site page added or removed."

## Checklist

- [x] `/deft:change <name>` — N/A: scoped bugfix on hook/occupancy files, not a new `/deft:change` proposal
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A: Unreleased CHANGELOG is the release-notes surface
- [x] Tests pass locally (iteration-lane Recut suites)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed.
