### PR TITLE
fix(hooks): dest-missing deny names inspect keys and shared recoveries (#4279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cursor dest-missing deny names inspectSpawnDestination keys and shared recoveries (#4279).** Parent continues, assist/ephemeral, and plan lead; explore is only for actually read-only spawns. Ritual notes on dest-missing are telemetry, not a recovery. Unmarked generalPurpose stays implement. Cursor Task isolation-key bind stays unbound until a PreToolUse measurement. Closes #4279.
 - **Yolo on the launching utterance confirms a posted all-accept design-critique map (#4308).** Standing for the arc; confirm conjunct only. `arc N yolo` still asks run posture. Recut-shaped maps stamp; ingest stays later. Closes #4308.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Cursor dest-missing deny names inspectSpawnDestination keys and shared recoveries (#4279).** Parent continues, assist/ephemeral, and plan lead; explore is only for actually read-only spawns. Ritual notes on dest-missing are telemetry, not a recovery. Unmarked generalPurpose stays implement. Cursor Task isolation-key bind stays unbound until a PreToolUse measurement. Closes #4279.
+- **Cursor dest-missing deny names inspectSpawnDestination keys and shared recoveries (#4279).** Parent continues, assist/ephemeral, and plan lead on dest-missing; explore leads only on an already read-only spawn deny. Ritual notes on dest-missing are telemetry, not a recovery. Unmarked generalPurpose stays implement. Cursor Task isolation-key bind stays unbound until a PreToolUse measurement. Closes #4279.
 - **Yolo on the launching utterance confirms a posted all-accept design-critique map (#4308).** Standing for the arc; confirm conjunct only. `arc N yolo` still asks run posture. Recut-shaped maps stamp; ingest stays later. Closes #4308.
 
 ### Removed

--- a/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
+++ b/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
@@ -4,10 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyWorktreeOccupancy } from "../session/occupancy.js";
-import {
-  readSpawnReservationIncarnation,
-  SPAWN_DEST_PATH_KEYS,
-} from "../session/spawn-occupancy.js";
+import { readSpawnReservationIncarnation } from "../session/spawn-occupancy.js";
 import { decideHook, type HookPolicySeams, spawnToolArgUpdatedInput } from "./index.js";
 import { isExploreSpawn, SPAWN_CLASS_RECOVERY } from "./readonly.js";
 
@@ -619,7 +616,7 @@ describe("Cursor Task dest-missing deny honesty (#4279)", () => {
   it("keeps unmarked generalPurpose fail-closed and does not lead recoveries with explore", () => {
     const inspectRitual = vi.fn(() => ({
       ...STALE_RITUAL,
-      message: "session ritual state is stale (older than 4h). Run deft session:start --rearm",
+      message: "ritual state is stale (older than 4h). Rearm does not clear dest-missing.",
     }));
     const decision = decideHook(
       {
@@ -640,12 +637,20 @@ describe("Cursor Task dest-missing deny honesty (#4279)", () => {
     const exploreIdx = decision.message.search(/subagent_type explore/i);
     expect(parentIdx).toBeGreaterThanOrEqual(0);
     expect(exploreIdx).toBeGreaterThan(parentIdx);
-    for (const key of SPAWN_DEST_PATH_KEYS) {
+    for (const key of [
+      "worktree_path",
+      "worktreePath",
+      "worktree",
+      "cwd",
+      "working_directory",
+      "workingDirectory",
+      "workdir",
+    ]) {
       expect(decision.message).toContain(key);
     }
     expect(decision.message).toContain("tool_input.isolation=worktree");
     expect(decision.message).toContain("ritual telemetry (does not clear dest-missing)");
-    expect(decision.message).toContain("session:start --rearm");
+    expect(decision.message).toContain("ritual state is stale");
     expect(decision.message).not.toMatch(/Also ritual-not-ready:/);
     expect(inspectRitual).toHaveBeenCalled();
   });

--- a/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
+++ b/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
@@ -679,7 +679,7 @@ describe("Cursor Task dest-missing deny honesty (#4279)", () => {
     expect(decision).toMatchObject({ verdict: "deny", code: "spawn-not-ready" });
   });
 
-  it("shares the same recovery set on the read-only spawn deny", () => {
+  it("shares the recovery inventory on the read-only spawn deny, explore first", () => {
     const decision = decideHook(
       {
         host: "cursor",
@@ -694,10 +694,12 @@ describe("Cursor Task dest-missing deny honesty (#4279)", () => {
       readySeams(),
     );
     expect(decision).toMatchObject({ verdict: "deny", code: "read-only-deny" });
-    expect(decision.message).toContain(SPAWN_CLASS_RECOVERY);
+    expect(decision.message).toMatch(/subagent_type explore/);
+    expect(decision.message).toMatch(/subagent_type plan/);
+    expect(decision.message).toMatch(/assist \/ ephemeral/);
     const parentIdx = decision.message.indexOf("Continue in the parent");
     const exploreIdx = decision.message.search(/subagent_type explore/i);
-    expect(parentIdx).toBeGreaterThanOrEqual(0);
-    expect(exploreIdx).toBeGreaterThan(parentIdx);
+    expect(exploreIdx).toBeGreaterThanOrEqual(0);
+    expect(parentIdx).toBeGreaterThan(exploreIdx);
   });
 });

--- a/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
+++ b/packages/core/src/hooks/dispatcher-spawn-dest.test.ts
@@ -4,8 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyWorktreeOccupancy } from "../session/occupancy.js";
-import { readSpawnReservationIncarnation } from "../session/spawn-occupancy.js";
+import {
+  readSpawnReservationIncarnation,
+  SPAWN_DEST_PATH_KEYS,
+} from "../session/spawn-occupancy.js";
 import { decideHook, type HookPolicySeams, spawnToolArgUpdatedInput } from "./index.js";
+import { isExploreSpawn, SPAWN_CLASS_RECOVERY } from "./readonly.js";
 
 const temps: string[] = [];
 afterEach(() => {
@@ -608,5 +612,87 @@ describe("Grok-applied spawn_subagent handler-runtime identity (#4272)", () => {
       ),
     ).toBeUndefined();
     expect(spawnToolArgUpdatedInput(null, "/wt", "inc-1")).toBeUndefined();
+  });
+});
+
+describe("Cursor Task dest-missing deny honesty (#4279)", () => {
+  it("keeps unmarked generalPurpose fail-closed and does not lead recoveries with explore", () => {
+    const inspectRitual = vi.fn(() => ({
+      ...STALE_RITUAL,
+      message: "session ritual state is stale (older than 4h). Run deft session:start --rearm",
+    }));
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Task",
+          tool_input: { subagent_type: "generalPurpose", prompt: "implement" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1" },
+      },
+      readySeams({ inspectRitual }),
+    );
+    expect(decision).toMatchObject({ verdict: "deny", code: "spawn-not-ready" });
+    expect(decision.message).toContain(SPAWN_CLASS_RECOVERY);
+    const parentIdx = decision.message.indexOf("Continue in the parent");
+    const exploreIdx = decision.message.search(/subagent_type explore/i);
+    expect(parentIdx).toBeGreaterThanOrEqual(0);
+    expect(exploreIdx).toBeGreaterThan(parentIdx);
+    for (const key of SPAWN_DEST_PATH_KEYS) {
+      expect(decision.message).toContain(key);
+    }
+    expect(decision.message).toContain("tool_input.isolation=worktree");
+    expect(decision.message).toContain("ritual telemetry (does not clear dest-missing)");
+    expect(decision.message).toContain("session:start --rearm");
+    expect(decision.message).not.toMatch(/Also ritual-not-ready:/);
+    expect(inspectRitual).toHaveBeenCalled();
+  });
+
+  it("does not explore-allow when implement conflict signals are present", () => {
+    expect(
+      isExploreSpawn({
+        tool_name: "Task",
+        tool_input: { subagent_type: "explore", drive_to: "merge-ready" },
+      }),
+    ).toBe(false);
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Task",
+          tool_input: { subagent_type: "explore", drive_to: "merge-ready" },
+        },
+        environ: { DEFT_SESSION_ID: "parent-1" },
+      },
+      readySeams(),
+    );
+    expect(decision.code).not.toBe("spawn-explore-ready");
+    expect(decision).toMatchObject({ verdict: "deny", code: "spawn-not-ready" });
+  });
+
+  it("shares the same recovery set on the read-only spawn deny", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Task",
+          tool_input: { subagent_type: "generalPurpose", isolation: "worktree" },
+        },
+        environ: { DEFT_HOOK_READ_ONLY: "1" },
+      },
+      readySeams(),
+    );
+    expect(decision).toMatchObject({ verdict: "deny", code: "read-only-deny" });
+    expect(decision.message).toContain(SPAWN_CLASS_RECOVERY);
+    const parentIdx = decision.message.indexOf("Continue in the parent");
+    const exploreIdx = decision.message.search(/subagent_type explore/i);
+    expect(parentIdx).toBeGreaterThanOrEqual(0);
+    expect(exploreIdx).toBeGreaterThan(parentIdx);
   });
 });

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -119,6 +119,7 @@ import {
   isProcessOnlyCriticSpawn,
   isReadOnlyHookContext,
   processOnlyCriticRequiresDest,
+  SPAWN_CLASS_RECOVERY,
 } from "./readonly.js";
 import {
   type ActiveScopeInspection,
@@ -1367,7 +1368,9 @@ function inspectMutationGates(
       const inspected = ritualDetailForOccupancyDeny();
       const ritualNote =
         inspected !== null && inspected.code !== 0
-          ? ` Also ritual-not-ready: ${inspected.message}`
+          ? consult.reason === "destination-missing"
+            ? ` Also ritual telemetry (does not clear dest-missing): ${inspected.message}`
+            : ` Also ritual-not-ready: ${inspected.message}`
           : "";
       return deny(
         input,
@@ -2578,8 +2581,7 @@ function routeHookDecision(
         "read-only-deny",
         toolName,
         `Directive denied ${toolName}: read-only posture blocks implementation sub-agent spawns. ` +
-          "Use subagent_type explore for read-only research spawns, or subagent_type plan / " +
-          "process_only for process-only critic spawns.",
+          SPAWN_CLASS_RECOVERY,
       );
     }
     if (isExploreSpawn(input.payload)) {

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -119,7 +119,7 @@ import {
   isProcessOnlyCriticSpawn,
   isReadOnlyHookContext,
   processOnlyCriticRequiresDest,
-  SPAWN_CLASS_RECOVERY,
+  SPAWN_READ_ONLY_RECOVERY,
 } from "./readonly.js";
 import {
   type ActiveScopeInspection,
@@ -2581,7 +2581,7 @@ function routeHookDecision(
         "read-only-deny",
         toolName,
         `Directive denied ${toolName}: read-only posture blocks implementation sub-agent spawns. ` +
-          SPAWN_CLASS_RECOVERY,
+          SPAWN_READ_ONLY_RECOVERY,
       );
     }
     if (isExploreSpawn(input.payload)) {

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -96,7 +96,7 @@ export function isReadOnlyHookContext(
  * Do not lead with explore: dest-missing callers were just classified implement.
  */
 export const SPAWN_CLASS_RECOVERY =
-  "Continue in the parent, or spawn with session assist / ephemeral markers for scratch, " +
+  "Continue in the parent, or spawn with assist / ephemeral markers for scratch, " +
   "or subagent_type plan / process_only for process-only critic spawns. Use subagent_type " +
   "explore only when the spawn is actually read-only research.";
 

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -97,8 +97,8 @@ export function isReadOnlyHookContext(
  */
 export const SPAWN_CLASS_RECOVERY =
   "Continue in the parent, or spawn with assist / ephemeral markers for scratch, " +
-  "or subagent_type plan / process_only for process-only critic spawns. Use subagent_type " +
-  "explore only when the spawn is actually read-only research.";
+  "or subagent_type plan. Use subagent_type explore only when the spawn is actually " +
+  "read-only research.";
 
 /** Explore sub-agent spawns are exempt from the implementation gate stack (#1185). */
 export function isExploreSpawn(payload: unknown): boolean {

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -91,11 +91,21 @@ export function isReadOnlyHookContext(
   return hookReadOnlyFromPayload(payload);
 }
 
+/**
+ * Shared spawn-class recovery for dest-missing and read-only spawn denials (#4279).
+ * Do not lead with explore: dest-missing callers were just classified implement.
+ */
+export const SPAWN_CLASS_RECOVERY =
+  "Continue in the parent, or spawn with session assist / ephemeral markers for scratch, " +
+  "or subagent_type plan / process_only for process-only critic spawns. Use subagent_type " +
+  "explore only when the spawn is actually read-only research.";
+
 /** Explore sub-agent spawns are exempt from the implementation gate stack (#1185). */
 export function isExploreSpawn(payload: unknown): boolean {
   const input = record(payload);
   if (input === null) return false;
   const toolInput = toolInputRecord(input) ?? input;
+  if (hasImplementConflictSignal(toolInput, input)) return false;
   const subagentType =
     fieldString(toolInput, "subagent_type") ??
     fieldString(toolInput, "subagentType") ??

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -100,6 +100,12 @@ export const SPAWN_CLASS_RECOVERY =
   "or subagent_type plan. Use subagent_type explore only when the spawn is actually " +
   "read-only research.";
 
+/** Same recovery inventory as SPAWN_CLASS_RECOVERY, ordered for an already read-only spawn. */
+export const SPAWN_READ_ONLY_RECOVERY =
+  "Use subagent_type explore for this read-only spawn, or subagent_type plan, " +
+  "or assist / ephemeral markers for scratch. Continue in the parent only when " +
+  "the remaining work stays read-only.";
+
 /** Explore sub-agent spawns are exempt from the implementation gate stack (#1185). */
 export function isExploreSpawn(payload: unknown): boolean {
   const input = record(payload);

--- a/packages/core/src/session/spawn-occupancy.test.ts
+++ b/packages/core/src/session/spawn-occupancy.test.ts
@@ -637,8 +637,8 @@ describe("consultImplementSpawnOccupancy (#4215)", () => {
     });
     expect(consult.allow).toBe(false);
     if (consult.allow) return;
-    expect(consult.reason).not.toBeUndefined();
-    expect(consult.message).not.toMatch(/process-only critic/);
+    expect(consult.reason).toBe("destination-missing");
+    expect(consult.message).not.toMatch(/skipped dest occupancy consult/);
   });
 
   it("cwd-without-occupy shares one dest for process_only siblings (#4296)", () => {

--- a/packages/core/src/session/spawn-occupancy.test.ts
+++ b/packages/core/src/session/spawn-occupancy.test.ts
@@ -16,6 +16,8 @@ import {
   readSpawnReservationIncarnation,
   releaseLeftoverSpawnReservation,
   releaseSpawnReservation,
+  SPAWN_DEST_ISOLATION_KEYS,
+  SPAWN_DEST_PATH_KEYS,
 } from "./spawn-occupancy.js";
 
 const temps: string[] = [];
@@ -1197,5 +1199,52 @@ describe("leftover dest-lock consult reuse (#4254)", () => {
     expect(second.ok).toBe(false);
     if (!second.ok) expect(second.reason).toBe("conflict");
     expect(readSpawnReservationIncarnation(root, dest)).toBe("inc-winner");
+  });
+});
+
+describe("Cursor Task dest-missing deny honesty (#4279)", () => {
+  it("names every inspectSpawnDestination key and shared recoveries, not a three-name subset", () => {
+    const decision = consultImplementSpawnOccupancy({
+      payload: {
+        tool_name: "Task",
+        tool_input: { subagent_type: "generalPurpose", prompt: "implement" },
+      },
+      payloadRoot: "/project",
+      host: "cursor",
+      parentId: "parent-1",
+      environ: {},
+    });
+    expect(decision.allow).toBe(false);
+    if (decision.allow) return;
+    expect(decision.reason).toBe("destination-missing");
+    expect(decision.message).toContain("tool_input.isolation=worktree");
+    for (const key of SPAWN_DEST_ISOLATION_KEYS.slice(1)) {
+      expect(decision.message).toContain(key);
+    }
+    for (const key of SPAWN_DEST_PATH_KEYS) {
+      expect(decision.message).toContain(key);
+    }
+    const parentIdx = decision.message.indexOf("Continue in the parent");
+    const exploreIdx = decision.message.search(/subagent_type explore/i);
+    expect(parentIdx).toBeGreaterThanOrEqual(0);
+    expect(exploreIdx).toBeGreaterThan(parentIdx);
+    expect(decision.message).toMatch(/assist \/ ephemeral/);
+    expect(decision.message).toMatch(/subagent_type plan/);
+    expect(decision.message).toMatch(/actually read-only/);
+  });
+
+  it("reads Isolation and workdir through the shared dest-key lists", () => {
+    expect(
+      inspectSpawnDestination({
+        tool_name: "Task",
+        tool_input: { Isolation: "worktree", prompt: "implement" },
+      }),
+    ).toEqual({ kind: "host-isolation", path: null, isolation: "worktree" });
+    expect(
+      inspectSpawnDestination({
+        tool_name: "Task",
+        tool_input: { workdir: "/tmp/worker-tree", prompt: "implement" },
+      }),
+    ).toEqual({ kind: "path", path: "/tmp/worker-tree", isolation: null });
   });
 });

--- a/packages/core/src/session/spawn-occupancy.ts
+++ b/packages/core/src/session/spawn-occupancy.ts
@@ -20,7 +20,11 @@ import {
   containedWrite,
 } from "../fs/contained-write.js";
 import { fieldPresent, fieldString, record, toolInputRecord } from "../hooks/classify/payload.js";
-import { appliesGrokSpawnDestContract, isProcessOnlyCriticSpawn } from "../hooks/readonly.js";
+import {
+  appliesGrokSpawnDestContract,
+  isProcessOnlyCriticSpawn,
+  SPAWN_CLASS_RECOVERY,
+} from "../hooks/readonly.js";
 import {
   type ChildOccupancyDispatchInput,
   type ChildOccupancyRecord,
@@ -99,6 +103,20 @@ export interface SpawnOccupancyConsultDeny {
 export type SpawnOccupancyConsult = SpawnOccupancyConsultAllow | SpawnOccupancyConsultDeny;
 
 const HOSTS_THAT_REROOT = new Set(["claude", "cursor", "codex"]);
+// #4279: Cursor Task dest-key bind waits on a recorded PreToolUse payload.
+// HOSTS_THAT_REROOT membership for Task is unbound until that measurement.
+
+export const SPAWN_DEST_ISOLATION_KEYS = ["isolation", "Isolation"] as const;
+export const SPAWN_DEST_PATH_KEYS = [
+  "worktree_path",
+  "worktreePath",
+  "worktree",
+  "cwd",
+  "working_directory",
+  "workingDirectory",
+  "workdir",
+] as const;
+
 const GROK_EXTRA_DEST_KEYS = ["worktree_path", "worktreePath", "worktree"] as const;
 
 /**
@@ -108,6 +126,24 @@ const GROK_EXTRA_DEST_KEYS = ["worktree_path", "worktreePath", "worktree"] as co
  */
 export const GROK_VENDOR_COMPAT_HOOKS_DISABLE_REFUSE =
   "Default-on vendor compat must work; do not set [compat.cursor] hooks = false as the product fix.";
+
+function firstNamedField(source: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = fieldString(source, key);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function rerootDestKeyList(): string {
+  const isolation = SPAWN_DEST_ISOLATION_KEYS.map((key, index) =>
+    index === 0 ? `tool_input.${key}=worktree` : key,
+  );
+  const names = [...isolation, ...SPAWN_DEST_PATH_KEYS];
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")}, or ${names[names.length - 1]}`;
+}
 
 function looksLikePath(value: string): boolean {
   if (value.length === 0) return false;
@@ -128,17 +164,9 @@ export function inspectSpawnDestination(payload: unknown): SpawnDestination | nu
   const nested = toolInputRecord(input);
   const toolInput = nested ?? {};
   const isolation =
-    fieldString(toolInput, "isolation") ??
-    fieldString(toolInput, "Isolation") ??
-    (nested === null ? fieldString(input, "isolation") : null);
-  const pathRaw =
-    fieldString(toolInput, "worktree_path") ??
-    fieldString(toolInput, "worktreePath") ??
-    fieldString(toolInput, "worktree") ??
-    fieldString(toolInput, "cwd") ??
-    fieldString(toolInput, "working_directory") ??
-    fieldString(toolInput, "workingDirectory") ??
-    fieldString(toolInput, "workdir");
+    firstNamedField(toolInput, SPAWN_DEST_ISOLATION_KEYS) ??
+    (nested === null ? firstNamedField(input, SPAWN_DEST_ISOLATION_KEYS) : null);
+  const pathRaw = firstNamedField(toolInput, SPAWN_DEST_PATH_KEYS);
   const path = pathRaw !== null && looksLikePath(pathRaw) ? pathRaw : null;
   const isolationWorktree = isolation !== null && isolation.toLowerCase() === "worktree";
   if (path !== null) {
@@ -227,11 +255,12 @@ function grokMissingDestMessage(): string {
 }
 
 function rerootMissingDestMessage(): string {
+  const destKeys = rerootDestKeyList();
   return (
     "Directive denied implement-class spawn: no worktree destination on the spawn payload " +
-    "(tool_input.isolation=worktree, worktree_path, or cwd). Spawned mutating work takes " +
-    "its own worktree; do not inherit the parent checkout. Pass isolation=worktree or a " +
-    "linked worktree_path before the spawn primitive."
+    `(${destKeys}). Spawned mutating work takes its own worktree; do not inherit the ` +
+    "parent checkout. Pass a destination field inspectSpawnDestination reads " +
+    `(${destKeys}) before the spawn primitive. ${SPAWN_CLASS_RECOVERY}`
   );
 }
 

--- a/packages/core/src/session/spawn-occupancy.ts
+++ b/packages/core/src/session/spawn-occupancy.ts
@@ -104,7 +104,7 @@ export type SpawnOccupancyConsult = SpawnOccupancyConsultAllow | SpawnOccupancyC
 
 const HOSTS_THAT_REROOT = new Set(["claude", "cursor", "codex"]);
 // #4279: Cursor Task dest-key bind waits on a recorded PreToolUse payload.
-// HOSTS_THAT_REROOT membership for Task is unbound until that measurement.
+// HOSTS_THAT_REROOT for Task stays unbound until that measurement.
 
 export const SPAWN_DEST_ISOLATION_KEYS = ["isolation", "Isolation"] as const;
 export const SPAWN_DEST_PATH_KEYS = [


### PR DESCRIPTION
## Summary

Cursor dest-missing deny now names the full inspectSpawnDestination key set and a shared recovery list that does not lead with explore. Unmarked generalPurpose stays implement. Ritual notes on dest-missing are telemetry, not a recovery. Cursor Task isolation-key bind stays unbound until a PreToolUse measurement.

## Changes

- Dest-missing copy names isolation/Isolation plus the full path key set inspectSpawnDestination reads.
- Shared SPAWN_CLASS_RECOVERY: parent continues, assist/ephemeral, plan, then explore only if the spawn is actually read-only.
- isExploreSpawn consults hasImplementConflictSignal so implement signals cannot relabel into the unfenced explore branch.
- Dest-missing ritual note is labeled telemetry; rearm does not clear dest-missing.
- HOSTS_THAT_REROOT and host-cursor.md Step 2e for Task stay unbound (no recorded PreToolUse dest payload).

## vBRIEF References

- `xbrief/active/2026-09-10-4279-bughookscursor-implement-class-task-deny-names-dest-fields-c.xbrief.json`

## Documentation impact

change_class: change
surfaces: none
rationale: "Operator-visible dest-missing deny copy changed; CHANGELOG records it. No command, skill-trigger, help, or docs-site surface added or removed. Cursor Task isolation-key bind and host-cursor.md Step 2e stay unbound."

## Checklist

- [x] `task check` passes locally (validate + lint + test; see `coding/testing.md`)
- [x] `CHANGELOG.md` has an `[Unreleased]` entry covering these changes
- [x] All affected vBRIEFs pass `task vbrief:validate`
- [x] Commit messages follow Conventional Commits format
- [x] No secrets or `.env` content in the diff
- [x] `.premigrate.*` files are gitignored (if this PR followed a `task migrate:vbrief` run)
- [x] New source files (`scripts/`, `src/`, `cmd/`, `*.py`, `*.go`) have corresponding tests in this PR

## Related Issues

Closes #4279

## Testing

- `pnpm exec vitest run packages/core/src/hooks/dispatcher-spawn-dest.test.ts packages/core/src/session/spawn-occupancy.test.ts` (72 passed)
- Full `task check` passed locally without occupancy env pollution
