### PR TITLE
fix(doctor): demote Codex /hooks off host-agnostic success copy (#4335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Init and doctor no longer tell every host to open Codex `/hooks` (#4335).** Green clone-wide hook readiness still lists all four hosts and Codex `trust=manual-review-required`. The host-unqualified Open `/hooks` command is off the success line. In-Codex review stays in `commands.md`. Does not opt out of Codex deposits.
+- **Init and doctor no longer tell every host to open Codex `/hooks` (#4335).** Codex trust remains `manual-review-required`.
 
 - **Dependabot high: brace-expansion DoS follow-ups (alerts #10/#13).** Pin `brace-expansion@5` to `5.0.9` (and `@2` to `2.1.4`) so the lockfile leaves CVE-2026-14257 / CVE-2026-69152. Closes #4348.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Init and doctor no longer tell every host to open Codex `/hooks` (#4335).** Green clone-wide hook readiness still lists all four hosts and Codex `trust=manual-review-required`. The host-unqualified Open `/hooks` command is off the success line. In-Codex review stays in `commands.md`. Does not opt out of Codex deposits.
+
 - **Dependabot high: brace-expansion DoS follow-ups (alerts #10/#13).** Pin `brace-expansion@5` to `5.0.9` (and `@2` to `2.1.4`) so the lockfile leaves CVE-2026-14257 / CVE-2026-69152. Closes #4348.
 
 ### Removed

--- a/packages/core/src/doctor/agent-hooks.test.ts
+++ b/packages/core/src/doctor/agent-hooks.test.ts
@@ -51,7 +51,8 @@ describe("runAgentHooksHealthCheck", () => {
       ),
     ).toBe(true);
     expect(lines.join("")).toContain("registered and structurally valid");
-    expect(lines.join("")).toContain("`/hooks`");
+    expect(lines.join("")).toContain("Codex trust is manual-review-required");
+    expect(lines.join("")).not.toMatch(/open\s+`\/hooks`/i);
     expect(findings).toEqual([
       expect.objectContaining({
         severity: "skip",
@@ -62,6 +63,7 @@ describe("runAgentHooksHealthCheck", () => {
         registrations,
       }),
     ]);
+    expect(findings[0]?.trust_review ?? "").not.toMatch(/open\s+`\/hooks`/i);
   });
 
   it("returns true without emitting a registered finding when cmdDoctor replaces it", () => {
@@ -427,10 +429,11 @@ describe("runAgentHooksLiveProbeCheck", () => {
   });
 
   it("keeps Codex trust review orthogonal after a successful live probe", () => {
+    const lines: string[] = [];
     const findings: Finding[] = [];
     runAgentHooksLiveProbeCheck(
       "/project",
-      createPlainSink({ write: () => undefined }),
+      createPlainSink({ write: (text) => lines.push(text) }),
       (finding) => findings.push(finding),
       {
         evaluateAgentHooks: () => ({
@@ -457,13 +460,15 @@ describe("runAgentHooksLiveProbeCheck", () => {
       },
     );
 
+    expect(lines.join("")).toContain("Codex trust is manual-review-required");
+    expect(lines.join("")).not.toMatch(/open\s+`\/hooks`/i);
     expect(findings).toEqual([
       expect.objectContaining({
         trust_status: "manual-review-required",
-        trust_review: expect.stringContaining("/hooks"),
         interception_status: "not-directly-verified",
       }),
     ]);
+    expect(findings[0]?.trust_review ?? "").not.toMatch(/open\s+`\/hooks`/i);
   });
 
   it("contains a thrown live readiness probe", () => {

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -870,7 +870,7 @@ export function runAgentHooksHealthCheck(
     const message =
       `${checkName}: registered and structurally valid` +
       (codexEnabled
-        ? "; Codex trust is manual-review-required — open `/hooks` to review the project commands"
+        ? "; Codex trust is manual-review-required"
         : "");
     sink.success(message);
     addFinding({
@@ -881,7 +881,7 @@ export function runAgentHooksHealthCheck(
       registrations: result.registrations,
       trust_status: codexEnabled ? "manual-review-required" : "not-applicable",
       trust_review: codexEnabled
-        ? "Open `/hooks` in Codex and review the exact project hook commands."
+        ? "Codex project-hook trust cannot be read by Directive and remains manual-review-required."
         : null,
       interception_status: "not-directly-verified",
     });
@@ -942,7 +942,7 @@ export function runAgentHooksLiveProbeCheck(
     const message =
       `${checkName}: registered, structurally valid, and live probe passed` +
       (codexEnabled
-        ? "; Codex trust is manual-review-required — open `/hooks` to review the project commands"
+        ? "; Codex trust is manual-review-required"
         : "") +
       "; direct shim invocation does not verify host interception";
     sink.success(message);
@@ -954,7 +954,7 @@ export function runAgentHooksLiveProbeCheck(
       registrations: result.registrations,
       trust_status: codexEnabled ? "manual-review-required" : "not-applicable",
       trust_review: codexEnabled
-        ? "Open `/hooks` in Codex and review the exact project hook commands."
+        ? "Codex project-hook trust cannot be read by Directive and remains manual-review-required."
         : null,
       interception_status: "not-directly-verified",
       live_probe: "passed",

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -869,9 +869,7 @@ export function runAgentHooksHealthCheck(
     );
     const message =
       `${checkName}: registered and structurally valid` +
-      (codexEnabled
-        ? "; Codex trust is manual-review-required"
-        : "");
+      (codexEnabled ? "; Codex trust is manual-review-required" : "");
     sink.success(message);
     addFinding({
       severity: "skip",
@@ -941,9 +939,7 @@ export function runAgentHooksLiveProbeCheck(
     );
     const message =
       `${checkName}: registered, structurally valid, and live probe passed` +
-      (codexEnabled
-        ? "; Codex trust is manual-review-required"
-        : "") +
+      (codexEnabled ? "; Codex trust is manual-review-required" : "") +
       "; direct shim invocation does not verify host interception";
     sink.success(message);
     addFinding({

--- a/packages/core/src/verify-env/agent-hook-readiness.test.ts
+++ b/packages/core/src/verify-env/agent-hook-readiness.test.ts
@@ -106,7 +106,7 @@ describe("evaluateAgentHookReadiness", () => {
     expect(probe).not.toHaveBeenCalled();
   });
 
-  it("reports Codex trust and interception separately without hard failing trust", () => {
+  it("reports Codex trust and interception separately without a /hooks next-step (#4335)", () => {
     const result = evaluateAgentHookReadiness("/project", {
       consumerContext: () => true,
       evaluateStructural: () => structural(),
@@ -120,7 +120,20 @@ describe("evaluateAgentHookReadiness", () => {
       trust: "manual-review-required",
       interception: "not-directly-verified",
     });
-    expect(result.message).toContain("/hooks");
+    expect(result.message).toContain("trust=manual-review-required");
+    expect(result.message).toMatch(/grok: registration=/);
+    expect(result.message).toMatch(/codex: registration=/);
+    expect(result.message).not.toMatch(/open\s+`\/hooks`/i);
+    expect(agentHookReadinessJson(result).hosts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          host: "codex",
+          trust: "manual-review-required",
+          interception: "not-directly-verified",
+        }),
+        expect.objectContaining({ host: "grok" }),
+      ]),
+    );
   });
 
   it("skips consumer deposits in a maintainer source checkout", () => {

--- a/packages/core/src/verify-env/agent-hook-readiness.ts
+++ b/packages/core/src/verify-env/agent-hook-readiness.ts
@@ -226,8 +226,7 @@ export function evaluateAgentHookReadiness(
           ? "timed-out"
           : "non-functional";
   const trustReview = policy.codex
-    ? "\n  Codex trust: manual-review-required. Open `/hooks` and approve the exact project hook commands. " +
-      "The live probe validates the shim and codec, not host interception."
+    ? "\n  Codex trust: manual-review-required. The live probe validates the shim and codec, not host interception."
     : "";
   const unusedHostRecovery =
     liveProbe.code === 0 || timeoutOnly ? "" : `\n  ${UNUSED_HOST_HOOKS_RECOVERY}`;

--- a/packages/core/src/verify-env/agent-hooks.test.ts
+++ b/packages/core/src/verify-env/agent-hooks.test.ts
@@ -27,6 +27,9 @@ describe("evaluateAgentHooks", () => {
     expect(result.message).toContain("Claude, Grok, Cursor, Codex");
     expect(result.message).toContain("spawn/Task tools");
     expect(result.message).toContain("DEFT_HOOK_READ_ONLY");
+    expect(result.message).toContain("manual-review-required");
+    expect(result.message).not.toMatch(/reviewed with `\/hooks`/);
+    expect(result.message).not.toMatch(/open\s+`\/hooks`/i);
   });
 
   it("reports missing registrations separately from git hooks", () => {

--- a/packages/core/src/verify-env/agent-hooks.ts
+++ b/packages/core/src/verify-env/agent-hooks.ts
@@ -101,7 +101,7 @@ export function evaluateAgentHooks(
       "(SessionStart + PreToolUse direct-write and spawn/Task tools; compact re-arm deposited for Claude/Grok/Cursor; " +
       "Codex has no native compact hook — re-run session ritual manually after compaction). " +
       'Read-only explore: prefer Grok role `default_capability_mode = "read-only"`; hooks also honor ' +
-      "DEFT_HOOK_READ_ONLY=1 and explore subagent_type. Codex runtime trust is user-controlled and must be reviewed with `/hooks`; shell/MCP policy is deferred." +
+      "DEFT_HOOK_READ_ONLY=1 and explore subagent_type. Codex runtime trust is user-controlled and remains manual-review-required; shell/MCP policy is deferred." +
       (disabledHosts.length > 0
         ? ` Intentional hostHooks disabled: ${disabledHosts.join(", ")}.`
         : "") +


### PR DESCRIPTION
## Summary

Init and doctor success copy no longer tells every host to open Codex `/hooks`.
Green clone-wide hook readiness still lists all four hosts and Codex
`trust=manual-review-required`. The in-Codex review instruction stays in
`commands.md`. Multi-host Codex deposits stay enabled.

This is a reporting change, not a current-host detector and not unused-host
opt-out.

## Related Issues

Closes #4335

## Documentation impact

change_class: change
surfaces: none
rationale: "Operator-facing init/doctor success copy no longer tells every host to open Codex /hooks. The in-Codex instruction stays in commands.md. CHANGELOG records the copy change."

## Checklist

- [x] `/deft:change <name>` — N/A: copy-only reporting change, not a new architecture or cross-cutting subsystem
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally (`task check` green)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed
