### PR TITLE
fix(security): bump brace-expansion to 5.0.9 for Dependabot #10/#13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dependabot high: brace-expansion DoS follow-ups (alerts #10/#13).** Pin `brace-expansion@5` to `5.0.9` (and `@2` to `2.1.4`) so the lockfile leaves CVE-2026-14257 / CVE-2026-69152. Closes #4348.
+
 ### Removed
 
 ## [0.115.0] - 2026-09-10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   vite: ^7.3.6
   esbuild: ^0.28.1
-  brace-expansion@2: 2.1.2
-  brace-expansion@5: 5.0.7
+  brace-expansion@2: 2.1.4
+  brace-expansion@5: 5.0.9
   postcss: 8.5.25
 
 importers:
@@ -580,9 +580,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -1289,7 +1289,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1424,7 +1424,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   nanoid@3.3.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,11 +11,11 @@ packages:
 overrides:
   vite: "^7.3.6"
   esbuild: "^0.28.1"
-  # Dependabot high: brace-expansion DoS via consecutive non-expanding {} groups
-  # (alerts #6/#7). Arrives via minimatch@9 (glob/test-exclude/vitest coverage)
-  # and minimatch@10 (archiver + test-exclude). Pin both major lines.
-  "brace-expansion@2": "2.1.2"
-  "brace-expansion@5": "5.0.7"
+  # Dependabot high: brace-expansion DoS via unbounded expansion / intermediate
+  # arrays (alerts #10/#13; CVE-2026-14257 / CVE-2026-69152). Arrives via
+  # minimatch@10 (runtime). Pin both major lines past the patched releases.
+  "brace-expansion@2": "2.1.4"
+  "brace-expansion@5": "5.0.9"
   # Dependabot high: PostCSS path traversal via sourceMappingURL auto-loading
   # of arbitrary .map files (alert #8). Transitive via vite <- vitest.
   # Patched range: >= 8.5.18 (pin latest stable 8.5.25).
@@ -31,6 +31,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - vite@7.3.6
-  - brace-expansion@2.1.2
-  - brace-expansion@5.0.7
+  - brace-expansion@2.1.4
+  - brace-expansion@5.0.9
   - postcss@8.5.25

--- a/xbrief/active/2026-09-10-4348-choresecurity-bump-brace-expansion-to-509-dependabot-1013.xbrief.json
+++ b/xbrief/active/2026-09-10-4348-choresecurity-bump-brace-expansion-to-509-dependabot-1013.xbrief.json
@@ -1,0 +1,70 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #4348",
+    "updated": "2026-09-10T23:46:35Z"
+  },
+  "plan": {
+    "title": "chore(security): bump brace-expansion to 5.0.9 (Dependabot #10/#13)",
+    "status": "running",
+    "narratives": {
+      "Description": "chore(security): bump brace-expansion to 5.0.9 (Dependabot #10/#13)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/4348",
+      "Overview": "## Problem\r\n\r\nDependabot alerts [#10](https://github.com/deftai/directive/security/dependabot/10) (CVE-2026-14257) and [#13](https://github.com/deftai/directive/security/dependabot/13) (CVE-2026-69152) stay open. Both are HIGH DoS in transitive brace-expansion (runtime, via minimatch@10).\r\n\r\npnpm-workspace.yaml still pins brace-expansion@5 to 5.0.7 from the prior advisory. That pin is one patch short of the current patched line (5.0.9).\r\n\r\n## What to build\r\n\r\nBump the pnpm 11 workspace override to 5.0.9, refresh pnpm-lock.yaml, and record the pin in CHANGELOG [Unreleased]. Also bump the leftover brace-expansion@2 override to 2.1.4 if that line is still declared.\r\n\r\n## Acceptance\r\n\r\n- pnpm-workspace.yaml pins brace-expansion@5 to 5.0.9.\r\n- pnpm-lock.yaml resolves brace-expansion@5 to 5.0.9, not 5.0.7.\r\n- CHANGELOG [Unreleased] records the bump and cites alerts #10 and #13.\r\n\r\nLiteral check:\r\n\r\n    pnpm why brace-expansion\r\n\n"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/4348",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #4348: chore(security): bump brace-expansion to 5.0.9 (Dependabot #10/#13)"
+      }
+    ],
+    "acceptance": {
+      "commands": [],
+      "none_stated": true,
+      "source_rung": "derived",
+      "derived_reason": "derived 3 independently testable clauses from the task statement before product edit (#3323)",
+      "clauses": [
+        {
+          "id": 1,
+          "text": "pnpm-workspace.yaml pins brace-expansion@5 to 5.0.9.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 2,
+          "text": "pnpm-lock.yaml resolves brace-expansion@5 to 5.0.9, not 5.0.7.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        },
+        {
+          "id": 3,
+          "text": "CHANGELOG [Unreleased] records the bump and cites alerts #10 and #13.",
+          "artifact_path": null,
+          "ambiguous": false,
+          "provenance": "statement"
+        }
+      ],
+      "ambiguity_attestation": "none_found"
+    },
+    "metadata": {
+      "intended_placement": {
+        "schema": "deft.scope.intended_placement.v1",
+        "files": [],
+        "module_boundary": ""
+      },
+      "x-directive/plan-id": {
+        "version": 1,
+        "source": "github-rest-id",
+        "github_issue_id": 5418486230,
+        "origin": "deftai/directive#4348",
+        "id": "github.issue.5418486230"
+      }
+    },
+    "id": "github.issue.5418486230",
+    "updated": "2026-09-10T23:46:35Z"
+  }
+}


### PR DESCRIPTION
## Summary

Bump the pnpm workspace override for transitive `brace-expansion` from 5.0.7 to 5.0.9 (and the leftover 2.x pin to 2.1.4) so Dependabot alerts #10 and #13 leave the CVE-2026-14257 / CVE-2026-69152 ranges.

## Related Issues

Closes #4348.

## Documentation impact

change_class: none
surfaces: none
rationale: "Supply-chain pin bump only. CHANGELOG [Unreleased] records it. No command, skill, help, or docs-site surface changed."

## Checklist

- [x] `/deft:change <name>` — N/A (pin bump, 4 files, not cross-cutting)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally
