### PR TITLE
fix(conformance): run D7 filename checks before parse (#4245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **agents:refresh stamps a resolvable framework identity instead of sha=unknown (#4246).** Writable AGENTS.md states (absent/missing/stale) on a non-git npm install use package.json version, then live GENERATION.json contentVersion, then the running core package version. Own-git-root still uses git short HEAD. Does not preserve a leftover checkout SHA, mint a second 12-hex, recut #3914/#4118 git-fatal silence, or recut commands.md. Closes #4246.
 
+- **`verify:vbrief-conformance --staged` (and `--all`) run D7 filename checks before parse (#4245).** The installed pre-commit hook uses `--staged`, which previously scanned bare keys only, so a dotted-slug xBRIEF could commit and then redden `vbrief:validate` / `task check`. Reuses `validateFilename`; does not retarget the hook at `vbrief:validate` and does not weaken D7 for version dots. Closes #4245.
+
+
+
 ### Removed
 
 ## [0.117.0] - 2026-09-11

--- a/packages/core/src/vbrief-validate/conformance.ts
+++ b/packages/core/src/vbrief-validate/conformance.ts
@@ -8,6 +8,8 @@ import {
 } from "../encoding/git.js";
 import { fnmatchCase } from "../encoding/text.js";
 import { isLifecycleArtifactPath, LIFECYCLE_DIR_NAMES } from "../layout/resolve.js";
+import { LIFECYCLE_FOLDERS } from "./constants.js";
+import { validateFilename } from "./filename.js";
 import { evaluateExtensionRoundtrip } from "./roundtrip.js";
 import type { JsonObject } from "./schema.js";
 
@@ -229,6 +231,17 @@ function isVbriefPath(posix: string): boolean {
   return isLifecycleArtifactPath(posix);
 }
 
+/** D7 applies to lifecycle-folder scope files, matching validateAll discoverVbriefs (#4245). */
+function isScopeLifecyclePath(posix: string): boolean {
+  const parts = posix.split("/");
+  if (parts.length < 3) {
+    return false;
+  }
+  const root = parts[0] ?? "";
+  const folder = parts[1] ?? "";
+  return (root === "xbrief" || root === "vbrief") && LIFECYCLE_FOLDERS.includes(folder);
+}
+
 export type ConformanceMode = "all" | "staged";
 
 export interface ConformanceEvaluateResult {
@@ -364,7 +377,11 @@ export function evaluateConformance(
   }
 
   const findings: ConformanceFinding[] = [];
+  const filenameErrors: string[] = [];
   for (const candidate of candidates) {
+    if (!candidate.configured && isScopeLifecyclePath(candidate.displayPath)) {
+      filenameErrors.push(...validateFilename(candidate.displayPath));
+    }
     let text: string;
     try {
       text = readFileSync(candidate.fullPath, "utf8");
@@ -398,22 +415,35 @@ export function evaluateConformance(
     findings.push(...scanVbrief(candidate.displayPath, data));
   }
 
-  if (findings.length > 0) {
-    const uniquePaths = new Set(findings.map((f) => f.path));
-    const header =
-      `\u274c verify_vbrief_conformance: detected ${findings.length} bare ` +
-      `key(s) across ${uniquePaths.size} file(s) (#1620).\n` +
-      "  Every vBRIEF key MUST be spec-core, x-directive/-namespaced, " +
-      "x-vbrief/-namespaced, or x-xbrief/-namespaced -- never bare.\n" +
-      "  Fix: migrate misused/misspelled core fields to their core home " +
-      "(see scripts/vbrief_migrate_conformance.py), or namespace a genuine\n" +
-      "  extension under x-directive/. Allow-list a documented file " +
-      "exception via --allow-list <path> (newline-separated globs).";
-    let body = findings.slice(0, 50).map(renderFinding).join("\n");
-    if (findings.length > 50) {
-      body += `\n  ... and ${findings.length - 50} more`;
+  if (filenameErrors.length > 0 || findings.length > 0) {
+    const parts: string[] = [];
+    if (filenameErrors.length > 0) {
+      const d7Header =
+        `\u274c verify_vbrief_conformance: ${filenameErrors.length} D7 filename ` +
+        `error(s) (#4245).\n` +
+        "  Scope filenames MUST match YYYY-MM-DD-descriptive-slug.vbrief.json; " +
+        "dots in the slug are not exempt.";
+      const d7Body = filenameErrors.map((err) => `FAIL: ${err}`).join("\n");
+      parts.push(`${d7Header}\n${d7Body}`);
     }
-    return { exitCode: 1, findings, message: `${header}\n${body}` };
+    if (findings.length > 0) {
+      const uniquePaths = new Set(findings.map((f) => f.path));
+      const header =
+        `\u274c verify_vbrief_conformance: detected ${findings.length} bare ` +
+        `key(s) across ${uniquePaths.size} file(s) (#1620).\n` +
+        "  Every vBRIEF key MUST be spec-core, x-directive/-namespaced, " +
+        "x-vbrief/-namespaced, or x-xbrief/-namespaced -- never bare.\n" +
+        "  Fix: migrate misused/misspelled core fields to their core home " +
+        "(see scripts/vbrief_migrate_conformance.py), or namespace a genuine\n" +
+        "  extension under x-directive/. Allow-list a documented file " +
+        "exception via --allow-list <path> (newline-separated globs).";
+      let body = findings.slice(0, 50).map(renderFinding).join("\n");
+      if (findings.length > 50) {
+        body += `\n  ... and ${findings.length - 50} more`;
+      }
+      parts.push(`${header}\n${body}`);
+    }
+    return { exitCode: 1, findings, message: parts.join("\n") };
   }
 
   const extensionRoundtrip = evaluateExtensionRoundtrip(root);

--- a/packages/core/src/vbrief-validate/conformance.ts
+++ b/packages/core/src/vbrief-validate/conformance.ts
@@ -423,7 +423,13 @@ export function evaluateConformance(
         `error(s) (#4245).\n` +
         "  Scope filenames MUST match YYYY-MM-DD-descriptive-slug.vbrief.json; " +
         "dots in the slug are not exempt.";
-      const d7Body = filenameErrors.map((err) => `FAIL: ${err}`).join("\n");
+      let d7Body = filenameErrors
+        .slice(0, 50)
+        .map((err) => `FAIL: ${err}`)
+        .join("\n");
+      if (filenameErrors.length > 50) {
+        d7Body += `\n  ... and ${filenameErrors.length - 50} more`;
+      }
       parts.push(`${d7Header}\n${d7Body}`);
     }
     if (findings.length > 0) {

--- a/packages/core/src/vbrief-validate/conformance.ts
+++ b/packages/core/src/vbrief-validate/conformance.ts
@@ -234,7 +234,7 @@ function isVbriefPath(posix: string): boolean {
 /** D7 applies to lifecycle-folder scope files, matching validateAll discoverVbriefs (#4245). */
 function isScopeLifecyclePath(posix: string): boolean {
   const parts = posix.split("/");
-  if (parts.length < 3) {
+  if (parts.length !== 3) {
     return false;
   }
   const root = parts[0] ?? "";

--- a/packages/core/src/vbrief-validate/extra-coverage.test.ts
+++ b/packages/core/src/vbrief-validate/extra-coverage.test.ts
@@ -1300,4 +1300,19 @@ describe("evaluateConformance D7 filename (#4245)", () => {
     expect(evaluateConformance(root, { mode: "all" }).exitCode).toBe(0);
     rmSync(root, { recursive: true, force: true });
   });
+
+  it("caps D7 diagnostic output at 50 findings", () => {
+    const root = mkdtempSync(join(tmpdir(), "vb-d7-many-"));
+    mkdirSync(join(root, "xbrief", "completed"), { recursive: true });
+    for (let i = 0; i < 51; i += 1) {
+      const name = "2026-09-07-bad-" + String(i) + ".1.xbrief.json";
+      writeFileSync(join(root, "xbrief", "completed", name), validBody, "utf8");
+    }
+    execSync("git init", { cwd: root, stdio: "ignore" });
+    execSync("git add -A", { cwd: root, stdio: "ignore" });
+    const result = evaluateConformance(root, { mode: "staged" });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("... and");
+    rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/packages/core/src/vbrief-validate/extra-coverage.test.ts
+++ b/packages/core/src/vbrief-validate/extra-coverage.test.ts
@@ -843,7 +843,7 @@ describe("vbrief-validate extra coverage", () => {
     const root = mkdtempSync(join(tmpdir(), "vb-conf-read-"));
     mkdirSync(join(root, "xbrief"), { recursive: true });
     execSync("git init", { cwd: root, stdio: "ignore" });
-    writeFileSync(join(root, "xbrief", "broken.xbrief.json"), "not-json", "utf8");
+    writeFileSync(join(root, "xbrief", "2026-01-01-broken.xbrief.json"), "not-json", "utf8");
     execSync("git add -A", { cwd: root, stdio: "ignore" });
     expect(evaluateConformance(root).exitCode).toBe(0);
     rmSync(root, { recursive: true, force: true });
@@ -1238,5 +1238,66 @@ describe("vbrief-validate extra coverage", () => {
         "f.json",
       ).some((e) => e.includes("must be a string")),
     ).toBe(true);
+  });
+});
+
+describe("evaluateConformance D7 filename (#4245)", () => {
+  const validBody = JSON.stringify({
+    xBRIEFInfo: { version: "0.8" },
+    plan: { title: "T", status: "completed", items: [] },
+  });
+
+  function stagedLifecycleRoot(fileName: string, contents: string): string {
+    const root = mkdtempSync(join(tmpdir(), "vb-d7-"));
+    mkdirSync(join(root, "xbrief", "completed"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "completed", fileName), contents, "utf8");
+    execSync("git init", { cwd: root, stdio: "ignore" });
+    execSync("git add -A", { cwd: root, stdio: "ignore" });
+    return root;
+  }
+
+  it("fails staged and all modes on a dotted-slug filename before parse", () => {
+    const name = "2026-09-07-deliberately-bad-1.2.3.xbrief.json";
+    const root = stagedLifecycleRoot(name, validBody);
+    const staged = evaluateConformance(root, { mode: "staged" });
+    expect(staged.exitCode).toBe(1);
+    expect(staged.message).toContain("(D7)");
+    expect(staged.message).toContain("1.2.3");
+    expect(staged.message).toContain("#4245");
+    const all = evaluateConformance(root, { mode: "all" });
+    expect(all.exitCode).toBe(1);
+    expect(all.message).toContain("(D7)");
+    expect(runConformance(["--staged", "--project-root", root])).toBe(1);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("fails staged D7 when the staged file is not valid JSON", () => {
+    const name = "2026-09-07-deliberately-bad-1.2.3.xbrief.json";
+    const root = stagedLifecycleRoot(name, "{not-json");
+    const staged = evaluateConformance(root, { mode: "staged" });
+    expect(staged.exitCode).toBe(1);
+    expect(staged.message).toContain("(D7)");
+    expect(staged.message).toContain("1.2.3");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("accepts a hyphenated slug that D7 allows", () => {
+    const name = "2026-09-07-deliberately-bad-123.xbrief.json";
+    const root = stagedLifecycleRoot(name, validBody);
+    expect(evaluateConformance(root, { mode: "staged" }).exitCode).toBe(0);
+    expect(evaluateConformance(root, { mode: "all" }).exitCode).toBe(0);
+    expect(runConformance(["--staged", "--project-root", root, "--quiet"])).toBe(0);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("skips D7 for root-level xbrief files that validateAll does not discover", () => {
+    const root = mkdtempSync(join(tmpdir(), "vb-d7-root-"));
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "plan-1.2.3.xbrief.json"), validBody, "utf8");
+    execSync("git init", { cwd: root, stdio: "ignore" });
+    execSync("git add -A", { cwd: root, stdio: "ignore" });
+    expect(evaluateConformance(root, { mode: "staged" }).exitCode).toBe(0);
+    expect(evaluateConformance(root, { mode: "all" }).exitCode).toBe(0);
+    rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/vbrief-validate/extra-coverage.test.ts
+++ b/packages/core/src/vbrief-validate/extra-coverage.test.ts
@@ -1315,4 +1315,19 @@ describe("evaluateConformance D7 filename (#4245)", () => {
     expect(result.message).toContain("... and");
     rmSync(root, { recursive: true, force: true });
   });
+
+  it("skips D7 for nested files under a lifecycle folder", () => {
+    const root = mkdtempSync(join(tmpdir(), "vb-d7-nested-"));
+    mkdirSync(join(root, "xbrief", "completed", "archive"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "completed", "archive", "2026-09-07-bad-1.2.3.xbrief.json"),
+      validBody,
+      "utf8",
+    );
+    execSync("git init", { cwd: root, stdio: "ignore" });
+    execSync("git add -A", { cwd: root, stdio: "ignore" });
+    expect(evaluateConformance(root, { mode: "staged" }).exitCode).toBe(0);
+    expect(evaluateConformance(root, { mode: "all" }).exitCode).toBe(0);
+    rmSync(root, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary

The pre-commit hook runs `deft verify:vbrief-conformance --staged`, which previously scanned bare keys only. D7 filename checks live on `vbrief:validate` / `validateAll`. A dotted-slug xBRIEF could commit and then redden `task check`.

This PR calls existing `validateFilename` on lifecycle-folder candidate paths in `evaluateConformance` before JSON parse, for both `--staged` and `--all`. The hook is not retargeted at `vbrief:validate`. D7 is not weakened for version dots.

## Related Issues

Tracking: #4245

## Documentation impact

change_class: change
surfaces: none
rationale: "Staged conformance now fails D7 filenames; CHANGELOG Unreleased records that operator-visible hook behavior. No new command, skill trigger, help key, or docs-site page."

## Checklist

- [x] `/deft:change` -- N/A: three files, focused D7 conformance fix, not cross-cutting architecture
- [x] `CHANGELOG.md` -- added entry under Unreleased
- [x] `ROADMAP.md` -- N/A, no ROADMAP item for this bug
- [x] Tests pass locally

## Test plan

- [x] Vitest: dotted-slug `--staged` and `--all` fail D7 before parse, including invalid JSON
- [x] Vitest: hyphenated slug still passes; root-level xbrief files are not D7-checked
- [x] `task check` green on this branch

