### PR TITLE
fix(agents-md): stamp inventory identity instead of sha=unknown (#4246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **agents:refresh stamps a resolvable framework identity instead of sha=unknown (#4246).** Writable AGENTS.md states (absent/missing/stale) on a non-git npm install use package.json version, then live GENERATION.json contentVersion, then the running core package version. Own-git-root still uses git short HEAD. Does not preserve a leftover checkout SHA, mint a second 12-hex, recut #3914/#4118 git-fatal silence, or recut commands.md. Closes #4246.
+
 ### Removed
 
 ## [0.117.0] - 2026-09-11

--- a/packages/cli/src/session-start.test.ts
+++ b/packages/cli/src/session-start.test.ts
@@ -390,6 +390,7 @@ describe("framework SHA own-git-root (#3914)", () => {
     }).trim();
     const nested = join(parent, "vendor", "framework");
     mkdirSync(nested, { recursive: true });
+    writeFileSync(join(nested, "package.json"), JSON.stringify({ version: "0.104.0" }));
     expect(payloadIsOwnGitRoot(nested)).toBe(false);
     expect(payloadIsOwnGitRoot(parent)).toBe(true);
     const plan = agentsRefreshPlan(nested, {
@@ -399,8 +400,9 @@ describe("framework SHA own-git-root (#3914)", () => {
       newSession: () => "sess0001",
       frameworkRoot: nested,
     });
-    expect(plan.sha).toBe("unknown");
+    expect(plan.sha).toBe("0.104.0");
     expect(plan.sha).not.toBe(parentSha);
+    expect(plan.sha).not.toBe("unknown");
   });
 
   it("own-git-root framework SHA is the short HEAD", () => {
@@ -423,9 +425,10 @@ describe("framework SHA own-git-root (#3914)", () => {
     expect(plan.sha).toBe(head);
   });
 
-  it("current managed section still reports unknown SHA when not own-git-root", () => {
+  it("current managed section reports inventory identity without rewriting (#4246)", () => {
     const dir = mkdtempSync(join(tmpdir(), "deft-sha-current-"));
     temps.push(dir);
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "0.104.0" }));
     const plan = agentsRefreshPlan(dir, {
       readTemplate: () => SHA_TEMPLATE,
       readAgents: () => SHA_TEMPLATE,
@@ -434,6 +437,7 @@ describe("framework SHA own-git-root (#3914)", () => {
       frameworkRoot: dir,
     });
     expect(plan.state).toBe("current");
-    expect(plan.sha).toBe("unknown");
+    expect(plan.sha).toBe("0.104.0");
+    expect(plan.new_content).toBe(SHA_TEMPLATE);
   });
 });

--- a/packages/core/src/doctor/agents-md-extra.test.ts
+++ b/packages/core/src/doctor/agents-md-extra.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { readCorePackageVersion } from "../engine-version.js";
 import { agentsRefreshPlan, hasManagedSectionMarker, hasV3ManagedMarker } from "./agents-md.js";
 
 const MANAGED = "<!-- deft:managed-section v3 -->\nbody\n<!-- /deft:managed-section -->";
@@ -16,7 +17,7 @@ describe("agents-md extra branches", () => {
     expect(plan.sha).toBe("customsha12");
   });
 
-  it("returns unknown when payload is not own git root (#4118)", () => {
+  it("returns inventory identity when payload is not own git root (#4246)", () => {
     const root = mkdtempSync(join(tmpdir(), "deft-doc-nongit-"));
     try {
       const plan = agentsRefreshPlan(root, {
@@ -24,7 +25,8 @@ describe("agents-md extra branches", () => {
         readAgents: () => null,
         frameworkRoot: root,
       });
-      expect(plan.sha).toBe("unknown");
+      expect(plan.sha).toBe(readCorePackageVersion());
+      expect(plan.sha).not.toBe("unknown");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/core/src/platform/agents-md.ts
+++ b/packages/core/src/platform/agents-md.ts
@@ -4,6 +4,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { atomicWriteText } from "../cache/io.js";
 import { contentRoot } from "../content-root.js";
+import { readCorePackageVersion } from "../engine-version.js";
+import { readLiveGeneration } from "../freshness/generation.js";
 import { timedGitRunner } from "../session/git.js";
 import { type LockDeps, withAppendLock } from "../slice/lock.js";
 import { composeGreenfieldAgentsMd } from "./agents-consumer-header.js";
@@ -67,14 +69,59 @@ function readAgentsTemplate(seams: AgentsMdSeams = {}): string | null {
   }
 }
 
-function resolveFrameworkSha(seams: AgentsMdSeams = {}): string {
+function isStampableManagedSha(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && !/\s/.test(trimmed) && !trimmed.includes("-->");
+}
+
+/** package.json version at the framework install root (npm deposit identity). */
+function readFrameworkPackageVersion(root: string): string | null {
+  try {
+    const pkgPath = join(root, "package.json");
+    if (!existsSync(pkgPath)) return null;
+    const parsed: unknown = JSON.parse(readFileSync(pkgPath, "utf8"));
+    if (parsed === null || typeof parsed !== "object") return null;
+    const version = (parsed as { version?: unknown }).version;
+    if (typeof version !== "string") return null;
+    return isStampableManagedSha(version) ? version.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Non-git framework identity from existing inventory (#4246).
+ * Prefer install package.json, then live GENERATION.json contentVersion, then
+ * the running core package version. Do not mint a git-shaped 12-hex.
+ */
+function resolveInventoryFrameworkIdentity(root: string, projectRoot?: string): string {
+  const fromPkg = readFrameworkPackageVersion(root);
+  if (fromPkg) return fromPkg;
+  if (projectRoot) {
+    try {
+      const live = readLiveGeneration(projectRoot);
+      const version = live?.contentVersion?.trim() ?? "";
+      if (isStampableManagedSha(version)) return version;
+    } catch {
+      // fall through
+    }
+  }
+  const core = readCorePackageVersion();
+  if (isStampableManagedSha(core)) return core.trim();
+  return "unknown";
+}
+
+function resolveFrameworkSha(seams: AgentsMdSeams = {}, projectRoot?: string): string {
   if (seams.resolveSha) return seams.resolveSha();
   const root = frameworkRoot(seams);
-  if (!payloadIsOwnGitRoot(root)) return "unknown";
-  const result = timedGitRunner(5000)(root, ["rev-parse", "--short=12", "HEAD"]);
-  if (result.code !== 0) return "unknown";
-  const sha = result.stdout.trim();
-  return sha || "unknown";
+  if (payloadIsOwnGitRoot(root)) {
+    const result = timedGitRunner(5000)(root, ["rev-parse", "--short=12", "HEAD"]);
+    if (result.code === 0) {
+      const sha = result.stdout.trim();
+      if (sha) return sha;
+    }
+  }
+  return resolveInventoryFrameworkIdentity(root, projectRoot);
 }
 
 function nowUtcIso(): string {
@@ -290,7 +337,6 @@ export function agentsRefreshPlan(
   seams: AgentsMdSeams = {},
 ): Record<string, unknown> {
   const readTemplate = seams.readTemplate ?? (() => readAgentsTemplate(seams));
-  const resolveSha = seams.resolveSha ?? (() => resolveFrameworkSha(seams));
   const nowIso = seams.nowIso ?? nowUtcIso;
   const newSession = seams.newSession ?? newSessionId;
   const readAgents =
@@ -324,7 +370,7 @@ export function agentsRefreshPlan(
       new_content: null,
     };
   }
-  const frameworkSha = resolveSha();
+  const frameworkSha = resolveFrameworkSha(seams, projectRoot);
   const refreshed = nowIso();
   const sessionId = newSession();
   const templateOpen = findManagedOpenMarker(templateText.replace(/\r\n/g, "\n"));

--- a/packages/core/src/platform/branch-coverage.test.ts
+++ b/packages/core/src/platform/branch-coverage.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { agentsRefreshPlan as doctorAgentsRefreshPlan } from "../doctor/agents-md.js";
+import { readCorePackageVersion } from "../engine-version.js";
 import {
   agentsRefreshPlan,
   frameworkRoot,
@@ -579,7 +580,7 @@ describe("agents-md default-seam (filesystem) branch coverage", () => {
     });
   });
 
-  it("default sha resolver falls back to 'unknown' on a non-repo root", () => {
+  it("default sha resolver uses inventory identity on a non-repo root (#4246)", () => {
     withTempDir((dir) => {
       const plan = agentsRefreshPlan(dir, {
         readTemplate: () => TEMPLATE,
@@ -589,7 +590,8 @@ describe("agents-md default-seam (filesystem) branch coverage", () => {
         frameworkRoot: dir,
       });
       expect(plan.state).toBe("absent");
-      expect(plan.sha).toBe("unknown");
+      expect(plan.sha).toBe(readCorePackageVersion());
+      expect(plan.sha).not.toBe("unknown");
     });
   });
 });
@@ -878,7 +880,7 @@ describe("silent git probes on non-git payload roots (#4118)", () => {
     });
   });
 
-  it("platform resolveFrameworkSha is silent and unknown", () => {
+  it("platform resolveFrameworkSha is silent and uses inventory identity (#4246)", () => {
     withTempDir((dir) => {
       let sha: unknown;
       const leaked = captureStderr(() => {
@@ -890,12 +892,13 @@ describe("silent git probes on non-git payload roots (#4118)", () => {
           frameworkRoot: dir,
         }).sha;
       });
-      expect(sha).toBe("unknown");
+      expect(sha).toBe(readCorePackageVersion());
+      expect(sha).not.toBe("unknown");
       expect(leaked).not.toMatch(GIT_FATAL);
     });
   });
 
-  it("doctor resolveFrameworkSha is silent and unknown", () => {
+  it("doctor resolveFrameworkSha is silent and uses inventory identity (#4246)", () => {
     withTempDir((dir) => {
       let sha: unknown;
       const leaked = captureStderr(() => {
@@ -907,8 +910,151 @@ describe("silent git probes on non-git payload roots (#4118)", () => {
           frameworkRoot: dir,
         }).sha;
       });
-      expect(sha).toBe("unknown");
+      expect(sha).toBe(readCorePackageVersion());
+      expect(sha).not.toBe("unknown");
       expect(leaked).not.toMatch(GIT_FATAL);
+    });
+  });
+});
+
+describe("resolveFrameworkSha inventory identity on writable states (#4246)", () => {
+  const leftoverOpen =
+    "<!-- deft:managed-section v3 sha=089bbf450e1a refreshed=2026-01-01T00:00:00Z session=oldsession01 -->";
+
+  it("stamps package.json version on absent writes, not unknown or leftover git sha", () => {
+    withTempDir((dir) => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "@deftai/directive", version: "0.104.0" }),
+      );
+      let leaked = "";
+      let plan: Record<string, unknown> = {};
+      leaked = captureStderr(() => {
+        plan = agentsRefreshPlan(dir, {
+          readTemplate: () => SHA_TEMPLATE,
+          readAgents: () => null,
+          nowIso: () => "2026-01-01T00:00:00Z",
+          newSession: () => "sess0001",
+          frameworkRoot: dir,
+        });
+      });
+      expect(plan.state).toBe("absent");
+      expect(plan.sha).toBe("0.104.0");
+      expect(plan.sha).not.toMatch(/^[0-9a-f]{12}$/);
+      expect(String(plan.attributed_rendered)).toContain("sha=0.104.0");
+      expect(String(plan.new_content)).toContain("sha=0.104.0");
+      expect(String(plan.new_content)).not.toContain("sha=unknown");
+      expect(leaked).not.toMatch(GIT_FATAL);
+    });
+  });
+
+  it("does not preserve a leftover checkout SHA onto npm-rendered stale bytes", () => {
+    withTempDir((dir) => {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "@deftai/directive", version: "0.104.0" }),
+      );
+      const leftover = `top\n${leftoverOpen}\n## Section\nold\n<!-- /deft:managed-section -->\nbottom`;
+      const plan = agentsRefreshPlan(dir, {
+        readTemplate: () => SHA_TEMPLATE,
+        readAgents: () => leftover,
+        nowIso: () => "2026-01-01T00:00:00Z",
+        newSession: () => "sess0001",
+        frameworkRoot: dir,
+      });
+      expect(plan.state).toBe("stale");
+      expect(plan.sha).toBe("0.104.0");
+      expect(String(plan.new_content)).toContain("sha=0.104.0");
+      expect(String(plan.new_content)).not.toContain("sha=089bbf450e1a");
+      expect(String(plan.new_content)).not.toContain("sha=unknown");
+    });
+  });
+
+  it("uses GENERATION.json contentVersion when package.json version is absent", () => {
+    withTempDir((dir) => {
+      mkdirSync(join(dir, ".deft"), { recursive: true });
+      writeFileSync(
+        join(dir, ".deft", "GENERATION.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          generation: 1,
+          contentVersion: "0.99.1",
+          stampedAt: "2026-09-11T00:00:00Z",
+          stampedBy: "test",
+        }),
+      );
+      const plan = agentsRefreshPlan(dir, {
+        readTemplate: () => SHA_TEMPLATE,
+        readAgents: () => null,
+        nowIso: () => "2026-01-01T00:00:00Z",
+        newSession: () => "sess0001",
+        frameworkRoot: dir,
+      });
+      expect(plan.state).toBe("absent");
+      expect(plan.sha).toBe("0.99.1");
+      expect(String(plan.new_content)).toContain("sha=0.99.1");
+    });
+  });
+
+  it("prefers install package.json over GENERATION.json", () => {
+    withTempDir((dir) => {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "0.104.0" }));
+      mkdirSync(join(dir, ".deft"), { recursive: true });
+      writeFileSync(
+        join(dir, ".deft", "GENERATION.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          generation: 1,
+          contentVersion: "0.99.1",
+          stampedAt: "2026-09-11T00:00:00Z",
+          stampedBy: "test",
+        }),
+      );
+      const plan = agentsRefreshPlan(dir, {
+        readTemplate: () => SHA_TEMPLATE,
+        readAgents: () => null,
+        nowIso: () => "2026-01-01T00:00:00Z",
+        newSession: () => "sess0001",
+        frameworkRoot: dir,
+      });
+      expect(plan.sha).toBe("0.104.0");
+    });
+  });
+
+  it("own-git-root still stamps short HEAD even when package.json is present", () => {
+    withTempDir((dir) => {
+      execFileSync("git", ["init", "-q"], { cwd: dir, stdio: "ignore", timeout: 10_000 });
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.email=t@example.com",
+          "-c",
+          "user.name=Test",
+          "commit",
+          "--allow-empty",
+          "--no-gpg-sign",
+          "-m",
+          "init",
+        ],
+        { cwd: dir, stdio: "ignore", timeout: 10_000 },
+      );
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "9.9.9" }));
+      const head = execFileSync("git", ["rev-parse", "--short=12", "HEAD"], {
+        cwd: dir,
+        encoding: "utf8",
+        timeout: 10_000,
+      }).trim();
+      expect(payloadIsOwnGitRoot(dir)).toBe(true);
+      const plan = agentsRefreshPlan(dir, {
+        readTemplate: () => SHA_TEMPLATE,
+        readAgents: () => null,
+        nowIso: () => "2026-01-01T00:00:00Z",
+        newSession: () => "sess0001",
+        frameworkRoot: dir,
+      });
+      expect(plan.sha).toBe(head);
+      expect(plan.sha).not.toBe("9.9.9");
     });
   });
 });

--- a/packages/core/src/platform/module-coverage.test.ts
+++ b/packages/core/src/platform/module-coverage.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { readCorePackageVersion } from "../engine-version.js";
 import {
   agentsRefreshPlan,
   attributeRenderManagedSection,
@@ -423,7 +424,8 @@ describe("silent payloadIsOwnGitRoot on non-git roots (#4118)", () => {
         readAgents: () => null,
         frameworkRoot: dir,
       });
-      expect(plan.sha).toBe("unknown");
+      expect(plan.sha).toBe(readCorePackageVersion());
+      expect(plan.sha).not.toBe("unknown");
     } finally {
       process.stderr.write = prev;
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

agents:refresh no longer stamps sha=unknown into consumer AGENTS.md on a non-git npm install. Writable states (absent/missing/stale) now stamp package.json version, then live GENERATION.json contentVersion, then the running core package version. Own-git-root still uses git short HEAD. Leftover checkout SHAs are not preserved onto npm-rendered bytes. payloadIsOwnGitRoot stays. Does not recut git-fatal silence or commands.md.

## Related Issues

Closes #4246

## Documentation impact

change_class: change
surfaces: none
rationale: "Writable AGENTS.md managed-section sha= on npm installs now stamps package or generation identity instead of unknown. CHANGELOG records that marker change. No command, skill-trigger, help, or docs-site page added or removed."

## Checklist

- [x] `/deft:change` N/A (bug fix on existing resolver, not a new cross-cutting proposal)
- [x] `CHANGELOG.md` Unreleased Fixed entry
- [x] `ROADMAP.md` N/A
- [x] Tests pass locally (`task check` exit 0)

## Post-Merge

- [ ] Verify issue auto-close after squash
