### PR TITLE
chore(xbrief): land completed-tracked artifact for #4391

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Land leftover completed-tracked artifact for #4391 (#3264 / #3476).** The #4391 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4402. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4356 (#3264 / #3476).** The #4356 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4394. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4389 (#3264 / #3476).** The #4389 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4396. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4361 (#3264 / #3476).** The #4361 xBRIEF stayed untracked after squash of PR 4392. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-09-11-4391-docsdc-grok-critic-spawn-from-primary-fails-two-ways.xbrief.json
+++ b/xbrief/completed/2026-09-11-4391-docsdc-grok-critic-spawn-from-primary-fails-two-ways.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF from GitHub issue #4391 Bound-remedy harvest (ingest gh-parse failed; REST+lean used)",
-    "updated": "2026-09-11T15:01:15Z"
+    "updated": "2026-09-11T16:11:03Z"
   },
   "plan": {
     "title": "docs(design-critique): Grok critic spawn from primary fails two ways; dest-rooted grok CLI is the working seat",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "docs(design-critique): Grok critic spawn from primary fails two ways; dest-rooted grok CLI is the working seat",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4391",
@@ -16,31 +16,73 @@
     "items": [
       {
         "title": "Do not bind leftover-on-primary as a universal native deny. Count selects the class: 2+ Deny 1; 0 is #2885; 1 eligible + dest cwd + parent id is spawn-ready implement-class (dest-lock, leftover file_scope). Documenting the 2-deny retry loop does not close the 1-eligible admit.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/hooks/dispatcher-spawn-dest.test.ts#does not lead Grok multiple-eligible spawn-not-ready with scope:activate",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       },
       {
         "title": "Native admit without skip-class (spawn-process-only-ready) is not a critic seat. Either CLI after any native outcome that is not that skip-class, or wait on #4315 so native can express process_only. Keep retarget default Grok seat to CLI forbidden. Keep dual-launch forbidden.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/hooks/dispatcher-spawn-dest.test.ts#keeps #2885 on destProven implement-class without process_only",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       },
       {
         "title": "Grok spawn-not-ready copy: name dest-rooted grok --cwd --prompt-file after recorded native deny as the critic recovery. Do not lead with scope:activate or DEFT_ACTIVE_SCOPE for this class. Playbook keeps argv. Skill stays a pointer (pack source, 80-line cap).",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/hooks/dispatcher-spawn-dest.test.ts + packages/core/src/session/spawn-occupancy.ts GROK_CRITIC_SPAWN_NOT_READY_RECOVERY",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       },
       {
         "title": "Say dest-rooted CLI is envelope-only process-only until #4219. Do not skip #4066 dest-proven. Dest still required.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "content/docs/grok-build-subscription-setup.md Design-critique dispatch envelope-only until #4219",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       },
       {
         "title": "Quote DEFT_ACTIVE_SCOPE, not DEFT_ACTIVE_SCOPE_PIN.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/hooks/dispatcher-spawn-dest.test.ts not.toContain DEFT_ACTIVE_SCOPE_PIN",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       },
       {
         "title": "Name the third Grok dest deny: isolation=worktree plus cwd is invalid-extra-destination, not dest-missing.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "packages/core/src/session/spawn-occupancy.test.ts occupancy-denies Grok isolation=worktree plus cwd",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       },
       {
         "title": "CHANGELOG if the pointer ships.",
-        "status": "proposed"
+        "status": "completed",
+        "x-directive/evidence": {
+          "kind": "test",
+          "pointer": "CHANGELOG.md [Unreleased] Fixed #4391",
+          "recorded_at": "2026-09-11T16:10:54Z",
+          "recorded_by": "4391-leaf-implementation"
+        }
       }
     ],
     "tags": [
@@ -137,9 +179,34 @@
         "schema": "deft.scope.admitted-target-digest.v1",
         "algorithm": "sha256",
         "sha256": "e0116f4c2ef78226572bd5b83ec7d23464f20d02e2d848af0fcc4366cd91caba"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4402,
+        "prBase": null,
+        "mergeCommit": "736347a2fa70d8b39dbf3c75461d6846f4e0c7d7",
+        "deliveryBranch": "master",
+        "deliveryCommit": "736347a2fa70d8b39dbf3c75461d6846f4e0c7d7",
+        "verifiedAt": "2026-09-11T16:11:03Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:grok:v1:MDFhMDkwZjQtZmU1OC03ZjcwLWJhZjUtN2FiNDBhMDJhYjJk"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-11T16:11:03Z"
+      },
+      "completedAt": "2026-09-11T16:11:03Z",
+      "completedSessionId": "host:grok:v1:MDFhMDkwZjQtZmU1OC03ZjcwLWJhZjUtN2FiNDBhMDJhYjJk",
+      "capacityBucket": "new-capability"
     },
     "id": "github.issue.5425289127",
-    "updated": "2026-09-11T15:01:15Z"
+    "updated": "2026-09-11T16:11:03Z"
   }
 }


### PR DESCRIPTION
## Summary

Land the #4391 xBRIEF in `xbrief/completed/` after squash of PR 4402. Required for `verify:completed-tracked` / `verify:orphan-active`.

## Related Issues

Refs #4391

## Documentation impact

change_class: change
surfaces: none
rationale: "CHANGELOG leftover-complete note only. No new command, skill trigger, help key, or docs-site page."

## Checklist

- [x] `/deft:change <name>` — N/A (lifecycle move after merge)
- [x] `CHANGELOG.md` — added leftover-complete entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally

## Post-Merge

- [x] Issue #4391 already closed by PR 4402
