### PR TITLE
chore(scope): land completed-tracked xBRIEF for #4379

### DIFF
--- a/xbrief/completed/2026-09-11-4379-bugtasksinstaller-the-deposited-consumer-taskfile-namespaces.xbrief.json
+++ b/xbrief/completed/2026-09-11-4379-bugtasksinstaller-the-deposited-consumer-taskfile-namespaces.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #4379",
-    "updated": "2026-09-11T15:18:22Z"
+    "updated": "2026-09-11T17:07:14Z"
   },
   "plan": {
     "title": "bug(tasks,installer): the deposited consumer Taskfile namespaces the deft include, so every documented \"task check\" / \"task scope:*\" invocation fails (exit 200 = task not found)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(tasks,installer): the deposited consumer Taskfile namespaces the deft include, so every documented \"task check\" / \"task scope:*\" invocation fails (exit 200 = task not found)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4379",
@@ -147,7 +147,32 @@
           "command": "task check",
           "reason": "Issue-body evidence fence (exit 200 on a namespaced consumer). Bound remedy 5636376446 forbids binding the body pick-one / that spelling as acceptance (#3721 / #4379)."
         }
-      ]
+      ],
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4405,
+        "prBase": null,
+        "mergeCommit": "a1d13077f1f080ef9f3bce08d258f5df97103d46",
+        "deliveryBranch": "master",
+        "deliveryCommit": "a1d13077f1f080ef9f3bce08d258f5df97103d46",
+        "verifiedAt": "2026-09-11T17:07:14Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:grok:v1:MDFhMDkxMGYtZDZlYS03NmMzLTk2NzctM2Y0NjA4MDc0MWZm"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-11T17:07:14Z"
+      },
+      "completedAt": "2026-09-11T17:07:14Z",
+      "completedSessionId": "host:grok:v1:MDFhMDkxMGYtZDZlYS03NmMzLTk2NzctM2Y0NjA4MDc0MWZm",
+      "capacityBucket": "technical-debt"
     },
     "acceptance": {
       "commands": [],
@@ -194,6 +219,6 @@
       "ambiguity_attestation": "none_found"
     },
     "id": "github.issue.5420778912",
-    "updated": "2026-09-11T15:18:22Z"
+    "updated": "2026-09-11T17:07:14Z"
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle land: move the #4379 scope xBRIEF from `xbrief/active/` to `xbrief/completed/` after PR #4405 squash-merged (`a1d13077f1f0`).

This is the #3476 completed-tracked artifact. Issue #4379 is already closed.

## Related Issues

Tracking #4379 (already closed by #4405; do not re-close)

## Documentation impact

change_class: none
surfaces: none
rationale: "Lifecycle-only xBRIEF active-to-completed move after #4405 merged; no command, skill, help, or docs-site surface changed."

## Checklist

- [x] `/deft:change <name>` — N/A lifecycle-only file-copy land (<3 files, not cross-cutting)
- [x] `CHANGELOG.md` — N/A lifecycle-only completed-tracked land
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally — N/A lifecycle-only land (#3476; not a product check)

## Post-Merge

- [x] Issue #4379 already closed by #4405
