### PR TITLE
fix(doctor): skip escaping-symlink test on Windows without privilege (#4344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Land leftover completed-tracked artifact for #4162 (#3264 / #3476).** The #4162 xBRIEF stayed in `xbrief/active/` on origin/master after the product land. Moved to `xbrief/completed/` so merge-gate orphan-active is green. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4321 (#3264 / #3476).** The #4321 xBRIEF stayed untracked after squash of PR 4329. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Consumer AGENTS.md names the explicit-body docs-impact seed (#4293 / #1309).** Pointer: compose the template `Documentation impact` block, then `verify:docs-impact --body-file` on those same bytes (leftover-complete / finalize-cohort). `plan.policy.agentsMdBudget.absoluteMaxBytes` 17600→17725 for that pointer after composing with #4295.
 - **Land leftover completed-tracked artifact for #4293 (#3264 / #3476).** Moved to xbrief/completed/ via scope:complete after PR 4312 merge.
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Doctor escaping-symlink test skips on Windows without symlink privilege (#4344).** `containDepositInstallRoot rejects an escaping symlink` still asserts on platforms that can create the symlink; EPERM/EACCES on win32 skips instead of failing `task check`. Closes #4344.
 - **Doctor layout splits project lifecycle from the deposit schema pack (#4162).** A healthy consumer with project-root `xbrief/` plus deposit `vbrief/` no longer warns missing `xbrief/`. Dual-populated unmarked `vbrief/` plus `xbrief/` warns rather than reporting healthy. Layout rows name project-lifecycle, framework-content, or engine/deposit. `migrate:preflight` schema FAIL uses `vbrief/schemas` via shared `contentRoot()`. Closes #4162.
 - **Clean clone passes migrate-preflight and lifecycle-visible --enforce (#4310).** Schema lookup uses content-root plus existing trees (`content/vbrief/schemas`, flattened `vbrief/schemas`, project-root `xbrief/schemas`). Tracked `xbrief/pending/.gitkeep` survives clone. Lifecycle-visible derived probes require a convention-valid filename; canonical `*.premigrate.*` backup exclusions stay. Findings name the derived probe and candidate ignore rule. Closes #4310.
 - **Cursor Task dest-missing deny names explore or continue-in-parent, not Grok-only plan (#4321).** Closes #4321.

--- a/packages/core/src/doctor/branches.test.ts
+++ b/packages/core/src/doctor/branches.test.ts
@@ -53,11 +53,20 @@ describe("manifest helpers", () => {
     }
   });
 
-  it("containDepositInstallRoot rejects an escaping symlink (#4162)", () => {
+  it("containDepositInstallRoot rejects an escaping symlink (#4162)", (ctx) => {
     const root = mkdtempSync(join(tmpdir(), "deft-contain-link-"));
     const outside = mkdtempSync(join(tmpdir(), "deft-contain-out-"));
     try {
-      symlinkSync(outside, join(root, "escape"));
+      try {
+        symlinkSync(outside, join(root, "escape"));
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        // SeCreateSymbolicLink is off without Developer Mode / admin (#4344).
+        if (process.platform === "win32" && (code === "EPERM" || code === "EACCES")) {
+          ctx.skip();
+        }
+        throw err;
+      }
       expect(containDepositInstallRoot(root, "escape")).toBe(FALLBACK_INSTALL_ROOT);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/xbrief/active/2026-09-10-4344-bugdoctor-4162-escaping-symlink-test-eperms-on-windows-witho.xbrief.json
+++ b/xbrief/active/2026-09-10-4344-bugdoctor-4162-escaping-symlink-test-eperms-on-windows-witho.xbrief.json
@@ -1,0 +1,92 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #4344",
+    "updated": "2026-09-10T22:22:28Z"
+  },
+  "plan": {
+    "title": "bug(doctor): #4162 escaping-symlink test EPERMs on Windows without Developer Mode",
+    "status": "running",
+    "narratives": {
+      "Description": "bug(doctor): #4162 escaping-symlink test EPERMs on Windows without Developer Mode",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/4344",
+      "Overview": "## Problem\nRelease `v0.115.0` Phase 4 Step 5 (`task check` / `verify:ac`) fails closed on Windows. `#4162` added `containDepositInstallRoot rejects an escaping symlink` in `packages/core/src/doctor/branches.test.ts`. `symlinkSync` throws `EPERM` unless Developer Mode / admin is on. The test has no platform skip.\n\nThis is the first cut that includes that test (not present at v0.114.0). Linux CI TypeScript is green; this host cannot create the symlink.\n\n`verify:ac` also targeted the just-completed leftover `#4162` brief (`#3357`) with `pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight`.\n\n## Recurrence\nAny Windows `task check` / release Step 5 after `#4162` lands.\n\n## Acceptance\n- The escaping-symlink case still runs on platforms that can create the symlink.\n- On Windows without symlink privilege, the test skips or uses a non-EPERM fixture. It must not fail `task check`.\n- `pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight` exits 0 on this Windows checkout.\n\n## Release\nv0.115.0 cut paused at Step 5. Do not `--skip-ci` as first recovery (#2859)."
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/4344",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #4344: bug(doctor): #4162 escaping-symlink test EPERMs on Windows without Developer Mode"
+      }
+    ],
+    "metadata": {
+      "literal_acceptance_commands": [
+        {
+          "command": "pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight",
+          "source": "explicit",
+          "sourceSpan": "operator-stamp#4344"
+        }
+      ],
+      "literal_acceptance_rejected": [
+        {
+          "command": "task check",
+          "reason": "inline backtick in prose is a mention, not a stated acceptance command (#3721)",
+          "sourceSpan": "inline@L4"
+        },
+        {
+          "command": "containDepositInstallRoot rejects an escaping symlink",
+          "reason": "inline backtick in prose is a mention, not a stated acceptance command (#3721)",
+          "sourceSpan": "inline@L4"
+        }
+      ],
+      "swarm": {},
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      },
+      "x-directive/plan-id": {
+        "version": 1,
+        "source": "github-rest-id",
+        "github_issue_id": 5417611808,
+        "origin": "deftai/directive#4344",
+        "id": "github.issue.5417611808"
+      }
+    },
+    "acceptance": {
+      "commands": [
+        "pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight"
+      ],
+      "none_stated": false,
+      "source_rung": "stated",
+      "derived_reason": "operator stamped the Windows vitest command after ingest marked none_stated (#3721 backticks)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "The escaping-symlink case still runs on platforms that can create the symlink.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "On Windows without symlink privilege, the test skips or uses a non-EPERM fixture. It must not fail `task check`.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "`pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight` exits 0 on this Windows checkout.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "id": "github.issue.5417611808",
+    "updated": "2026-09-10T22:22:28Z"
+  }
+}

--- a/xbrief/completed/2026-09-10-4162-framework-gap-doctor-checks-consumer-xbrief-under-the-deposi.xbrief.json
+++ b/xbrief/completed/2026-09-10-4162-framework-gap-doctor-checks-consumer-xbrief-under-the-deposi.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #4162",
-    "updated": "2026-09-10T18:03:04Z"
+    "updated": "2026-09-10T21:38:06Z"
   },
   "plan": {
     "title": "[framework-gap] doctor checks consumer xbrief under the deposit root and emits an impossible warning",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Doctor's consumer framework-layout check looks for xbrief under the deposit while a current consumer keeps lifecycle at project-root xbrief and the shipped schema pack at deposit vbrief. The bound recut splits those identities, aligns migrate-preflight to vbrief/schemas, contains AGENTS.md install-root before echoing paths, and uses published-flatten fixtures.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4162",
@@ -19,66 +19,75 @@
     "items": [
       {
         "title": "Do not bind a one-row retarget of consumer `framework-layout`'s `xbrief` slot onto project-root `xbrief/` as the whole design.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a packed consumer with project-root xbrief/ plus deposit vbrief/ and no .deft/core/xbrief/, when doctor --full --json runs, then it emits no missing-xbrief framework-layout warning."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Keep the postcondition: a healthy current consumer with project-root `xbrief/` plus deposit `vbrief/` and no `.deft/core/xbrief/` must not warn missing `xbrief/`.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the same healthy consumer, when a one-row project-root swap is proposed as the whole fix, then the shipped change rejects that as the complete design and records the split identities."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Split Doctor layout into distinct identities: project lifecycle at project-root `xbrief/` via existing `resolveLifecycleLayout` / envelope-version; framework schema pack at `contentRoot` as `vbrief/schemas`; engine dirs (`tasks`, source `scripts`) on deposit/framework root.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given DEFT_ROOT or a content-package framework root, when Doctor layout-checks deposit/content rows, then those rows use the resolved framework/content root and do not discard it for an AGENTS.md depositRoot."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Consumer deposit/content rows must use the resolved framework/content root, not a re-derived AGENTS.md `depositRoot` that discards that root (DEFT_ROOT / content-package cases).",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a source or flattened tree whose pack is vbrief/schemas, when migrate-preflight checkLayout runs, then it fails or passes against contentRoot vbrief/schemas and does not require project-root xbrief/schemas as the framework pack."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Align `migrate:preflight` schema FAIL to the real pack name `vbrief/schemas` through shared `contentRoot()`. Do not move that FAIL onto project-root `xbrief/schemas`. Preflight already checks project-root `xbrief/` separately.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given an AGENTS.md install-root with .. or an absolute path, when Doctor prints a resolved layout path, then it rejects or contains that root (or falls back to .deft/core) and does not emit a host path outside the project."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "If project-lifecycle absence remains in Doctor, report it under a project-lifecycle identity with the resolved project path. Do not treat `isDirectory(projectRoot/xbrief)` as complete health; cover valid, empty/greenfield, partial, legacy-only, and absent states without turning absence into an uncaught throw.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a packed-consumer fixture, when tests assert framework-layout, then the fixture uses project-root xbrief/ plus deposit vbrief/ and does not mkdir .deft/core/xbrief as the healthy shape."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Human and JSON output must identify which tree a missing path belongs to (project-lifecycle vs framework-content vs engine/deposit). Before probing or printing an AGENTS.md install-root, apply existing deposit containment (reject `..`, absolute, escaping symlinks) or fall back to `.deft/core`.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given missing or partial project lifecycle, when Doctor reports it, then the finding returns a project-lifecycle identity with the resolved project path and does not treat a bare isDirectory as complete health."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Packed-consumer and installed-package fixtures must use the published flatten (lifecycle at project root, `vbrief` under the deposit). Do not mkdir `.deft/core/xbrief` as the healthy shape. Add first row-level `framework-layout` coverage for consumer and source-checkout branches. Move the #3372 fixture's deposit `xbrief` to the project root.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given missing framework vbrief/schemas, when Doctor or migrate-preflight reports it, then the finding returns a framework-content identity with the selected content path."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       },
       {
         "title": "Source-checkout coverage is re-derived from the same project/deposit split (roots coincide here), not a freeze of today's `EXPECTED_FRAMEWORK_DIRS` behavior.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given source-checkout layout, when framework-layout coverage runs, then it is re-derived from the same project/deposit split and records CHANGELOG Unreleased."
-        }
+        },
+        "completed": "2026-09-10T21:26:53Z"
       }
     ],
     "tags": [
@@ -216,10 +225,35 @@
           "command": "task check",
           "reason": "merge-chokepoint hygiene, not a product acceptance command; including it in verify:ac recurses because check runs verify:ac (#3721)"
         }
-      ]
+      ],
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4339,
+        "prBase": null,
+        "mergeCommit": "d419389acb65f49f2f6b0c36d4a7324ad41c179a",
+        "deliveryBranch": "master",
+        "deliveryCommit": "efa70239aee280a0e128bfdb52eb0b317da17e0e",
+        "verifiedAt": "2026-09-10T21:38:06Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:grok:v1:MDFhMDhkMmMtZGRlYy03OWYzLWFiOGEtZjA5ZjdjZTE4YTRl"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-09-10T21:38:06Z",
+      "completedSessionId": "host:grok:v1:MDFhMDhkMmMtZGRlYy03OWYzLWFiOGEtZjA5ZjdjZTE4YTRl",
+      "capacityBucket": "technical-debt",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-10T21:38:06Z"
+      }
     },
     "id": "github.issue.5337132295",
-    "updated": "2026-09-10T18:03:04Z",
+    "updated": "2026-09-10T21:38:06Z",
     "architecture": {
       "systemOfRecord": {
         "note": "This story does not add durable product state. Filesystem writes in the diff are Vitest temp fixtures for doctor/migrate-preflight layout tests.",
@@ -233,7 +267,7 @@
               "filesystem"
             ],
             "excludedFromProduction": true,
-            "productionGuard": "writeFileSync calls are inside Vitest test helpers using mkdtempSync \u2014 never invoked at runtime"
+            "productionGuard": "writeFileSync calls are inside Vitest test helpers using mkdtempSync — never invoked at runtime"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Skip the `#4162` `containDepositInstallRoot rejects an escaping symlink` fixture on Windows without symlink privilege (`EPERM`/`EACCES`). Platforms that can create the symlink still assert. Land leftover completed `#4162` xBRIEF so origin/master orphan-active is green.

## Changes

- Catch `EPERM`/`EACCES` from `symlinkSync` on win32 and `ctx.skip()`; keep the posix assertion.
- Stamp `plan.acceptance.commands` with `pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight`.
- Move leftover `#4162` xBRIEF from `xbrief/active/` to `xbrief/completed/`.
- CHANGELOG `[Unreleased]` for `#4344` and leftover `#4162`.

## vBRIEF References

- `xbrief/active/2026-09-10-4344-bugdoctor-4162-escaping-symlink-test-eperms-on-windows-witho.xbrief.json`

## Documentation impact

change_class: none
surfaces: none
rationale: "Windows test skip plus leftover completed #4162 xBRIEF. CHANGELOG [Unreleased] records the skip. No command, skill-trigger, help, or docs-site surface changed."

## Checklist

- [x] `task check` passes locally (validate + lint + test; see `coding/testing.md`)
- [x] `CHANGELOG.md` has an `[Unreleased]` entry covering these changes
- [x] All affected vBRIEFs pass `task vbrief:validate`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] No secrets or `.env` content in the diff
- [x] `.premigrate.*` files are gitignored (if this PR followed a `task migrate:vbrief` run)
- [x] New source files (`scripts/`, `src/`, `cmd/`, `*.py`, `*.go`) have corresponding tests in this PR

## Related Issues

Closes #4344
Refs #4162

## Testing

On this Windows checkout: `pnpm exec vitest run packages/core/src/doctor packages/core/src/migrate-preflight` (443 passed, 1 skipped). Full `task check` exit 0.
