### PR TITLE
chore(scope): land completed-tracked xBRIEF for #4393

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Land leftover completed-tracked artifact for #4393 (#3264 / #3476).** The #4393 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4413. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4399 (#3264 / #3476).** The #4399 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4420. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4266 (#3264 / #3476).** The #4266 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4415. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.
 - **Land leftover completed-tracked artifact for #4406 (#3264 / #3476).** The #4406 xBRIEF stayed in xbrief/active/ on origin/master after squash of PR 4416. Moved to xbrief/completed/ via scope:complete. Does not reopen or recut that issue. Refs #2321, #3476.

--- a/xbrief/completed/2026-09-11-4393-bughooks-dest-proven-grok-implement-spawn-still-hits-4007-on.xbrief.json
+++ b/xbrief/completed/2026-09-11-4393-bughooks-dest-proven-grok-implement-spawn-still-hits-4007-on.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #4393",
-    "updated": "2026-09-11T15:55:09Z"
+    "updated": "2026-09-11T19:12:45Z"
   },
   "plan": {
     "title": "bug(hooks): dest-proven Grok implement spawn still hits #4007 on primary leftover actives; spawn cannot pass the story pin",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(hooks): dest-proven Grok implement spawn still hits #4007 on primary leftover actives; spawn cannot pass the story pin",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/4393",
@@ -122,7 +122,32 @@
         "schema": "deft.scope.admitted-target-digest.v1",
         "algorithm": "sha256",
         "sha256": "16250b2c533c187defe47533672a4e31cb76adac8b19cb402f6afddccfdc7ce0"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 4413,
+        "prBase": null,
+        "mergeCommit": "756ecc04b3a9ba356acdb77715636315bab0c2ce",
+        "deliveryBranch": "master",
+        "deliveryCommit": "756ecc04b3a9ba356acdb77715636315bab0c2ce",
+        "verifiedAt": "2026-09-11T19:12:45Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null,
+        "completedSessionId": "host:grok:v1:MDFhMDkxYTYtZjEzMS03ZWUyLTlhMjgtMjA1YzFlZDdiMGI1"
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "lifecycleWrite": {
+        "action": "complete",
+        "writtenAt": "2026-09-11T19:12:45Z"
+      },
+      "completedAt": "2026-09-11T19:12:45Z",
+      "completedSessionId": "host:grok:v1:MDFhMDkxYTYtZjEzMS03ZWUyLTlhMjgtMjA1YzFlZDdiMGI1",
+      "capacityBucket": "technical-debt"
     },
     "acceptance": {
       "commands": [],
@@ -169,6 +194,6 @@
       "ambiguity_attestation": "none_found"
     },
     "id": "github.issue.5425597951",
-    "updated": "2026-09-11T15:55:09Z"
+    "updated": "2026-09-11T19:12:45Z"
   }
 }


### PR DESCRIPTION
## Summary

Land leftover completed-tracked xBRIEF for #4393 after squash of PR 4413. Moves the brief from `xbrief/active/` to `xbrief/completed/`. Does not reopen or recut that issue.

## Related Issues

Refs #2321, #3476, #4393

## Documentation impact

change_class: none
surfaces: none
rationale: "Lifecycle artifact move plus CHANGELOG leftover-complete note; no command, skill trigger, help key, or docs-site page was added or removed."

## Checklist

- [x] `/deft:change <name>` — N/A (post-merge scope:complete leftover land)
- [x] `CHANGELOG.md` — leftover completed-tracked entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally

## Post-Merge

- [x] Issue #4393 already closed by PR 4413
