### PR TITLE
chore(scope): land leftover completed xBRIEF after PR 4346 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Land leftover completed-tracked artifact for #4344 (#3264 / #3476).** The #4344 xBRIEF stayed in `xbrief/active/` on origin/master after squash of PR 4346. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4162 (#3264 / #3476).** The #4162 xBRIEF stayed in `xbrief/active/` on origin/master after the product land. Moved to `xbrief/completed/` so merge-gate orphan-active is green. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4321 (#3264 / #3476).** The #4321 xBRIEF stayed untracked after squash of PR 4329. Moved to `xbrief/completed/` via `scope:complete`. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Consumer AGENTS.md names the explicit-body docs-impact seed (#4293 / #1309).** Pointer: compose the template `Documentation impact` block, then `verify:docs-impact --body-file` on those same bytes (leftover-complete / finalize-cohort). `plan.policy.agentsMdBudget.absoluteMaxBytes` 17600→17725 for that pointer after composing with #4295.

--- a/xbrief/completed/2026-09-10-4344-bugdoctor-4162-escaping-symlink-test-eperms-on-windows-witho.xbrief.json
+++ b/xbrief/completed/2026-09-10-4344-bugdoctor-4162-escaping-symlink-test-eperms-on-windows-witho.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #4344",
-    "updated": "2026-09-10T22:22:28Z"
+    "updated": "2026-09-10T22:48:02Z"
   },
   "plan": {
     "title": "bug(doctor): #4162 escaping-symlink test EPERMs on Windows without Developer Mode",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(doctor): #4162 escaping-symlink test EPERMs on Windows without Developer Mode",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4344",
@@ -52,7 +52,32 @@
         "github_issue_id": 5417611808,
         "origin": "deftai/directive#4344",
         "id": "github.issue.5417611808"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4346,
+        "prBase": null,
+        "mergeCommit": "64be462c586b49ed1fcfe6df4c25cf36efc9ca9c",
+        "deliveryBranch": "master",
+        "deliveryCommit": "64be462c586b49ed1fcfe6df4c25cf36efc9ca9c",
+        "verifiedAt": "2026-09-10T22:48:02Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:claude:v1:MDFhMDhkNmMtNDVhMi03MDIyLTg1Y2ItNmJhZTcwMWI0M2Fl"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-10T22:48:02Z"
+      },
+      "completedAt": "2026-09-10T22:48:02Z",
+      "completedSessionId": "host:claude:v1:MDFhMDhkNmMtNDVhMi03MDIyLTg1Y2ItNmJhZTcwMWI0M2Fl",
+      "capacityBucket": "new-capability"
     },
     "acceptance": {
       "commands": [
@@ -87,6 +112,6 @@
       "ambiguity_attestation": "none_found"
     },
     "id": "github.issue.5417611808",
-    "updated": "2026-09-10T22:22:28Z"
+    "updated": "2026-09-10T22:48:02Z"
   }
 }


### PR DESCRIPTION
## Summary

Land leftover completed-tracked xBRIEF for #4344 after squash of PR 4346. Does not reopen or recut that issue.

## Changes

- Move `xbrief/active/2026-09-10-4344-bugdoctor-4162-escaping-symlink-test-eperms-on-windows-witho.xbrief.json` to `xbrief/completed/` via `scope:complete`.
- CHANGELOG leftover-complete entry.

## Documentation impact

change_class: none
surfaces: none
rationale: "Lifecycle leftover land of an already-merged story xBRIEF. CHANGELOG records the leftover-complete. No command, skill-trigger, help, or docs-site surface changed."

## Checklist

- [x] `CHANGELOG.md` has an `[Unreleased]` entry covering these changes
- [x] Commit messages follow Conventional Commits
- [x] No secrets or `.env` content in the diff
- [x] New source files have corresponding tests in this PR

## Related Issues

Refs #4344

## Testing

`task verify:orphan-active -- --issue 4344` exit 0 locally after `scope:complete`.
