### PR TITLE
fix(session): print HEAD checkout orientation at mutation start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mutation session:start prints checkout, HEAD, and ahead/behind versus the default upstream (#4291).** Branch-sync now measures HEAD, not local main/master. Warns when behind, diverged, or 0-ahead/N-behind; fetch failure stays a warning with unknown counts. Does not refuse. Out of this number: mint/host rewrite, stranger worktree copy, shell honesty, and write versus gated doctor. Closes #4291.
 - **Setup no longer seeds xBRIEF DeftVersion stamps; two-pass upgrade is independently green (#4271).** Setup retirement locks evaluate Markdown list/section units on pack body and rendered skill. Pass 2 commit-set is installerManagedMatchers() in hygiene.ts; frozen Go is source-only. npm-publish.yml runs the post-publish fixture after the four packages ship. Consumer AGENTS.md forbids xBRIEF DeftVersion stamps. Closes #4271.
 - **Cursor dest-missing deny names inspectSpawnDestination keys and shared recoveries (#4279).** Parent continues, assist/ephemeral, and plan lead on dest-missing; explore leads only on an already read-only spawn deny. Ritual notes on dest-missing are telemetry, not a recovery. Unmarked generalPurpose stays implement. Cursor Task isolation-key bind stays unbound until a PreToolUse measurement. Closes #4279.
 - **Yolo on the launching utterance confirms a posted all-accept design-critique map (#4308).** Standing for the arc; confirm conjunct only. `arc N yolo` still asks run posture. Recut-shaped maps stamp; ingest stays later. Closes #4308.

--- a/packages/core/src/session/session-start-sync-branches.test.ts
+++ b/packages/core/src/session/session-start-sync-branches.test.ts
@@ -119,6 +119,87 @@ describe("defaultBranchSync branch coverage", () => {
   });
 });
 
+it("prints orientation with checkout, HEAD, and ahead/behind vs default upstream", () => {
+  const root = tmpRoot();
+  let revListSpec: string | undefined;
+  const sync = defaultBranchSync(
+    root,
+    gitStub((args) => {
+      if (args[0] === "symbolic-ref") return { code: 0, stdout: "origin/main", stderr: "" };
+      if (args[0] === "rev-parse" && args[2] === "HEAD") {
+        return { code: 0, stdout: "fix/stale", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { code: 0, stdout: "origin/main", stderr: "" };
+      }
+      if (args[0] === "fetch") return { code: 0, stdout: "", stderr: "" };
+      if (args[0] === "rev-list") {
+        revListSpec = args[3];
+        return { code: 0, stdout: "0 64", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    }),
+  );
+  expect(revListSpec).toBe("HEAD...origin/main");
+  expect(sync.head).toBe("fix/stale");
+  expect(sync.ahead).toBe(0);
+  expect(sync.behind).toBe(64);
+  expect(sync.orientation).toContain(`checkout=${root}`);
+  expect(sync.orientation).toContain("HEAD=fix/stale");
+  expect(sync.orientation).toContain("ahead=0");
+  expect(sync.orientation).toContain("behind=64");
+  expect(sync.orientation).toContain("vs origin/main");
+  expect(sync.warning).toContain("0 ahead");
+  expect(sync.warning).toContain("64");
+  expect(sync.warning).toContain("behind");
+});
+
+it("warns on fetch-fail with null counts and does not refuse", () => {
+  const root = tmpRoot();
+  const sync = defaultBranchSync(
+    root,
+    gitStub((args) => {
+      if (args[0] === "symbolic-ref") return { code: 0, stdout: "origin/main", stderr: "" };
+      if (args[0] === "rev-parse" && args[2] === "HEAD") {
+        return { code: 0, stdout: "feature", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { code: 0, stdout: "origin/main", stderr: "" };
+      }
+      if (args[0] === "fetch") return { code: 1, stdout: "", stderr: "offline" };
+      return { code: 0, stdout: "", stderr: "" };
+    }),
+  );
+  expect(sync.ahead).toBeNull();
+  expect(sync.behind).toBeNull();
+  expect(sync.warning).toContain("refresh");
+  expect(sync.orientation).toContain("ahead=unknown");
+  expect(sync.orientation).toContain("behind=unknown");
+  expect(sync.orientation).toContain("HEAD=feature");
+});
+
+it("warns when HEAD has diverged from the default upstream", () => {
+  const root = tmpRoot();
+  const sync = defaultBranchSync(
+    root,
+    gitStub((args) => {
+      if (args[0] === "symbolic-ref") return { code: 0, stdout: "origin/main", stderr: "" };
+      if (args[0] === "rev-parse" && args[2] === "HEAD") {
+        return { code: 0, stdout: "topic", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { code: 0, stdout: "origin/main", stderr: "" };
+      }
+      if (args[0] === "fetch") return { code: 0, stdout: "", stderr: "" };
+      if (args[0] === "rev-list") return { code: 0, stdout: "2 3", stderr: "" };
+      return { code: 0, stdout: "", stderr: "" };
+    }),
+  );
+  expect(sync.warning).toContain("diverged");
+  expect(sync.orientation).toContain("ahead=2");
+  expect(sync.orientation).toContain("behind=3");
+});
+
 describe("parseDeferrals branch coverage", () => {
   it("normalises step aliases and rejects bad input", () => {
     expect(parseDeferrals(["branch=ok"]).deferrals.branch_policy).toBe("ok");

--- a/packages/core/src/session/session-start.test.ts
+++ b/packages/core/src/session/session-start.test.ts
@@ -962,4 +962,20 @@ describe("runSessionStart mutation HEAD orientation (#4291)", () => {
     expect(text).toContain("behind=unknown");
     expect(text).toContain("refresh");
   });
+
+  it("prints orientation even when branch_policy is deferred", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      deferrals: { branch_policy: "ok" },
+      runGit: headSyncGit(root, "0 64"),
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const text = result.lines.join("\n");
+    expect(text).toContain(`checkout=${root}`);
+    expect(text).toContain("HEAD=fix/stale");
+    expect(text).toContain("ahead=0");
+    expect(text).toContain("behind=64");
+  });
 });

--- a/packages/core/src/session/session-start.test.ts
+++ b/packages/core/src/session/session-start.test.ts
@@ -47,6 +47,9 @@ function tempRoot(): string {
 /** Fake git runner: HEAD + toplevel resolve; everything else is a benign no-op. */
 function fakeGit(root: string): (root: string, args: readonly string[]) => GitRunResult {
   return (_root, args) => {
+    if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "HEAD") {
+      return { code: 1, stdout: "", stderr: "" };
+    }
     if (args[0] === "rev-parse" && args.includes("HEAD")) {
       return { code: 0, stdout: "deadbeef", stderr: "" };
     }
@@ -889,5 +892,74 @@ describe("runSessionStart consumer evidence (#3358)", () => {
     };
     expect(dial.inputs.taskSize).toBe("S");
     expect(dial.depth).toBe("rapid");
+  });
+});
+
+describe("runSessionStart mutation HEAD orientation (#4291)", () => {
+  function headSyncGit(root: string, counts: string, fetchCode = 0): SessionStartOptions["runGit"] {
+    const base = fakeGit(root);
+    return (_root, args) => {
+      if (args[0] === "symbolic-ref") {
+        return { code: 0, stdout: "origin/main", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "HEAD") {
+        return { code: 0, stdout: "fix/stale", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { code: 0, stdout: "origin/main", stderr: "" };
+      }
+      if (args[0] === "fetch") {
+        return { code: fetchCode, stdout: "", stderr: fetchCode === 0 ? "" : "offline" };
+      }
+      if (args[0] === "rev-list") {
+        return { code: 0, stdout: counts, stderr: "" };
+      }
+      if (args[0] === "show-ref") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return base(_root, args);
+    };
+  }
+
+  it("prints checkout, HEAD, and ahead/behind on mutation session:start", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      runGit: headSyncGit(root, "0 64"),
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const text = result.lines.join("\n");
+    expect(text).toContain(`checkout=${root}`);
+    expect(text).toContain("HEAD=fix/stale");
+    expect(text).toContain("ahead=0");
+    expect(text).toContain("behind=64");
+    expect(text).toContain("vs origin/main");
+    expect(text).toContain("0 ahead");
+  });
+
+  it("does not refuse when HEAD is 0 ahead and N behind", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      runGit: headSyncGit(root, "0 64"),
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    expect(result.payload.ready).not.toBe(false);
+  });
+
+  it("fetch-fail stays a warning with unknown counts and exit 0", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      runGit: headSyncGit(root, "0 0", 1),
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const text = result.lines.join("\n");
+    expect(text).toContain("ahead=unknown");
+    expect(text).toContain("behind=unknown");
+    expect(text).toContain("refresh");
   });
 });

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -1537,11 +1537,6 @@ export function runSessionStart(
     if (humanMergeLine !== null) {
       lines.push(humanMergeLine);
     }
-    const branchSync = defaultBranchSync(projectRoot, runGit);
-    lines.push(branchSync.orientation);
-    if (branchSync.warning) {
-      lines.push(branchSync.warning);
-    }
     const durationMs = elapsedMs(stepStarted);
     quickSteps.branch_policy = ritualStep({
       ok,
@@ -1553,6 +1548,12 @@ export function runSessionStart(
     stepTimings.push({ name: "branch_policy", duration_ms: durationMs });
   } else {
     stepTimings.push({ name: "branch_policy", duration_ms: 0, skipped: true });
+  }
+  // Orientation is independent of branch_policy deferral (#4291 / Greptile).
+  const branchSync = defaultBranchSync(projectRoot, runGit);
+  lines.push(branchSync.orientation);
+  if (branchSync.warning) {
+    lines.push(branchSync.warning);
   }
   // Standing disclosure is independent of branch_policy deferral (#3314 / Greptile).
   pushCoverageCheckResumeDisclosure(lines, projectRoot);

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -233,6 +233,10 @@ export interface DefaultBranchSync {
   readonly ahead: number | null;
   readonly behind: number | null;
   readonly warning: string | null;
+  /** Pretty HEAD name (git rev-parse --abbrev-ref HEAD); not the default branch. */
+  readonly head: string | null;
+  /** Always-printed mutation orientation: checkout, HEAD, ahead/behind vs default upstream. */
+  readonly orientation: string;
 }
 
 export interface SessionStartResult {
@@ -566,39 +570,99 @@ function defaultBranchCandidates(projectRoot: string, runGit: GitRunner): string
   return candidates;
 }
 
+function checkoutOrientationLine(
+  checkout: string,
+  head: string | null,
+  ahead: number | null,
+  behind: number | null,
+  upstream: string | null,
+): string {
+  const aheadText = ahead === null ? "unknown" : String(ahead);
+  const behindText = behind === null ? "unknown" : String(behind);
+  const headText = head ?? "unknown";
+  const upstreamText = upstream ?? "unresolved";
+  return (
+    "[deft branch] checkout=" +
+    checkout +
+    " HEAD=" +
+    headText +
+    " ahead=" +
+    aheadText +
+    " behind=" +
+    behindText +
+    " vs " +
+    upstreamText
+  );
+}
+
+function packDefaultBranchSync(
+  projectRoot: string,
+  head: string | null,
+  fields: {
+    branch: string | null;
+    upstream: string | null;
+    ahead: number | null;
+    behind: number | null;
+    warning: string | null;
+  },
+): DefaultBranchSync {
+  return {
+    ...fields,
+    head,
+    orientation: checkoutOrientationLine(
+      projectRoot,
+      head,
+      fields.ahead,
+      fields.behind,
+      fields.upstream,
+    ),
+  };
+}
+
+/** #4291: retarget at HEAD vs the default upstream. Warn when behind, diverged, or 0-ahead/N-behind. Do not refuse on the body's "merged and finished" predicate. Do not add a second ahead/behind helper. */
 export function defaultBranchSync(
   projectRoot: string,
   runGit: GitRunner = defaultGitRunner,
 ): DefaultBranchSync {
+  const headResult = runGit(projectRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const head =
+    headResult.code === 0 && headResult.stdout.trim() !== "" ? headResult.stdout.trim() : null;
+  const pack = (fields: {
+    branch: string | null;
+    upstream: string | null;
+    ahead: number | null;
+    behind: number | null;
+    warning: string | null;
+  }): DefaultBranchSync => packDefaultBranchSync(projectRoot, head, fields);
   const candidates = defaultBranchCandidates(projectRoot, runGit);
   if (candidates.length === 0) {
-    return {
+    return pack({
       branch: null,
       upstream: null,
       ahead: null,
       behind: null,
       warning: "[deft branch] Could not resolve a local default branch (`main` or `master`).",
-    };
+    });
   }
   const branch = candidates[0] ?? null;
   if (!branch) {
-    return {
+    return pack({
       branch: null,
       upstream: null,
       ahead: null,
       behind: null,
       warning: "[deft branch] Could not resolve a local default branch (`main` or `master`).",
-    };
+    });
   }
   const upstreamResult = runGit(projectRoot, ["rev-parse", "--abbrev-ref", `${branch}@{upstream}`]);
   if (upstreamResult.code !== 0 || !upstreamResult.stdout) {
-    return {
+    return pack({
       branch,
       upstream: null,
       ahead: null,
       behind: null,
       warning: `[deft branch] Local ${branch} has no upstream tracking branch.`,
-    };
+    });
   }
   const upstream = upstreamResult.stdout;
   const slash = upstream.indexOf("/");
@@ -607,71 +671,67 @@ export function defaultBranchSync(
   const fetch = runGit(projectRoot, ["fetch", "--quiet", remote, remoteBranch]);
   if (fetch.code !== 0) {
     const detail = fetch.stderr || "remote refresh failed";
-    return {
+    return pack({
       branch,
       upstream,
       ahead: null,
       behind: null,
-      warning: `[deft branch] Could not refresh ${upstream} for local ${branch}: ${detail}`,
-    };
+      warning: `[deft branch] Could not refresh ${upstream} for HEAD: ${detail}`,
+    });
   }
-  const counts = runGit(projectRoot, [
-    "rev-list",
-    "--left-right",
-    "--count",
-    `${branch}...${upstream}`,
-  ]);
+  const counts = runGit(projectRoot, ["rev-list", "--left-right", "--count", `HEAD...${upstream}`]);
   if (counts.code !== 0 || !counts.stdout) {
     const detail = counts.stderr || "ahead/behind count failed";
-    return {
+    return pack({
       branch,
       upstream,
       ahead: null,
       behind: null,
-      warning: `[deft branch] Could not compare local ${branch} with ${upstream}: ${detail}`,
-    };
+      warning: `[deft branch] Could not compare HEAD with ${upstream}: ${detail}`,
+    });
   }
   const parts = counts.stdout.trim().split(/\s+/);
   if (parts.length !== 2) {
-    return {
+    return pack({
       branch,
       upstream,
       ahead: null,
       behind: null,
       warning:
-        `[deft branch] Could not parse branch sync counts for ${branch} ` +
+        `[deft branch] Could not parse branch sync counts for HEAD ` +
         `and ${upstream}: ${counts.stdout}`,
-    };
+    });
   }
   const ahead = Number.parseInt(parts[0] ?? "", 10);
   const behind = Number.parseInt(parts[1] ?? "", 10);
   if (Number.isNaN(ahead) || Number.isNaN(behind)) {
-    return {
+    return pack({
       branch,
       upstream,
       ahead: null,
       behind: null,
       warning:
-        `[deft branch] Could not parse branch sync counts for ${branch} ` +
+        `[deft branch] Could not parse branch sync counts for HEAD ` +
         `and ${upstream}: ${counts.stdout}`,
-    };
+    });
   }
+  const headName = head ?? "HEAD";
   if (ahead === 0 && behind === 0) {
-    return { branch, upstream, ahead, behind, warning: null };
+    return pack({ branch, upstream, ahead, behind, warning: null });
   }
   let warning: string;
   if (ahead > 0 && behind > 0) {
     warning =
-      `[deft branch] Local ${branch} has diverged from ${upstream} ` +
+      `[deft branch] HEAD ${headName} has diverged from ${upstream} ` +
       `(${ahead} ahead, ${behind} behind).`;
-  } else if (behind > 0) {
+  } else if (ahead === 0 && behind > 0) {
     const plural = behind === 1 ? "commit" : "commits";
-    warning = `[deft branch] Local ${branch} is behind ${upstream} by ${behind} ${plural}.`;
+    warning = `[deft branch] HEAD ${headName} is 0 ahead and ${behind} ${plural} behind ${upstream}.`;
   } else {
     const plural = ahead === 1 ? "commit" : "commits";
-    warning = `[deft branch] Local ${branch} is ahead of ${upstream} by ${ahead} ${plural}.`;
+    warning = `[deft branch] HEAD ${headName} is ahead of ${upstream} by ${ahead} ${plural}.`;
   }
-  return { branch, upstream, ahead, behind, warning };
+  return pack({ branch, upstream, ahead, behind, warning });
 }
 
 /**
@@ -1478,6 +1538,7 @@ export function runSessionStart(
       lines.push(humanMergeLine);
     }
     const branchSync = defaultBranchSync(projectRoot, runGit);
+    lines.push(branchSync.orientation);
     if (branchSync.warning) {
       lines.push(branchSync.warning);
     }


### PR DESCRIPTION
## Summary

Mutation session:start now prints one orientation line with checkout path, HEAD branch, and ahead/behind versus the default upstream. The existing branch-sync object measures HEAD, not local main or master. It warns when behind, diverged, or 0-ahead/N-behind. Fetch failure stays a warning with unknown counts.

## Changes

- Retarget defaultBranchSync at HEAD versus the default upstream
- Always print an orientation line on mutation session:start
- Warn on behind, diverged, and 0-ahead/N-behind
- Keep fetch-fail as a warning with null counts

## vBRIEF References

- `xbrief/active/2026-09-10-4291-bugsessionbranch-policy-no-checkout-or-branch-signal-at-muta.xbrief.json`

## Documentation impact

change_class: change
surfaces: none
rationale: "Operator-visible session:start orientation is recorded in CHANGELOG; no command, skill trigger, help key, or docs-site page was added or removed."

## Checklist

- [x] `task check` passes locally (validate + lint + test; see `coding/testing.md`)
- [x] `CHANGELOG.md` has an `[Unreleased]` entry covering these changes
- [x] All affected vBRIEFs pass `task vbrief:validate`
- [x] Commit messages follow Conventional Commits format
- [x] No secrets or `.env` content in the diff
- [x] `.premigrate.*` files are gitignored (if this PR followed a `task migrate:vbrief` run)
- [x] New source files (`scripts/`, `src/`, `cmd/`, `*.py`, `*.go`) have corresponding tests in this PR

## Related Issues

Closes #4291

## Testing

- `pnpm exec vitest run packages/core/src/session/session-start.test.ts packages/core/src/session/session-start-sync-branches.test.ts`
- `task check`
